### PR TITLE
Add LLM-as-judge pattern for GEPA

### DIFF
--- a/crates/dspy-rs/examples/10-gepa-llm-judge.rs
+++ b/crates/dspy-rs/examples/10-gepa-llm-judge.rs
@@ -1,0 +1,338 @@
+/// Example: Using LLM-as-a-Judge with GEPA for Math Word Problems
+///
+/// This example demonstrates how to use an LLM judge to automatically generate
+/// rich textual feedback for GEPA optimization. The judge evaluates both the
+/// correctness of answers AND the quality of reasoning.
+///
+/// To run:
+/// ```
+/// OPENAI_API_KEY=your_key cargo run --example 10-gepa-llm-judge
+/// ```
+
+use anyhow::Result;
+use bon::Builder;
+use dspy_rs::*;
+use dsrs_macros::{Signature, Optimizable};
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+// ============================================================================
+// Step 1: Define the task signature with chain-of-thought reasoning
+// ============================================================================
+
+#[Signature(cot)]
+struct MathWordProblem {
+    /// Solve the math word problem step by step. Show your work clearly.
+    
+    #[input]
+    pub problem: String,
+    
+    #[output]
+    pub reasoning: String,
+    
+    #[output]
+    pub answer: String,
+}
+
+// ============================================================================
+// Step 2: Define the LLM judge signature
+// ============================================================================
+
+#[Signature]
+struct MathJudge {
+    /// You are an expert math teacher evaluating student work. Analyze both
+    /// the final answer and the reasoning process. Be specific about what
+    /// went wrong or what was done well.
+    
+    #[input(desc = "The math problem that was given")]
+    pub problem: String,
+    
+    #[input(desc = "The expected correct answer")]
+    pub expected_answer: String,
+    
+    #[input(desc = "The student's answer")]
+    pub student_answer: String,
+    
+    #[input(desc = "The student's reasoning/work shown")]
+    pub student_reasoning: String,
+    
+    #[output(desc = "Detailed evaluation of the work")]
+    pub evaluation: String,
+}
+
+// ============================================================================
+// Step 3: Create the main module with LLM judge
+// ============================================================================
+
+#[derive(Builder, Optimizable)]
+struct MathSolver {
+    // The main predictor we want to optimize
+    #[parameter]
+    solver: Predict,
+    
+    // The judge predictor (not optimized, just used for evaluation)
+    judge: Predict,
+    
+    // LM for the judge (could be different/cheaper model)
+    judge_lm: Arc<Mutex<LM>>,
+}
+
+impl Module for MathSolver {
+    async fn forward(&self, inputs: Example) -> Result<Prediction> {
+        // Just forward to the solver - judge only used during evaluation
+        self.solver.forward(inputs).await
+    }
+}
+
+// ============================================================================
+// Step 4: Implement regular Evaluator for non-GEPA optimizers
+// ============================================================================
+
+impl Evaluator for MathSolver {
+    async fn metric(&self, example: &Example, prediction: &Prediction) -> f32 {
+        // For regular optimizers, just return scalar score
+        let feedback = self.feedback_metric(example, prediction).await;
+        feedback.score
+    }
+}
+
+// ============================================================================
+// Step 5: Implement FeedbackEvaluator with LLM judge for GEPA
+// ============================================================================
+
+impl FeedbackEvaluator for MathSolver {
+    async fn feedback_metric(&self, example: &Example, prediction: &Prediction) 
+        -> FeedbackMetric 
+    {
+        // Extract the problem and answers
+        let problem = example
+            .get("problem", None)
+            .as_str()
+            .unwrap_or("")
+            .to_string();
+        
+        let expected = example
+            .get("expected_answer", None)
+            .as_str()
+            .unwrap_or("")
+            .to_string();
+        
+        let student_answer = prediction
+            .get("answer", None)
+            .as_str()
+            .unwrap_or("")
+            .to_string();
+        
+        let student_reasoning = prediction
+            .get("reasoning", None)
+            .as_str()
+            .unwrap_or("No reasoning provided")
+            .to_string();
+        
+        // Quick check: is the answer exactly correct?
+        let answer_matches = student_answer.trim() == expected.trim();
+        
+        // Use LLM judge to analyze the reasoning quality
+        // This is where the magic happens - the judge provides rich feedback
+        let judge_input = example! {
+            "problem": "input" => &problem,
+            "expected_answer": "input" => &expected,
+            "student_answer": "input" => &student_answer,
+            "student_reasoning": "input" => &student_reasoning
+        };
+        
+        let judge_output = match self.judge
+            .forward_with_config(judge_input, Arc::clone(&self.judge_lm))
+            .await 
+        {
+            Ok(output) => output,
+            Err(_) => {
+                // If judge fails, fall back to simple feedback
+                let score = if answer_matches { 1.0 } else { 0.0 };
+                let simple_feedback = format!(
+                    "Problem: {}\nExpected: {}\nPredicted: {}\nAnswer: {}",
+                    problem, expected, student_answer,
+                    if answer_matches { "CORRECT" } else { "INCORRECT" }
+                );
+                return FeedbackMetric::new(score, simple_feedback);
+            }
+        };
+        
+        let judge_evaluation = judge_output
+            .get("evaluation", None)
+            .as_str()
+            .unwrap_or("Unable to evaluate")
+            .to_string();
+        
+        // Calculate score based on answer correctness and reasoning quality
+        // The judge's evaluation helps us assign partial credit
+        let score = if answer_matches {
+            // Correct answer - check if reasoning is also sound
+            if judge_evaluation.to_lowercase().contains("sound reasoning") 
+                || judge_evaluation.to_lowercase().contains("correct approach") {
+                1.0  // Perfect: right answer, good reasoning
+            } else {
+                0.7  // Right answer but flawed reasoning (lucky guess?)
+            }
+        } else {
+            // Wrong answer - check if there's any partial credit
+            if judge_evaluation.to_lowercase().contains("correct approach")
+                || judge_evaluation.to_lowercase().contains("good start") {
+                0.3  // Wrong answer but some valid steps
+            } else {
+                0.0  // Completely wrong
+            }
+        };
+        
+        // Construct rich textual feedback
+        // This combines factual info with the judge's analysis
+        let mut feedback = String::new();
+        
+        feedback.push_str(&format!("Problem: {}\n", problem));
+        feedback.push_str(&format!("Expected: {}\n", expected));
+        feedback.push_str(&format!("Predicted: {}\n", student_answer));
+        
+        if answer_matches {
+            feedback.push_str("Answer: CORRECT\n\n");
+        } else {
+            feedback.push_str("Answer: INCORRECT\n\n");
+        }
+        
+        feedback.push_str("Reasoning Quality Analysis:\n");
+        feedback.push_str(&judge_evaluation);
+        
+        // Return the feedback metric with score and rich text
+        FeedbackMetric::new(score, feedback)
+    }
+}
+
+// ============================================================================
+// Step 6: Main function - Set up and run GEPA optimization
+// ============================================================================
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    println!("GEPA with LLM-as-a-Judge Example\n");
+    println!("This example shows how to use an LLM judge to automatically");
+    println!("generate rich feedback for optimizing a math solver.\n");
+    
+    // Setup: Configure the LLM
+    let api_key = std::env::var("OPENAI_API_KEY")
+        .expect("OPENAI_API_KEY environment variable not set");
+    
+    // Main LM for the task
+    let task_lm = LM::builder()
+        .api_key(api_key.clone().into())
+        .config(
+            LMConfig::builder()
+                .model("gpt-4o-mini".to_string())
+                .temperature(0.7)
+                .build(),
+        )
+        .build();
+    
+    // Judge LM (could use a different/cheaper model)
+    let judge_lm = LM::builder()
+        .api_key(api_key.into())
+        .config(
+            LMConfig::builder()
+                .model("gpt-4o-mini".to_string())
+                .temperature(0.3)  // Lower temp for more consistent judging
+                .build(),
+        )
+        .build();
+    
+    configure(task_lm, ChatAdapter);
+    
+    // Create training examples
+    let trainset = vec![
+        example! {
+            "problem": "input" => "Sarah has 12 apples. She gives 3 to her friend and buys 5 more. How many apples does she have now?",
+            "expected_answer": "input" => "14"
+        },
+        example! {
+            "problem": "input" => "A train travels 60 miles in 1 hour. How far will it travel in 3.5 hours at the same speed?",
+            "expected_answer": "input" => "210"
+        },
+        example! {
+            "problem": "input" => "There are 24 students in a class. If 1/3 of them are absent, how many students are present?",
+            "expected_answer": "input" => "16"
+        },
+        example! {
+            "problem": "input" => "A rectangle has length 8 cm and width 5 cm. What is its area?",
+            "expected_answer": "input" => "40"
+        },
+        example! {
+            "problem": "input" => "John has $50. He spends $12 on lunch and $8 on a book. How much money does he have left?",
+            "expected_answer": "input" => "30"
+        },
+    ];
+    
+    // Create the module
+    let mut module = MathSolver::builder()
+        .solver(Predict::new(MathWordProblem::new()))
+        .judge(Predict::new(MathJudge::new()))
+        .judge_lm(Arc::new(Mutex::new(judge_lm)))
+        .build();
+    
+    // Evaluate baseline performance
+    println!("Step 1: Baseline Performance");
+    println!("Testing the solver before optimization...\n");
+    let baseline_score = module.evaluate(trainset.clone()).await;
+    println!("  Baseline average score: {:.3}\n", baseline_score);
+    
+    // Configure GEPA optimizer
+    println!("Step 2: Configure GEPA");
+    println!("Setting up the optimizer with budget controls...\n");
+    
+    let gepa = GEPA::builder()
+        .num_iterations(3)      // Fewer iterations for demo
+        .minibatch_size(3)       // Smaller batches
+        .temperature(0.9)
+        .track_stats(true)
+        .maybe_max_lm_calls(Some(100)) // Important: we're using 2x LM calls (task + judge)
+        .build();
+    
+    // Run GEPA optimization
+    println!("Step 3: Run GEPA Optimization");
+    println!("The judge will analyze reasoning quality and provide feedback...\n");
+    
+    let result = gepa.compile_with_feedback(&mut module, trainset.clone()).await?;
+    
+    // Display results
+    println!("\nStep 4: Results");
+    println!("===============\n");
+    println!("Optimization complete!");
+    println!("  Best average score: {:.3}", result.best_candidate.average_score());
+    println!("  Improvement: {:.3}", result.best_candidate.average_score() - baseline_score);
+    println!("  Total rollouts: {}", result.total_rollouts);
+    println!("  Total LM calls: {} (includes judge evaluations)", result.total_lm_calls);
+    
+    println!("\nEvolution over time:");
+    for (generation, score) in &result.evolution_history {
+        println!("  Generation {}: {:.3}", generation, score);
+    }
+    
+    println!("\nOptimized instruction:");
+    println!("  {}", result.best_candidate.instruction);
+    
+    // Test the optimized solver
+    println!("\nStep 5: Test Optimized Solver");
+    println!("==============================\n");
+    
+    let test_problem = example! {
+        "problem": "input" => "A store sells pencils for $0.25 each. If you buy 8 pencils, how much will you pay?",
+        "expected_answer": "input" => "2"
+    };
+    
+    let test_prediction = module.forward(test_problem.clone()).await?;
+    let test_feedback = module.feedback_metric(&test_problem, &test_prediction).await;
+    
+    println!("Test problem: A store sells pencils for $0.25 each. If you buy 8 pencils, how much will you pay?");
+    println!("\nAnswer: {}", test_prediction.get("answer", None));
+    println!("Score: {:.3}\n", test_feedback.score);
+    println!("Detailed Feedback from Judge:");
+    println!("{}", test_feedback.feedback);
+    
+    Ok(())
+}

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -35,6 +35,15 @@
               "docs/data/examples",
               "docs/data/prediction"
             ]
+          },
+          {
+            "group": "Optimizers",
+            "pages": [
+              "docs/optimizers/copro",
+              "docs/optimizers/miprov2",
+              "docs/optimizers/gepa",
+              "docs/optimizers/gepa-llm-judge"
+            ]
           }
         ]
       },

--- a/docs/docs/optimizers/copro.mdx
+++ b/docs/docs/optimizers/copro.mdx
@@ -1,0 +1,131 @@
+---
+title: 'COPRO'
+description: 'Fast iterative prompt refinement'
+icon: 'rotate'
+---
+
+COPRO (Collaborative Prompt Optimizer) is a simple but effective optimizer that iteratively refines prompts through generation and evaluation cycles.
+
+## How it Works
+
+COPRO uses a straightforward approach:
+
+1. **Generate candidates**: Create multiple prompt variations using an LLM
+2. **Evaluate**: Test each candidate on your training data
+3. **Refine**: Use the best candidates to generate improved versions
+4. **Repeat**: Continue for a fixed number of depth iterations
+
+## Configuration
+
+```rust
+let copro = COPRO::builder()
+    .breadth(10)              // Number of candidates per iteration
+    .depth(3)                 // Number of refinement iterations
+    .init_temperature(1.4)    // Temperature for generation
+    .track_stats(false)       // Track optimization statistics
+    .build();
+```
+
+## Usage Example
+
+```rust
+use dspy_rs::{COPRO, Optimizer};
+
+#[derive(Builder, Optimizable)]
+struct MyModule {
+    #[parameter]
+    predictor: Predict,
+}
+
+impl Module for MyModule {
+    async fn forward(&self, inputs: Example) -> Result<Prediction> {
+        self.predictor.forward(inputs).await
+    }
+}
+
+impl Evaluator for MyModule {
+    async fn metric(&self, example: &Example, prediction: &Prediction) -> f32 {
+        // Your evaluation logic
+        if prediction.get("answer", None) == example.get("expected", None) {
+            1.0
+        } else {
+            0.0
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let lm = LM::builder()...build();
+    configure(lm, ChatAdapter);
+    
+    let mut module = MyModule::builder()...build();
+    
+    let copro = COPRO::builder()
+        .breadth(10)
+        .depth(3)
+        .build();
+    
+    copro.compile(&mut module, trainset).await?;
+    
+    Ok(())
+}
+```
+
+## When to Use COPRO
+
+**Best for:**
+- Quick iteration cycles
+- Simple tasks
+- Limited compute budget
+- When you need results fast
+
+**Avoid when:**
+- You need best possible quality (use MIPROv2 or GEPA)
+- Task has complex failure modes (use GEPA)
+- You want to leverage prompting best practices (use MIPROv2)
+
+## Comparison with Other Optimizers
+
+| Feature | COPRO | MIPROv2 | GEPA |
+|---------|-------|---------|------|
+| **Speed** | Fast | Slow | Medium |
+| **Quality** | Good | Better | Best |
+| **Feedback** | Score | Score | Score + Text |
+| **Diversity** | Low | Medium | High |
+| **Setup** | Simple | Moderate | Moderate |
+
+## Configuration Details
+
+### Breadth
+Number of candidate prompts generated at each iteration. Higher breadth means more exploration but more compute.
+
+Recommended: 5-15
+
+### Depth
+Number of refinement iterations. Each iteration builds on the best candidates from the previous one.
+
+Recommended: 2-5
+
+### Temperature
+Controls randomness in prompt generation. Higher temperature means more diverse candidates.
+
+Recommended: 1.0-1.5
+
+### Track Stats
+When enabled, COPRO tracks detailed statistics about all evaluated candidates and their scores over time.
+
+## Implementation Notes
+
+COPRO maintains:
+- All evaluated candidates with their scores
+- Best candidates from each iteration
+- History of improvements over iterations
+
+The algorithm avoids re-evaluating candidates it has already seen by caching results.
+
+## Examples
+
+<Card title="COPRO Examples" icon="code" href="https://github.com/krypticmouse/DSRs/tree/main/crates/dspy-rs/examples">
+  See examples 03-evaluate-hotpotqa.rs and 04-optimize-hotpotqa.rs
+</Card>

--- a/docs/docs/optimizers/gepa-llm-judge.mdx
+++ b/docs/docs/optimizers/gepa-llm-judge.mdx
@@ -1,4 +1,8 @@
-# Using LLM-as-a-Judge with GEPA
+---
+title: 'GEPA with LLM-as-Judge'
+description: 'Use an LLM judge to automatically generate rich feedback'
+icon: 'gavel'
+---
 
 This guide explains how to use an LLM judge to automatically generate rich textual feedback for GEPA optimization, making it easier to optimize complex tasks where manual feedback rules are hard to codify.
 
@@ -18,21 +22,26 @@ Better Task LM prompt
 
 ## Why Use LLM-as-a-Judge?
 
-**Good for:**
-- Subjective quality assessment (writing style, helpfulness, clarity)
-- Complex reasoning evaluation (is the logic sound?)
-- Tasks where rules are hard to codify
-- Analyzing reasoning quality beyond just answer correctness
-
-**When to avoid:**
-- You have deterministic checks (unit tests, schema validation)
-- Verifiable correctness (code compilation, exact matches)
-- Need fast/cheap evaluation
-- Simple binary pass/fail
+<Tabs>
+  <Tab title="Good For">
+    - Subjective quality assessment (writing style, helpfulness, clarity)
+    - Complex reasoning evaluation (is the logic sound?)
+    - Tasks where rules are hard to codify
+    - Analyzing reasoning quality beyond just answer correctness
+  </Tab>
+  <Tab title="When to Avoid">
+    - You have deterministic checks (unit tests, schema validation)
+    - Verifiable correctness (code compilation, exact matches)
+    - Need fast/cheap evaluation
+    - Simple binary pass/fail
+  </Tab>
+</Tabs>
 
 ## Complete Example Walkthrough
 
-See `examples/10-gepa-llm-judge.rs` for a full working example. Here are the key pieces:
+<Card title="Full Working Example" icon="code" href="https://github.com/krypticmouse/DSRs/blob/main/crates/dspy-rs/examples/10-gepa-llm-judge.rs">
+  See the complete implementation with step-by-step comments
+</Card>
 
 ### 1. Task Signature with Reasoning
 
@@ -155,36 +164,45 @@ impl FeedbackEvaluator for MathSolver {
 
 ## Key Benefits
 
-**1. Catches lucky guesses:**
-```
-Answer: Correct (1.0)
-But reasoning: "I just multiplied random numbers"
-Score: 0.7 (penalized for bad reasoning)
-```
+<AccordionGroup>
+  <Accordion title="Catches Lucky Guesses">
+    ```
+    Answer: Correct (1.0)
+    But reasoning: "I just multiplied random numbers"
+    Score: 0.7 (penalized for bad reasoning)
+    ```
+    
+    The judge identifies when the model got the right answer for the wrong reasons.
+  </Accordion>
 
-**2. Rewards partial progress:**
-```
-Answer: Wrong
-But reasoning: "Correct approach, arithmetic error in final step"
-Score: 0.3 (partial credit)
-```
+  <Accordion title="Rewards Partial Progress">
+    ```
+    Answer: Wrong
+    But reasoning: "Correct approach, arithmetic error in final step"
+    Score: 0.3 (partial credit)
+    ```
+    
+    The judge recognizes valid methodology even when the final answer is wrong.
+  </Accordion>
 
-**3. Identifies systematic issues:**
-The judge notices patterns like:
-- "Model consistently skips showing intermediate steps"
-- "Model confuses similar concepts (area vs perimeter)"
-- "Model doesn't check units in answers"
-
-GEPA's reflection can then say:
-> "Add explicit instruction to show all intermediate steps and verify units"
+  <Accordion title="Identifies Systematic Issues">
+    The judge notices patterns like:
+    - "Model consistently skips showing intermediate steps"
+    - "Model confuses similar concepts (area vs perimeter)"
+    - "Model doesn't check units in answers"
+    
+    GEPA's reflection can then say:
+    > "Add explicit instruction to show all intermediate steps and verify units"
+  </Accordion>
+</AccordionGroup>
 
 ## Cost Considerations
 
-LLM judges double your evaluation cost since every prediction requires:
-1. Task LM call (generate answer)
-2. Judge LM call (evaluate quality)
+<Warning>
+LLM judges double your evaluation cost since every prediction requires both a task LM call and a judge LM call.
+</Warning>
 
-**Budget accordingly:**
+Budget accordingly:
 
 ```rust
 GEPA::builder()
@@ -194,13 +212,14 @@ GEPA::builder()
     .build()
 ```
 
-**Optimization tips:**
+### Optimization Tips
+
 - Use a cheaper model for judging (gpt-4o-mini vs gpt-4)
 - Judge only failed examples (not ones that passed)
 - Cache judge evaluations for identical outputs
 - Use parallel evaluation to reduce wall-clock time
 
-## When to Use Hybrid Approach
+## Hybrid Approach
 
 Best results often come from combining explicit checks with LLM judging:
 
@@ -236,19 +255,27 @@ async fn feedback_metric(&self, example: &Example, prediction: &Prediction)
 }
 ```
 
-## Example Output
+## Example Evolution
 
 When you run the example, GEPA will evolve prompts based on judge feedback:
 
-```
-Baseline: "Solve the math word problem step by step"
-  → Some solutions skip steps
-  → Judge: "Reasoning incomplete, jumped from step 2 to answer"
-
-After GEPA:
-  → "Solve step by step. Show ALL intermediate calculations. Label each step clearly."
-  → Judge: "Sound reasoning, all steps shown clearly"
-```
+<Steps>
+  <Step title="Baseline">
+    Instruction: "Solve the math word problem step by step"
+    
+    Result: Some solutions skip steps
+    
+    Judge: "Reasoning incomplete, jumped from step 2 to answer"
+  </Step>
+  
+  <Step title="After GEPA">
+    Instruction: "Solve step by step. Show ALL intermediate calculations. Label each step clearly."
+    
+    Result: Complete solutions with all steps shown
+    
+    Judge: "Sound reasoning, all steps shown clearly"
+  </Step>
+</Steps>
 
 The judge's analysis becomes the signal that drives prompt improvement.
 

--- a/docs/docs/optimizers/gepa.mdx
+++ b/docs/docs/optimizers/gepa.mdx
@@ -1,8 +1,14 @@
-# GEPA: Reflective Prompt Optimizer for DSRs
+---
+title: 'GEPA: Reflective Optimizer'
+description: 'Optimize prompts using rich textual feedback and Pareto frontiers'
+icon: 'dna'
+---
 
 **GEPA** (Genetic-Pareto) is a state-of-the-art reflective prompt optimizer that uses rich textual feedback and evolutionary algorithms to improve LM-powered applications.
 
-> Reference: "GEPA: Reflective Prompt Evolution Can Outperform Reinforcement Learning" (Agrawal et al., 2025, [arxiv:2507.19457](https://arxiv.org/abs/2507.19457))
+<Info>
+Reference: "GEPA: Reflective Prompt Evolution Can Outperform Reinforcement Learning" (Agrawal et al., 2025, [arxiv:2507.19457](https://arxiv.org/abs/2507.19457))
+</Info>
 
 ## What is GEPA?
 
@@ -12,33 +18,31 @@ GEPA is a reflective optimizer that adaptively evolves textual components (such 
 
 Unlike traditional optimizers (COPRO, MIPROv2), GEPA introduces several key innovations:
 
-### 1. **Rich Textual Feedback**
+### 1. Rich Textual Feedback
 Instead of just scalar scores (0.8, 0.9), GEPA leverages detailed explanations:
 ```
-✗ Incorrect classification
+Incorrect classification
   Expected: "positive"
   Predicted: "negative"
   Input text: "Great product but shipping was slow"
-  ✗ May have misunderstood mixed sentiment
+  May have misunderstood mixed sentiment
 ```
 
-### 2. **Pareto-based Selection**
+### 2. Pareto-based Selection
 GEPA maintains a diverse set of candidates that excel on different examples, preventing premature convergence:
 - Candidate A: Best on examples 1, 3, 5
 - Candidate B: Best on examples 2, 4, 6
 - Both stay in the population (complementary strengths)
 
-### 3. **LLM-driven Reflection**
+### 3. LLM-driven Reflection
 Uses LLMs to analyze execution traces and propose targeted improvements:
 ```
 "The current instruction doesn't handle mixed sentiments well. 
 Suggest modifying to explicitly consider both positive and negative aspects..."
 ```
 
-### 4. **Inference-Time Search**
+### 4. Inference-Time Search
 Can optimize at test time, not just training time.
-
----
 
 ## Quick Start
 
@@ -79,9 +83,9 @@ impl FeedbackEvaluator for MyModule {
         let score = if correct { 1.0 } else { 0.0 };
         
         let feedback = if correct {
-            format!("✓ Correct answer: {}", predicted)
+            format!("Correct answer: {}", predicted)
         } else {
-            format!("✗ Incorrect\n  Expected: {}\n  Predicted: {}", expected, predicted)
+            format!("Incorrect\n  Expected: {}\n  Predicted: {}", expected, predicted)
         };
         
         FeedbackMetric::new(score, feedback)
@@ -98,7 +102,7 @@ let gepa = GEPA::builder()
     .num_trials(10)
     .temperature(0.9)
     .track_stats(true)
-    .max_rollouts(Some(500))  // Budget control
+    .maybe_max_rollouts(Some(500))  // Budget control
     .build();
 
 let result = gepa.compile_with_feedback(&mut module, trainset).await?;
@@ -106,8 +110,6 @@ let result = gepa.compile_with_feedback(&mut module, trainset).await?;
 println!("Best score: {:.3}", result.best_candidate.average_score());
 println!("Best instruction: {}", result.best_candidate.instruction);
 ```
-
----
 
 ## Feedback Helpers
 
@@ -125,8 +127,8 @@ let feedback = retrieval_feedback(
 
 // Output:
 // Retrieved 3/5 correct documents (Precision: 0.6, Recall: 0.6, F1: 0.6)
-// ✓ Correctly retrieved: doc1, doc2, doc3
-// ✗ Missed: doc4, doc5
+// Correctly retrieved: doc1, doc2, doc3
+// Missed: doc4, doc5
 ```
 
 ### Code Generation
@@ -144,9 +146,9 @@ let stages = vec![
 let feedback = code_pipeline_feedback(&stages, 0.6);
 
 // Output:
-// ✓ Parse: Success
-// ✓ Compile: Success
-// ✗ Execute: Division by zero on line 42
+// Parse: Success
+// Compile: Success
+// Execute: Division by zero on line 42
 ```
 
 ### Multi-Objective Optimization
@@ -159,43 +161,12 @@ objectives.insert("latency".to_string(), (0.7, "Acceptable latency".to_string())
 objectives.insert("cost".to_string(), (0.8, "Within budget".to_string()));
 
 let mut weights = HashMap::new();
-weights.insert("accuracy".to_string(), 2.0);  // Double weight for accuracy
+weights.insert("accuracy".to_string(), 2.0);
 weights.insert("latency".to_string(), 1.0);
 weights.insert("cost".to_string(), 1.0);
 
 let feedback = multi_objective_feedback(&objectives, Some(&weights));
-
-// Output:
-// [accuracy] Score: 0.9 - High accuracy
-// [cost] Score: 0.8 - Within budget
-// [latency] Score: 0.7 - Acceptable latency
-// Overall: 0.85 (weighted average)
 ```
-
-### String Similarity
-```rust
-use dspy_rs::feedback_helpers::string_similarity_feedback;
-
-let feedback = string_similarity_feedback("Hello world", "Hello World");
-
-// Output:
-// ✓ Match ignoring case (minor formatting difference)
-```
-
-### Classification
-```rust
-use dspy_rs::feedback_helpers::classification_feedback;
-
-let feedback = classification_feedback("positive", "negative", Some(0.85));
-
-// Output:
-// ✗ Incorrect classification
-//   Expected: "negative"
-//   Predicted: "positive"
-//   Confidence: 0.850
-```
-
----
 
 ## Configuration Options
 
@@ -207,14 +178,12 @@ GEPA::builder()
     .temperature(0.9)            // LLM temperature for mutations
     .track_stats(true)           // Track detailed statistics
     .track_best_outputs(false)   // Store best outputs per example
-    .max_rollouts(Some(500))     // Budget: max rollouts
-    .max_lm_calls(Some(1000))    // Budget: max LM calls
-    .prompt_model(Some(lm))      // Separate LM for meta-prompting
-    .valset(Some(examples))      // Validation set (default: trainset)
+    .maybe_max_rollouts(Some(500))   // Budget: max rollouts
+    .maybe_max_lm_calls(Some(1000))  // Budget: max LM calls
+    .maybe_prompt_model(Some(lm))    // Separate LM for meta-prompting
+    .maybe_valset(Some(examples))    // Validation set
     .build()
 ```
-
----
 
 ## Understanding GEPA Results
 
@@ -234,30 +203,22 @@ println!("Total LM calls: {}", result.total_lm_calls);
 for (generation, score) in &result.evolution_history {
     println!("Gen {}: {:.3}", generation, score);
 }
-
-// Pareto frontier statistics
-for (i, stats) in result.frontier_history.iter().enumerate() {
-    println!("Iteration {}: {} candidates, coverage: {:.1}", 
-        i, stats.num_candidates, stats.avg_coverage);
-}
 ```
 
----
-
-## 🏗️ Architecture Deep Dive
+## Architecture
 
 ### Core Components
 
-#### 1. **FeedbackMetric**
+**FeedbackMetric**
 ```rust
 pub struct FeedbackMetric {
-    pub score: f32,                                    // Numerical score
-    pub feedback: String,                              // Rich explanation
-    pub metadata: HashMap<String, serde_json::Value>,  // Structured data
+    pub score: f32,
+    pub feedback: String,
+    pub metadata: HashMap<String, serde_json::Value>,
 }
 ```
 
-#### 2. **ExecutionTrace**
+**ExecutionTrace**
 ```rust
 pub struct ExecutionTrace {
     pub inputs: Example,
@@ -269,13 +230,12 @@ pub struct ExecutionTrace {
 }
 ```
 
-#### 3. **ParetoFrontier**
-Maintains candidates using per-example dominance:
+**ParetoFrontier**
 - Each candidate tracks which examples it wins on
-- Sampling is proportional to coverage (# examples won)
+- Sampling is proportional to coverage
 - Automatically prunes dominated candidates
 
-#### 4. **GEPACandidate**
+**GEPACandidate**
 ```rust
 pub struct GEPACandidate {
     pub id: usize,
@@ -289,103 +249,89 @@ pub struct GEPACandidate {
 
 ### Evolutionary Algorithm
 
-The GEPA algorithm follows these steps:
-
 1. **Initialize** the candidate pool with the unoptimized program
 2. **Iterate**:
-   - **Sample a candidate** from Pareto frontier (proportional to coverage)
-   - **Sample a minibatch** from the training set
-   - **Collect execution traces + feedback** for module rollout on minibatch
-   - **Select a module** of the candidate for targeted improvement
-   - **LLM Reflection**: Propose a new instruction/prompt for the targeted module using reflective meta-prompting and the gathered feedback
-   - **Roll out the new candidate** on the minibatch; if improved, evaluate on Pareto validation set
-   - **Update the candidate pool/Pareto frontier**
-   - **[Optional] System-aware merge/crossover**: Combine best-performing modules from distinct lineages
-3. **Continue** until rollout or metric budget is exhausted
-4. **Return** candidate with best aggregate performance on validation
-
----
+   - Sample a candidate from Pareto frontier (proportional to coverage)
+   - Sample a minibatch from the training set
+   - Collect execution traces with feedback
+   - Select a module for targeted improvement
+   - LLM Reflection: Propose new instruction using reflective meta-prompting
+   - Roll out the new candidate; if improved, evaluate on validation set
+   - Update the Pareto frontier
+3. **Continue** until budget is exhausted
+4. **Return** best candidate by average score
 
 ## Implementing Feedback Metrics
 
-A well-designed metric is central to GEPA's sample efficiency and learning signal richness. The DSRs implementation expects the metric to return a `FeedbackMetric` struct with both a score and rich textual feedback. GEPA leverages natural language traces from LM-based workflows for optimization, preserving intermediate trajectories and errors in plain text rather than reducing them to numerical rewards. This mirrors human diagnostic processes, enabling clearer identification of system behaviors and bottlenecks.
+A well-designed metric is central to GEPA's sample efficiency. The DSRs implementation expects the metric to return a `FeedbackMetric` struct with both a score and rich textual feedback.
 
 ### Practical Recipe for GEPA-Friendly Feedback
 
-- **Leverage Existing Artifacts**: Use logs, unit tests, evaluation scripts, and profiler outputs; surfacing these often suffices
-- **Decompose Outcomes**: Break scores into per-objective components (e.g., correctness, latency, cost, safety) and attribute errors to steps
-- **Expose Trajectories**: Label pipeline stages, reporting pass/fail with salient errors (e.g., in code generation pipelines)
-- **Ground in Checks**: Employ automatic validators (unit tests, schemas, simulators) or LLM-as-a-judge for non-verifiable tasks
-- **Prioritize Clarity**: Focus on error coverage and decision points over technical complexity
+- **Leverage Existing Artifacts**: Use logs, unit tests, evaluation scripts, profiler outputs
+- **Decompose Outcomes**: Break scores into per-objective components
+- **Expose Trajectories**: Label pipeline stages with pass/fail and errors
+- **Ground in Checks**: Use validators or LLM-as-a-judge for subjective tasks
+- **Prioritize Clarity**: Focus on error coverage and decision points
 
 ### Feedback Examples by Domain
 
-- **Document Retrieval** (e.g., HotpotQA): List correctly retrieved, incorrect, or missed documents, beyond mere Recall/F1 scores
-- **Multi-Objective Tasks** (e.g., PUPA): Decompose aggregate scores to reveal contributions from each objective, highlighting tradeoffs (e.g., quality vs. privacy)
-- **Stacked Pipelines** (e.g., code generation: parse → compile → run → profile → evaluate): Expose stage-specific failures; natural-language traces often suffice for LLM self-correction
+**Document Retrieval**: List correctly retrieved, incorrect, or missed documents
 
----
+**Multi-Objective Tasks**: Decompose aggregate scores to reveal contributions from each objective
+
+**Stacked Pipelines**: Expose stage-specific failures (parse, compile, run, test)
 
 ## Best Practices
 
-### 1. **Design Feedback for Actionability**
+### Design Feedback for Actionability
 ```rust
 // BAD: Vague feedback
 FeedbackMetric::new(0.5, "Wrong answer")
 
 // GOOD: Specific, actionable feedback
 FeedbackMetric::new(0.5, 
-    "✗ Incorrect answer\n\
+    "Incorrect answer\n\
      Expected: 'Paris'\n\
      Predicted: 'France'\n\
      Issue: Returned country instead of city")
 ```
 
-### 2. **Leverage Domain Knowledge**
-```rust
-// Code generation: Show stage-specific failures
-// Retrieval: List specific documents missed
-// QA: Explain reasoning errors
-```
+### Leverage Domain Knowledge
+- Code generation: Show stage-specific failures
+- Retrieval: List specific documents missed
+- QA: Explain reasoning errors
 
-### 3. **Balance Feedback Detail**
+### Balance Feedback Detail
 - Too brief: Not actionable
 - Too verbose: Drowns out signal
 - Sweet spot: 2-5 lines per issue
 
-### 4. **Use Metadata for Structured Analysis**
-```rust
-FeedbackMetric::new(score, feedback)
-    .add_metadata("error_type", json!("parsing"))
-    .add_metadata("line_number", json!(42))
-    .add_metadata("latency_ms", json!(250))
-```
-
-### 5. **Set Realistic Budgets**
+### Set Realistic Budgets
 ```rust
 // For development/testing
 GEPA::builder()
     .num_iterations(5)
-    .max_rollouts(Some(100))
+    .maybe_max_rollouts(Some(100))
     .build()
 
 // For production optimization
 GEPA::builder()
     .num_iterations(20)
-    .max_rollouts(Some(1000))
+    .maybe_max_rollouts(Some(1000))
     .build()
 ```
 
----
+## Examples
 
-## 📦 Examples
+<Card title="Sentiment Analysis" icon="face-smile" href="https://github.com/krypticmouse/DSRs/blob/main/crates/dspy-rs/examples/09-gepa-sentiment.rs">
+  Basic GEPA usage with explicit feedback for sentiment classification
+</Card>
 
-- **[09-gepa-sentiment.rs](../crates/dspy-rs/examples/09-gepa-sentiment.rs)**: Sentiment analysis with rich feedback
-- See [GEPA.md](../GEPA.md) for paper details and advanced features
+<Card title="LLM-as-Judge" icon="gavel" href="/docs/optimizers/gepa-llm-judge">
+  Using an LLM judge to automatically generate feedback
+</Card>
 
----
-
-## 🔬 Comparison with Other Optimizers
+## Comparison with Other Optimizers
 
 | Feature              | COPRO | MIPROv2 | GEPA |
 |----------------------|-------|---------|------|
@@ -409,9 +355,7 @@ GEPA::builder()
 - **COPRO**: Simple tasks, quick iteration
 - **MIPROv2**: Best prompting practices, single objective
 
----
-
-## 🐛 Troubleshooting
+## Troubleshooting
 
 ### Issue: "GEPA requires FeedbackEvaluator trait"
 ```rust
@@ -441,66 +385,10 @@ GEPA::builder().temperature(1.2).build()
 ```rust
 // Reduce iterations or increase budget
 GEPA::builder()
-    .num_iterations(10)           // Fewer iterations
-    .max_rollouts(Some(2000))     // Higher budget
+    .num_iterations(10)
+    .maybe_max_rollouts(Some(2000))
     .build()
 ```
-
----
-
-## 🚦 Next Steps
-
-1. Read the [Quick Start](#quick-start)
-2. Run the sentiment analysis example
-3. Implement FeedbackEvaluator for your use case
-4. Use feedback helpers for common patterns
-5. Experiment with configuration
-6. Monitor evolution history and Pareto statistics
-
----
-
-## Implementation Details
-
-### Statistics
-
-| Component | Lines of Code | Tests | Status |
-|-----------|---------------|-------|--------|
-| Core Data Structures | 301 | 4 | Complete |
-| Pareto Frontier | 361 | 5 | Complete |
-| GEPA Optimizer | 563 | 2 | Complete |
-| Feedback Helpers | 458 | 7 | Complete |
-| Example | 240 | - | Complete |
-| Documentation | ~900 | - | Complete |
-| **Total** | **~2800** | **18** | **Complete** |
-
-### Files Created
-
-1. `crates/dspy-rs/src/evaluate/feedback.rs` - Rich feedback structures
-2. `crates/dspy-rs/src/evaluate/feedback_helpers.rs` - Helper utilities
-3. `crates/dspy-rs/src/optimizer/pareto.rs` - Pareto frontier implementation
-4. `crates/dspy-rs/src/optimizer/gepa.rs` - GEPA optimizer
-5. `crates/dspy-rs/examples/09-gepa-sentiment.rs` - Example usage
-6. `crates/dspy-rs/tests/test_gepa.rs` - GEPA tests
-7. `crates/dspy-rs/tests/test_pareto.rs` - Pareto frontier tests
-
-### Dependencies Added
-
-```toml
-rand = "0.8.5"  # For coverage-weighted sampling
-```
-
-### Key Features
-
-- Per-example Pareto frontier (not simplified aggregate)
-- LLM reflection on execution traces
-- Budget controls (max rollouts, max LM calls)
-- Module selection support for multi-module programs
-- Evolution history tracking
-- Inference-time search capability
-- Parallel evaluation for speed
-- Comprehensive feedback helper library
-
----
 
 ## Inference-Time Search
 
@@ -510,7 +398,7 @@ GEPA can act as a test-time/inference search mechanism. By setting your `valset`
 let gepa = GEPA::builder()
     .track_stats(true)
     .track_best_outputs(true)
-    .valset(Some(my_tasks.clone()))
+    .maybe_valset(Some(my_tasks.clone()))
     .build();
 
 let result = gepa.compile_with_feedback(&mut module, my_tasks).await?;
@@ -520,16 +408,9 @@ let best_scores = result.highest_score_achieved_per_val_task;
 let best_outputs = result.best_outputs_valset;
 ```
 
----
-
 ## Additional Resources
 
 - [GEPA Paper](https://arxiv.org/abs/2507.19457)
-- [GEPA GitHub](https://github.com/gepa-ai/gepa) - Core GEPA evolution pipeline
-- [DSRs Documentation](https://dsrs.herumbshandilya.com)
-- [API Reference](https://docs.rs/dspy-rs)
-- [Examples Directory](../crates/dspy-rs/examples/)
-
----
-
-Built with Rust for the DSPy x Rust community
+- [GEPA GitHub](https://github.com/gepa-ai/gepa)
+- [LLM-as-Judge Pattern](/docs/optimizers/gepa-llm-judge)
+- [Example Code](https://github.com/krypticmouse/DSRs/blob/main/crates/dspy-rs/examples/09-gepa-sentiment.rs)

--- a/docs/docs/optimizers/miprov2.mdx
+++ b/docs/docs/optimizers/miprov2.mdx
@@ -1,17 +1,15 @@
-# MIPROv2 Implementation
-
-## Overview
+---
+title: 'MIPROv2'
+description: 'LLM-guided prompt generation with best practices'
+icon: 'wand-magic-sparkles'
+---
 
 MIPROv2 (Multi-prompt Instruction Proposal Optimizer v2) is an optimizer that uses LLMs to generate and refine prompts automatically. It differs from COPRO by using an LLM to understand the program and apply prompting best practices, rather than just iterating on existing instructions.
-
-The approach:
-- LLM generates descriptions of what your program does
-- Incorporates prompting tips and techniques  
-- Evaluates candidates systematically
 
 ## How it Works
 
 ### Stage 1: Trace Generation
+
 ```rust
 async fn generate_traces<M>(
     &self,
@@ -25,14 +23,6 @@ async fn generate_traces<M>(
 - Creates a dataset of execution traces that show current behavior
 
 ### Stage 2: Candidate Prompt Generation
-```rust
-async fn generate_candidate_instructions(
-    &self,
-    program_description: &str,
-    traces: &[Trace],
-    num_candidates: usize,
-) -> Result<Vec<String>>
-```
 
 This stage has two sub-steps:
 
@@ -47,15 +37,6 @@ The prompting tips library includes:
 - Request structured outputs when needed
 
 ### Stage 3: Evaluation and Selection
-```rust
-async fn evaluate_and_select_best<M>(
-    &self,
-    module: &mut M,
-    candidates: Vec<PromptCandidate>,
-    eval_examples: &[Example],
-    predictor_name: &str,
-) -> Result<PromptCandidate>
-```
 
 - Evaluates each candidate on a minibatch of examples
 - Computes performance scores
@@ -80,26 +61,6 @@ You can adjust:
 - Temperature for generation diversity
 - Whether to display progress stats
 
-## Implementation Notes
-
-The code follows standard Rust practices:
-- No unsafe blocks
-- Results for error handling with context via anyhow
-- Strong types (Trace, PromptCandidate, PromptingTips)
-- Builder pattern for configuration
-- Async throughout, no blocking calls
-
-Key types:
-- `Trace` - Input/output pair with evaluation score
-- `PromptCandidate` - Instruction text with score
-- `PromptingTips` - Library of best practices
-
-Main methods:
-- `generate_traces()` - Run module and capture traces
-- `generate_program_description()` - LLM describes the program
-- `generate_candidate_instructions()` - LLM generates prompts using tips
-- `evaluate_and_select_best()` - Test candidates and pick winner
-
 ## Usage Example
 
 ```rust
@@ -116,47 +77,68 @@ let optimizer = MIPROv2::builder()
 optimizer.compile(&mut module, train_examples).await?;
 ```
 
-## COPRO vs MIPROv2
+## Comparison: COPRO vs MIPROv2 vs GEPA
 
-| | COPRO | MIPROv2 |
-|---|---|---|
-| Approach | Iterative refinement | LLM-guided generation |
-| LLM calls | Moderate | High |
-| Speed | Faster | Slower |
-| Use for | Quick iteration, simple tasks | Best results, complex tasks |
+| Feature | COPRO | MIPROv2 | GEPA |
+|---------|-------|---------|------|
+| **Approach** | Iterative refinement | LLM-guided generation | Reflective evolution |
+| **Feedback** | Score only | Score only | Score + Text |
+| **Selection** | Best candidate | Batch evaluation | Pareto frontier |
+| **LLM calls** | Moderate | High | Medium-High |
+| **Speed** | Faster | Slower | Medium |
+| **Diversity** | Low | Medium | High |
+| **Best for** | Quick iteration | Best results | Complex tasks |
 
-Use MIPROv2 when:
+### When to Use MIPROv2
+
 - You have decent training data (15+ examples recommended)
 - Quality matters more than speed
 - Task benefits from prompting best practices
+- Need LLM-generated program understanding
 
-Use COPRO when:
+### When to Use COPRO
+
 - You need fast iteration
 - Compute budget is limited
 - Task is straightforward
 
-## Future Work
+### When to Use GEPA
 
-Potential additions:
+- Complex tasks with subtle failure modes
+- You can provide rich feedback
+- Multi-objective optimization
+- Need diverse solutions
 
-**Few-shot demos** - The `PromptCandidate` struct has a `demos` field that's currently unused. Could integrate demo selection into the optimization.
+## Implementation Notes
 
-**Iterative refinement** - Run multiple rounds where good candidates inform the next generation.
+The code follows standard Rust practices:
+- No unsafe blocks
+- Results for error handling with context via anyhow
+- Strong types (Trace, PromptCandidate, PromptingTips)
+- Builder pattern for configuration
+- Async throughout, no blocking calls
 
-**Custom tips** - Let users provide domain-specific prompting tips alongside the defaults.
+Key types:
+- `Trace` - Input/output pair with evaluation score
+- `PromptCandidate` - Instruction text with score
+- `PromptingTips` - Library of best practices
 
 ## Testing
 
 Run tests:
 ```bash
-cargo test optimizer::mipro::tests
+cargo test test_miprov2
 ```
 
 There are 29 test cases covering trace generation, candidate selection, configuration, and edge cases.
 
-## Example Usage
+## Example
 
-See `examples/08-optimize-mipro.rs` for a working example. It loads HuggingFace data, measures baseline performance, runs optimization, and shows the improvement.
+<Card title="MIPROv2 Example" icon="file-code" href="https://github.com/krypticmouse/DSRs/blob/main/crates/dspy-rs/examples/08-optimize-mipro.rs">
+  Complete working example with HuggingFace data loading
+</Card>
+
+The example loads data, measures baseline performance, runs optimization, and shows the improvement.
 
 ## References
 

--- a/docs/gepa-llm-judge-pattern.md
+++ b/docs/gepa-llm-judge-pattern.md
@@ -1,0 +1,265 @@
+# Using LLM-as-a-Judge with GEPA
+
+This guide explains how to use an LLM judge to automatically generate rich textual feedback for GEPA optimization, making it easier to optimize complex tasks where manual feedback rules are hard to codify.
+
+## The Pattern
+
+Instead of manually writing feedback rules, use another LLM to evaluate the output and reasoning:
+
+```
+Task LM → generates answer + reasoning
+    ↓
+Judge LM → analyzes quality and provides feedback
+    ↓
+GEPA Reflection LM → reads feedback and improves prompt
+    ↓
+Better Task LM prompt
+```
+
+## Why Use LLM-as-a-Judge?
+
+**Good for:**
+- Subjective quality assessment (writing style, helpfulness, clarity)
+- Complex reasoning evaluation (is the logic sound?)
+- Tasks where rules are hard to codify
+- Analyzing reasoning quality beyond just answer correctness
+
+**When to avoid:**
+- You have deterministic checks (unit tests, schema validation)
+- Verifiable correctness (code compilation, exact matches)
+- Need fast/cheap evaluation
+- Simple binary pass/fail
+
+## Complete Example Walkthrough
+
+See `examples/10-gepa-llm-judge.rs` for a full working example. Here are the key pieces:
+
+### 1. Task Signature with Reasoning
+
+```rust
+#[Signature(cot)]
+struct MathWordProblem {
+    #[input]
+    pub problem: String,
+    
+    #[output]
+    pub reasoning: String,  // We want to optimize this too
+    
+    #[output]
+    pub answer: String,
+}
+```
+
+### 2. Judge Signature
+
+```rust
+#[Signature]
+struct MathJudge {
+    /// You are an expert math teacher evaluating student work.
+    
+    #[input]
+    pub problem: String,
+    
+    #[input]
+    pub expected_answer: String,
+    
+    #[input]
+    pub student_answer: String,
+    
+    #[input]
+    pub student_reasoning: String,
+    
+    #[output(desc = "Detailed evaluation of the work")]
+    pub evaluation: String,  // This becomes the feedback
+}
+```
+
+### 3. Module with Embedded Judge
+
+```rust
+#[derive(Builder, Optimizable)]
+struct MathSolver {
+    #[parameter]
+    solver: Predict,  // This gets optimized
+    
+    judge: Predict,   // This stays fixed, just evaluates
+    judge_lm: Arc<Mutex<LM>>,
+}
+```
+
+### 4. FeedbackEvaluator with Judge
+
+```rust
+impl FeedbackEvaluator for MathSolver {
+    async fn feedback_metric(&self, example: &Example, prediction: &Prediction) 
+        -> FeedbackMetric 
+    {
+        // Extract outputs
+        let student_answer = prediction.get("answer", None).as_str().unwrap();
+        let student_reasoning = prediction.get("reasoning", None).as_str().unwrap();
+        let expected = example.get("expected_answer", None).as_str().unwrap();
+        
+        // Call the judge
+        let judge_input = example! {
+            "problem": "input" => problem,
+            "expected_answer": "input" => expected,
+            "student_answer": "input" => student_answer,
+            "student_reasoning": "input" => student_reasoning
+        };
+        
+        let judge_output = match self.judge
+            .forward_with_config(judge_input, Arc::clone(&self.judge_lm))
+            .await 
+        {
+            Ok(output) => output,
+            Err(_) => {
+                // Fallback if judge fails
+                return FeedbackMetric::new(
+                    if student_answer == expected { 1.0 } else { 0.0 },
+                    format!("Expected: {}, Got: {}", expected, student_answer)
+                );
+            }
+        };
+        
+        let judge_evaluation = judge_output
+            .get("evaluation", None)
+            .as_str()
+            .unwrap_or("No evaluation provided")
+            .to_string();
+        
+        // Score based on both correctness AND reasoning quality
+        let answer_correct = student_answer.trim() == expected.trim();
+        let good_reasoning = judge_evaluation.to_lowercase().contains("sound reasoning") 
+            || judge_evaluation.to_lowercase().contains("correct approach");
+        
+        let score = match (answer_correct, good_reasoning) {
+            (true, true) => 1.0,   // Perfect
+            (true, false) => 0.7,  // Right answer, flawed reasoning
+            (false, true) => 0.3,  // Wrong answer, but valid approach
+            (false, false) => 0.0, // Completely wrong
+        };
+        
+        // Combine factual info with judge's analysis
+        let feedback = format!(
+            "Problem: {}\nExpected: {}\nPredicted: {}\n\
+             Answer: {}\n\nReasoning Quality Analysis:\n{}",
+            problem, expected, student_answer,
+            if answer_correct { "CORRECT" } else { "INCORRECT" },
+            judge_evaluation
+        );
+        
+        FeedbackMetric::new(score, feedback)
+    }
+}
+```
+
+## Key Benefits
+
+**1. Catches lucky guesses:**
+```
+Answer: Correct (1.0)
+But reasoning: "I just multiplied random numbers"
+Score: 0.7 (penalized for bad reasoning)
+```
+
+**2. Rewards partial progress:**
+```
+Answer: Wrong
+But reasoning: "Correct approach, arithmetic error in final step"
+Score: 0.3 (partial credit)
+```
+
+**3. Identifies systematic issues:**
+The judge notices patterns like:
+- "Model consistently skips showing intermediate steps"
+- "Model confuses similar concepts (area vs perimeter)"
+- "Model doesn't check units in answers"
+
+GEPA's reflection can then say:
+> "Add explicit instruction to show all intermediate steps and verify units"
+
+## Cost Considerations
+
+LLM judges double your evaluation cost since every prediction requires:
+1. Task LM call (generate answer)
+2. Judge LM call (evaluate quality)
+
+**Budget accordingly:**
+
+```rust
+GEPA::builder()
+    .num_iterations(3)           // Fewer iterations
+    .minibatch_size(3)           // Smaller batches
+    .maybe_max_lm_calls(Some(100))  // Explicit limit
+    .build()
+```
+
+**Optimization tips:**
+- Use a cheaper model for judging (gpt-4o-mini vs gpt-4)
+- Judge only failed examples (not ones that passed)
+- Cache judge evaluations for identical outputs
+- Use parallel evaluation to reduce wall-clock time
+
+## When to Use Hybrid Approach
+
+Best results often come from combining explicit checks with LLM judging:
+
+```rust
+async fn feedback_metric(&self, example: &Example, prediction: &Prediction) 
+    -> FeedbackMetric 
+{
+    let mut feedback_parts = vec![];
+    let mut score = 1.0;
+    
+    // Explicit checks first (fast, cheap, deterministic)
+    if !is_valid_json(output) {
+        feedback_parts.push("Invalid JSON format");
+        score = 0.0;
+    }
+    
+    if missing_required_fields(output) {
+        feedback_parts.push("Missing fields: user_id, timestamp");
+        score *= 0.5;
+    }
+    
+    // Only call judge if basic checks pass
+    if score > 0.0 {
+        let judge_feedback = self.judge_quality(example, prediction).await;
+        feedback_parts.push(judge_feedback);
+        
+        if judge_feedback.contains("low quality") {
+            score *= 0.7;
+        }
+    }
+    
+    FeedbackMetric::new(score, feedback_parts.join("\n"))
+}
+```
+
+## Example Output
+
+When you run the example, GEPA will evolve prompts based on judge feedback:
+
+```
+Baseline: "Solve the math word problem step by step"
+  → Some solutions skip steps
+  → Judge: "Reasoning incomplete, jumped from step 2 to answer"
+
+After GEPA:
+  → "Solve step by step. Show ALL intermediate calculations. Label each step clearly."
+  → Judge: "Sound reasoning, all steps shown clearly"
+```
+
+The judge's analysis becomes the signal that drives prompt improvement.
+
+## Running the Example
+
+```bash
+OPENAI_API_KEY=your_key cargo run --example 10-gepa-llm-judge
+```
+
+This will show:
+1. Baseline performance
+2. Judge evaluations during optimization
+3. How feedback evolves the prompt
+4. Final test with judge analysis

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -60,4 +60,11 @@ Understand in-depth about the building blocks of DSRs
   >
     Learn about the concepts that make up the foundation of DSRs
   </Card>
+  <Card
+    title="Optimizers"
+    icon="wand-magic-sparkles"
+    href="/docs/optimizers/copro"
+  >
+    Optimize your modules with COPRO, MIPROv2, and GEPA
+  </Card>
 </Columns>


### PR DESCRIPTION
This adds an example showing how to use an LLM judge to automatically generate feedback for GEPA instead of writing manual feedback rules.

**The pattern:**

Task LM generates answer with reasoning → Judge LM evaluates quality and provides detailed feedback → GEPA reflection uses that feedback to improve the prompt.

**Why this is useful:**

When you can't easily codify feedback rules - like evaluating reasoning quality, writing style, or subjective criteria. The judge can catch things like skipped steps in reasoning, logical errors, or lucky guesses that manual checks would miss.

**Example included:**

Math word problem solver where the judge evaluates both answer correctness and reasoning quality. Assigns partial credit based on approach - wrong answer but valid method gets 0.3, right answer with flawed reasoning gets 0.7, both correct gets 1.0.

Tested and working. The judge's analysis helps GEPA learn to optimize for better reasoning processes, not just right answers. This generalizes better to new problems.

**Trade-off:**

Doubles LM calls per evaluation (task + judge), so added budget controls in the example. Documentation explains when to use explicit feedback vs judge vs hybrid approach.

New files:
- examples/10-gepa-llm-judge.rs (339 lines)
- docs/gepa-llm-judge-pattern.md (266 lines)