### PR TITLE
Add tracing instrumentation across dspy runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1189,6 +1189,8 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -4215,9 +4217,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -4226,9 +4228,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4237,9 +4239,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -4270,9 +4272,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.20"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
 dependencies = [
  "matchers",
  "nu-ansi-term",

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Here's a simple example to get you started:
 
 ```rust
 use anyhow::Result;
-use dspy_rs::{configure, ChatAdapter, LM, Predict, Signature};
+use dspy_rs::{configure, init_tracing, ChatAdapter, LM, Predict, Signature};
 
 #[derive(Signature, Clone)]
 struct SentimentAnalyzer {
@@ -64,6 +64,8 @@ struct SentimentAnalyzer {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    init_tracing()?;
+
     // API key automatically read from OPENAI_API_KEY env var
     configure(
         LM::builder()

--- a/crates/dspy-rs/Cargo.toml
+++ b/crates/dspy-rs/Cargo.toml
@@ -40,6 +40,8 @@ foyer = { version = "0.20.0", features = ["serde"]}
 tempfile = "3.23.0"
 rig-core = { git = "https://github.com/0xPlaygrounds/rig", rev="e7849df" }
 enum_dispatch = "0.3.13"
+tracing = "0.1.44"
+tracing-subscriber = { version = "0.3.22", features = ["env-filter", "fmt"] }
 
 [package.metadata.cargo-machete]
 ignored = ["rig-core"]

--- a/crates/dspy-rs/examples/01-simple.rs
+++ b/crates/dspy-rs/examples/01-simple.rs
@@ -15,7 +15,7 @@ cargo run --example 01-simple
 
 use anyhow::Result;
 use bon::Builder;
-use dspy_rs::{ChatAdapter, Example, LM, Module, Predict, Prediction, configure};
+use dspy_rs::{ChatAdapter, Example, LM, Module, Predict, Prediction, configure, init_tracing};
 
 const QA_INSTRUCTION: &str = "Answer the question step by step.";
 const RATE_INSTRUCTION: &str = "Rate the answer on a scale of 1 (very bad) to 10 (very good).";
@@ -93,6 +93,8 @@ impl Module for QARater {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    init_tracing()?;
+
     configure(
         LM::builder()
             .model("openai:gpt-4o-mini".to_string())

--- a/crates/dspy-rs/examples/02-module-iteration-and-updation.rs
+++ b/crates/dspy-rs/examples/02-module-iteration-and-updation.rs
@@ -13,7 +13,7 @@ use anyhow::Result;
 use bon::Builder;
 use dspy_rs::{
     Example, LegacyPredict, LegacySignature, Module, Optimizable, Prediction, Predictor, hashmap,
-    prediction,
+    init_tracing, prediction,
 };
 
 #[LegacySignature(cot)]
@@ -92,6 +92,8 @@ impl Module for QARater {
 
 #[tokio::main]
 async fn main() {
+    init_tracing().expect("failed to initialize tracing");
+
     // Single module test
     let mut qa_rater = QARater::builder().build();
     for (name, param) in qa_rater.parameters() {

--- a/crates/dspy-rs/examples/03-evaluate-hotpotqa.rs
+++ b/crates/dspy-rs/examples/03-evaluate-hotpotqa.rs
@@ -13,7 +13,7 @@ use anyhow::Result;
 use bon::Builder;
 use dspy_rs::{
     ChatAdapter, Evaluator, Example, LM, LegacyPredict, LegacySignature, Module, Optimizable,
-    Prediction, Predictor, configure,
+    Prediction, Predictor, configure, init_tracing,
 };
 
 use dspy_rs::DataLoader;
@@ -62,6 +62,8 @@ impl Evaluator for QARater {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    init_tracing()?;
+
     configure(
         LM::builder()
             .model("openai:gpt-4o-mini".to_string())

--- a/crates/dspy-rs/examples/04-optimize-hotpotqa.rs
+++ b/crates/dspy-rs/examples/04-optimize-hotpotqa.rs
@@ -13,7 +13,7 @@ use anyhow::Result;
 use bon::Builder;
 use dspy_rs::{
     COPRO, ChatAdapter, DataLoader, Evaluator, Example, LM, LegacyPredict, LegacySignature, Module,
-    Optimizable, Optimizer, Prediction, Predictor, configure,
+    Optimizable, Optimizer, Prediction, Predictor, configure, init_tracing,
 };
 
 #[LegacySignature(cot)]
@@ -58,6 +58,8 @@ impl Evaluator for QARater {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    init_tracing()?;
+
     configure(
         LM::builder()
             .model("openai:gpt-4o-mini".to_string())

--- a/crates/dspy-rs/examples/05-heterogenous-examples.rs
+++ b/crates/dspy-rs/examples/05-heterogenous-examples.rs
@@ -9,7 +9,9 @@ cargo run --example 05-heterogenous-examples
 
 #![allow(deprecated)]
 
-use dspy_rs::{ChatAdapter, LM, LegacyPredict, LegacySignature, Predictor, configure, example};
+use dspy_rs::{
+    ChatAdapter, LM, LegacyPredict, LegacySignature, Predictor, configure, example, init_tracing,
+};
 
 #[LegacySignature]
 struct NumberSignature {
@@ -23,6 +25,8 @@ struct NumberSignature {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    init_tracing()?;
+
     configure(
         LM::builder()
             .model("openai:gpt-4o-mini".to_string())

--- a/crates/dspy-rs/examples/06-other-providers-batch.rs
+++ b/crates/dspy-rs/examples/06-other-providers-batch.rs
@@ -13,7 +13,7 @@ use anyhow::Result;
 use bon::Builder;
 use dspy_rs::{
     ChatAdapter, Example, LM, LegacyPredict, LegacySignature, Module, Prediction, Predictor,
-    configure, example, hashmap, prediction,
+    configure, example, hashmap, init_tracing, prediction,
 };
 
 #[LegacySignature(cot)]
@@ -77,6 +77,8 @@ impl Module for QARater {
 
 #[tokio::main]
 async fn main() {
+    init_tracing().expect("failed to initialize tracing");
+
     // Anthropic
     configure(
         LM::builder()

--- a/crates/dspy-rs/examples/07-inspect-history.rs
+++ b/crates/dspy-rs/examples/07-inspect-history.rs
@@ -13,7 +13,7 @@ use anyhow::Result;
 use bon::Builder;
 use dspy_rs::{
     ChatAdapter, Example, LM, LegacyPredict, LegacySignature, Module, Prediction, Predictor,
-    configure, example, get_lm,
+    configure, example, get_lm, init_tracing,
 };
 
 #[LegacySignature]
@@ -38,6 +38,8 @@ impl Module for QARater {
 
 #[tokio::main]
 async fn main() {
+    init_tracing().expect("failed to initialize tracing");
+
     let lm = LM::builder()
         .model("openai:gpt-4o-mini".to_string())
         .build()

--- a/crates/dspy-rs/examples/08-optimize-mipro.rs
+++ b/crates/dspy-rs/examples/08-optimize-mipro.rs
@@ -23,7 +23,7 @@ use anyhow::Result;
 use bon::Builder;
 use dspy_rs::{
     ChatAdapter, DataLoader, Evaluator, Example, LM, LegacyPredict, LegacySignature, MIPROv2,
-    Module, Optimizable, Optimizer, Prediction, Predictor, configure, example,
+    Module, Optimizable, Optimizer, Prediction, Predictor, configure, example, init_tracing,
 };
 
 #[LegacySignature]
@@ -84,6 +84,8 @@ impl Evaluator for SimpleQA {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    init_tracing()?;
+
     println!("=== MIPROv2 Optimizer Example ===\n");
 
     // Configure the LM

--- a/crates/dspy-rs/examples/09-gepa-sentiment.rs
+++ b/crates/dspy-rs/examples/09-gepa-sentiment.rs
@@ -116,6 +116,8 @@ impl FeedbackEvaluator for SentimentAnalyzer {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    init_tracing()?;
+
     println!("GEPA Sentiment Analysis Optimization Example\n");
 
     // Setup LM

--- a/crates/dspy-rs/examples/10-gepa-llm-judge.rs
+++ b/crates/dspy-rs/examples/10-gepa-llm-judge.rs
@@ -219,6 +219,8 @@ impl FeedbackEvaluator for MathSolver {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    init_tracing()?;
+
     println!("GEPA with LLM-as-a-Judge Example\n");
     println!("This example shows how to use an LLM judge to automatically");
     println!("generate rich feedback for optimizing a math solver.\n");

--- a/crates/dspy-rs/examples/11-custom-client.rs
+++ b/crates/dspy-rs/examples/11-custom-client.rs
@@ -15,6 +15,7 @@ cargo run --example 11-custom-client
 use anyhow::Result;
 use dspy_rs::{
     ChatAdapter, LM, LMClient, LegacyPredict, LegacySignature, Predictor, configure, example,
+    init_tracing,
 };
 use rig::providers::*;
 use std::env;
@@ -30,6 +31,8 @@ struct QASignature {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    init_tracing()?;
+
     // Create a custom Azure OpenAI completion model directly
     let api_key = env::var("AZURE_OPENAI_API_KEY").unwrap_or_else(|_| "dummy-key".to_string());
     let endpoint = env::var("AZURE_OPENAI_ENDPOINT")

--- a/crates/dspy-rs/examples/12-tracing.rs
+++ b/crates/dspy-rs/examples/12-tracing.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use bon::Builder;
 use dspy_rs::{
     ChatAdapter, LM, LegacyPredict, LegacySignature, Module, Prediction, Predictor, configure,
-    example, prediction,
+    example, init_tracing, prediction,
     trace::{self, IntoTracked},
 };
 
@@ -63,6 +63,8 @@ impl Module for QARater {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    init_tracing()?;
+
     // Configure with a dummy model string
     configure(
         LM::builder()

--- a/crates/dspy-rs/examples/15-tools.rs
+++ b/crates/dspy-rs/examples/15-tools.rs
@@ -18,7 +18,9 @@ cargo run --example 15-tools
 #![allow(deprecated)]
 
 use anyhow::Result;
-use dspy_rs::{ChatAdapter, LM, LegacyPredict, LegacySignature, Predictor, configure, example};
+use dspy_rs::{
+    ChatAdapter, LM, LegacyPredict, LegacySignature, Predictor, configure, example, init_tracing,
+};
 use rig::completion::ToolDefinition;
 use rig::tool::Tool;
 use serde::{Deserialize, Serialize};
@@ -137,6 +139,8 @@ struct MathQuestionSignature {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    init_tracing()?;
+
     // Setup LM
     let lm = LM::builder()
         .model("groq:openai/gpt-oss-120b".to_string())

--- a/crates/dspy-rs/examples/16-insurance-claim-prompt.rs
+++ b/crates/dspy-rs/examples/16-insurance-claim-prompt.rs
@@ -5,7 +5,7 @@ Run with:
 cargo run --example 16-insurance-claim-prompt
 */
 
-use dspy_rs::{BamlType, ChatAdapter, Signature};
+use dspy_rs::{BamlType, ChatAdapter, Signature, init_tracing};
 
 // Keep the example self-contained; dates are represented as YYYY-MM-DD strings.
 type NaiveDate = String;
@@ -184,6 +184,8 @@ pub struct InsuranceClaimInfo {
 }
 
 fn main() {
+    init_tracing().expect("failed to initialize tracing");
+
     let adapter = ChatAdapter;
     let system = adapter
         .format_system_message_typed::<InsuranceClaimInfo>()

--- a/crates/dspy-rs/examples/17-pretty-tracing.rs
+++ b/crates/dspy-rs/examples/17-pretty-tracing.rs
@@ -1,0 +1,32 @@
+use anyhow::Result;
+use dspy_rs::{Chat, DummyLM, Example, Message, hashmap, init_tracing};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Turn on human-readable tracing output with a sensible default filter.
+    init_tracing()?;
+
+    let lm = DummyLM::new().await;
+    let example = Example::new(
+        hashmap! {
+            "problem".to_string() => "What is 2 + 2?".to_string().into(),
+        },
+        vec!["problem".to_string()],
+        vec!["answer".to_string()],
+    );
+    let chat = Chat::new(vec![
+        Message::system("You are a precise math assistant."),
+        Message::user("What is 2 + 2?"),
+    ]);
+
+    let response = lm
+        .call(
+            example,
+            chat,
+            "[[ ## answer ## ]]\n4\n\n[[ ## completed ## ]]".to_string(),
+        )
+        .await?;
+
+    println!("assistant response: {}", response.output.content());
+    Ok(())
+}

--- a/crates/dspy-rs/src/core/lm/mod.rs
+++ b/crates/dspy-rs/src/core/lm/mod.rs
@@ -12,6 +12,7 @@ use rig::{completion::AssistantContent, message::ToolCall, message::ToolChoice, 
 use bon::Builder;
 use std::{collections::HashMap, sync::Arc};
 use tokio::sync::Mutex;
+use tracing::{Instrument, debug, trace, warn};
 
 use crate::utils::cache::CacheEntry;
 use crate::{Cache, Example, Prediction, ResponseCache};
@@ -83,26 +84,48 @@ impl LM {
     ///    → Uses OpenAI client for vLLM/local servers (dummy key)
     /// 3. Provider via model string: no `base_url`, model in "provider:model" format
     ///    → Uses provider-specific client (openai, anthropic, gemini, etc.)
+    #[tracing::instrument(
+        name = "dsrs.lm.initialize_client",
+        level = "debug",
+        skip(self),
+        fields(
+            model = %self.model,
+            base_url_present = self.base_url.is_some(),
+            api_key_present = self.api_key.is_some(),
+            cache_enabled = self.cache,
+            max_tokens = self.max_tokens,
+            temperature = self.temperature,
+            max_tool_iterations = self.max_tool_iterations
+        )
+    )]
     async fn initialize_client(mut self) -> Result<Self> {
         // Determine which build case based on what's provided
         let client = match (&self.base_url, &self.api_key, &self.model) {
             // Case 1: OpenAI-compatible with authentication (base_url + api_key)
             // For custom OpenAI-compatible APIs that require API keys
-            (Some(base_url), Some(api_key), _) => Arc::new(LMClient::from_openai_compatible(
-                base_url,
-                api_key,
-                &self.model,
-            )?),
+            (Some(base_url), Some(api_key), _) => {
+                debug!(build_case = 1, "using openai-compatible client with auth");
+                Arc::new(LMClient::from_openai_compatible(
+                    base_url,
+                    api_key,
+                    &self.model,
+                )?)
+            }
             // Case 2: Local OpenAI-compatible server (base_url only, no api_key)
             // For vLLM, text-generation-inference, and other local OpenAI-compatible servers
-            (Some(base_url), None, _) => Arc::new(LMClient::from_local(base_url, &self.model)?),
+            (Some(base_url), None, _) => {
+                debug!(build_case = 2, "using local openai-compatible client");
+                Arc::new(LMClient::from_local(base_url, &self.model)?)
+            }
             // Case 3: Provider via model string (no base_url, model in "provider:model" format)
             // Uses provider-specific clients
             (None, api_key, model) if model.contains(':') => {
+                debug!(build_case = 3, "using provider:model client");
                 Arc::new(LMClient::from_model_string(model, api_key.as_deref())?)
             }
             // Default case: assume OpenAI provider if no colon in model name
             (None, api_key, model) => {
+                debug!(build_case = 4, "defaulting model to openai provider");
                 let model_str = if model.contains(':') {
                     model.to_string()
                 } else {
@@ -116,9 +139,11 @@ impl LM {
 
         // Initialize cache if enabled
         if self.cache && self.cache_handler.is_none() {
+            debug!("initializing response cache");
             self.cache_handler = Some(Arc::new(Mutex::new(ResponseCache::new().await)));
         }
 
+        debug!("lm client initialized");
         Ok(self)
     }
 
@@ -138,8 +163,16 @@ impl<S: l_m_builder::State> LMBuilder<S> {
     /// 1. OpenAI-compatible with auth: `base_url` + `api_key` provided
     /// 2. Local OpenAI-compatible: `base_url` only (for vLLM, etc.)
     /// 3. Provider via model string: model in "provider:model" format
+    #[tracing::instrument(name = "dsrs.lm.build", level = "debug", skip(self))]
     pub async fn build(self) -> Result<LM> {
         let lm = self.__internal_build();
+        debug!(
+            model = %lm.model,
+            base_url_present = lm.base_url.is_some(),
+            api_key_present = lm.api_key.is_some(),
+            cache_enabled = lm.cache,
+            "building lm"
+        );
         lm.initialize_client().await
     }
 }
@@ -153,6 +186,23 @@ struct ToolLoopResult {
 }
 
 impl LM {
+    #[tracing::instrument(
+        name = "dsrs.lm.tools.loop",
+        level = "debug",
+        skip(
+            self,
+            initial_tool_call,
+            tools,
+            tool_definitions,
+            chat_history,
+            system_prompt,
+            accumulated_usage
+        ),
+        fields(
+            initial_tool = %initial_tool_call.function.name,
+            max_iterations = self.max_tool_iterations as usize
+        )
+    )]
     async fn execute_tool_loop(
         &self,
         initial_tool_call: &rig::message::ToolCall,
@@ -167,25 +217,40 @@ impl LM {
         use rig::message::UserContent;
 
         let max_iterations = self.max_tool_iterations as usize;
-
         let mut tool_calls = Vec::new();
         let mut tool_executions = Vec::new();
 
         // Execute the first tool call
         let tool_name = &initial_tool_call.function.name;
         let args_str = initial_tool_call.function.arguments.to_string();
+        debug!(tool = %tool_name, "executing initial tool call");
 
         let mut tool_result = format!("Tool '{}' not found", tool_name);
+        let mut found_tool = false;
         for tool in &mut tools {
             let def = tool.definition("".to_string()).await;
             if def.name == *tool_name {
                 // Actually execute the tool
-                tool_result = tool.call(args_str.clone()).await.unwrap();
+                tool_result = tool.call(args_str.clone()).await.map_err(|err| {
+                    anyhow::anyhow!(
+                        "tool `{}` execution failed during initial call: {:?}",
+                        tool_name,
+                        err
+                    )
+                })?;
                 tool_calls.push(initial_tool_call.clone());
                 tool_executions.push(tool_result.clone());
+                found_tool = true;
                 break;
             }
         }
+        if !found_tool {
+            warn!(tool = %tool_name, "tool not found");
+        }
+        trace!(
+            tool_result_len = tool_result.len(),
+            "initial tool execution complete"
+        );
 
         // Add initial tool call and result to history
         chat_history.push(rig::message::Message::Assistant {
@@ -213,7 +278,7 @@ impl LM {
         });
 
         // Now loop until we get a text response
-        for _iteration in 1..max_iterations {
+        for iteration in 1..max_iterations {
             let request = CompletionRequest {
                 preamble: Some(system_prompt.clone()),
                 chat_history: if chat_history.len() == 1 {
@@ -239,9 +304,17 @@ impl LM {
             accumulated_usage.prompt_tokens += response.usage.input_tokens;
             accumulated_usage.completion_tokens += response.usage.output_tokens;
             accumulated_usage.total_tokens += response.usage.total_tokens;
+            debug!(
+                iteration,
+                prompt_tokens = accumulated_usage.prompt_tokens,
+                completion_tokens = accumulated_usage.completion_tokens,
+                total_tokens = accumulated_usage.total_tokens,
+                "tool loop usage updated"
+            );
 
             match response.choice.first() {
                 AssistantContent::Text(text) => {
+                    debug!(iteration, "tool loop completed with text");
                     return Ok(ToolLoopResult {
                         message: Message::assistant(&text.text),
                         chat_history,
@@ -250,6 +323,7 @@ impl LM {
                     });
                 }
                 AssistantContent::Reasoning(reasoning) => {
+                    debug!(iteration, "tool loop completed with reasoning");
                     return Ok(ToolLoopResult {
                         message: Message::assistant(reasoning.reasoning.join("\n")),
                         chat_history,
@@ -261,18 +335,36 @@ impl LM {
                     // Execute tool and continue
                     let tool_name = &tool_call.function.name;
                     let args_str = tool_call.function.arguments.to_string();
+                    debug!(iteration, tool = %tool_name, "executing tool call");
 
                     let mut tool_result = format!("Tool '{}' not found", tool_name);
+                    let mut found_tool = false;
                     for tool in &mut tools {
                         let def = tool.definition("".to_string()).await;
                         if def.name == *tool_name {
                             // Actually execute the tool
-                            tool_result = tool.call(args_str.clone()).await.unwrap();
+                            tool_result = tool.call(args_str.clone()).await.map_err(|err| {
+                                anyhow::anyhow!(
+                                    "tool `{}` execution failed at iteration {}: {:?}",
+                                    tool_name,
+                                    iteration,
+                                    err
+                                )
+                            })?;
                             tool_calls.push(tool_call.clone());
                             tool_executions.push(tool_result.clone());
+                            found_tool = true;
                             break;
                         }
                     }
+                    if !found_tool {
+                        warn!(iteration, tool = %tool_name, "tool not found");
+                    }
+                    trace!(
+                        iteration,
+                        tool_result_len = tool_result.len(),
+                        "tool execution complete"
+                    );
 
                     chat_history.push(rig::message::Message::Assistant {
                         id: None,
@@ -302,19 +394,35 @@ impl LM {
             }
         }
 
+        warn!(max_iterations, "max tool iterations reached");
         Err(anyhow::anyhow!("Max tool iterations reached"))
     }
 
+    #[tracing::instrument(
+        name = "dsrs.lm.call",
+        level = "debug",
+        skip(self, messages, tools),
+        fields(
+            model = %self.model,
+            message_count = messages.len(),
+            tool_count = tools.len(),
+            cache_enabled = self.cache
+        )
+    )]
     pub async fn call(&self, messages: Chat, tools: Vec<Arc<dyn ToolDyn>>) -> Result<LMResponse> {
         use rig::OneOrMany;
         use rig::completion::CompletionRequest;
-
         let request_messages = messages.get_rig_messages();
 
         let mut tool_definitions = Vec::new();
         for tool in &tools {
             tool_definitions.push(tool.definition("".to_string()).await);
         }
+        trace!(
+            conversation_messages = request_messages.conversation.len(),
+            tool_definitions = tool_definitions.len(),
+            "prepared completion request inputs"
+        );
 
         // Build the completion request manually
         let mut chat_history = request_messages.conversation;
@@ -348,6 +456,12 @@ impl LM {
             })?
             .completion(request)
             .await?;
+        debug!(
+            prompt_tokens = response.usage.input_tokens,
+            completion_tokens = response.usage.output_tokens,
+            total_tokens = response.usage.total_tokens,
+            "lm completion received"
+        );
 
         let mut accumulated_usage = LmUsage::from(response.usage);
 
@@ -360,6 +474,7 @@ impl LM {
             }
             AssistantContent::ToolCall(tool_call) if !tools.is_empty() => {
                 // Only execute tool loop if we have tools available
+                debug!(tool = %tool_call.function.name, "entering tool loop");
                 let result = self
                     .execute_tool_loop(
                         &tool_call,
@@ -369,14 +484,14 @@ impl LM {
                         request_messages.system,
                         &mut accumulated_usage,
                     )
-                    .await
-                    .unwrap();
+                    .await?;
                 let message = result.message.clone();
                 tool_loop_result = Some(result);
                 message
             }
             AssistantContent::ToolCall(tool_call) => {
                 // No tools available, just return a message indicating this
+                warn!(tool = %tool_call.function.name, "tool requested but no tools available");
                 let msg = format!(
                     "Tool call requested: {} with args: {}, but no tools available",
                     tool_call.function.name, tool_call.function.arguments
@@ -388,6 +503,18 @@ impl LM {
 
         let mut full_chat = messages.clone();
         full_chat.push_message(first_choice.clone());
+        debug!(
+            tool_calls = tool_loop_result
+                .as_ref()
+                .map(|result| result.tool_calls.len())
+                .unwrap_or(0),
+            tool_executions = tool_loop_result
+                .as_ref()
+                .map(|result| result.tool_executions.len())
+                .unwrap_or(0),
+            total_tokens = accumulated_usage.total_tokens,
+            "lm call completed"
+        );
 
         Ok(LMResponse {
             output: first_choice,
@@ -406,6 +533,12 @@ impl LM {
     /// Returns the `n` most recent cached calls.
     ///
     /// Panics if caching is disabled for this `LM`.
+    #[tracing::instrument(
+        name = "dsrs.lm.inspect_history",
+        level = "trace",
+        skip(self),
+        fields(n)
+    )]
     pub async fn inspect_history(&self, n: usize) -> Vec<CacheEntry> {
         self.cache_handler
             .as_ref()
@@ -452,6 +585,16 @@ impl DummyLM {
     ///
     /// The provided `prediction` becomes the assistant output and is inserted
     /// into the shared cache when caching is enabled.
+    #[tracing::instrument(
+        name = "dsrs.lm.dummy_call",
+        level = "debug",
+        skip(self, example, messages, prediction),
+        fields(
+            cache_enabled = self.cache,
+            cache_handler_present = self.cache_handler.is_some(),
+            message_count = messages.len()
+        )
+    )]
     pub async fn call(
         &self,
         example: Example,
@@ -471,9 +614,13 @@ impl DummyLM {
             let example_clone = example.clone();
 
             // Spawn the cache insert operation to avoid deadlock
-            tokio::spawn(async move {
-                let _ = cache_clone.lock().await.insert(example_clone, rx).await;
-            });
+            tokio::spawn(
+                async move {
+                    let _ = cache_clone.lock().await.insert(example_clone, rx).await;
+                }
+                .instrument(tracing::Span::current()),
+            );
+            debug!("spawned async cache insert");
 
             // Send the result to the cache
             tx.send(CacheEntry {
@@ -485,6 +632,7 @@ impl DummyLM {
             })
             .await
             .map_err(|_| anyhow::anyhow!("Failed to send to cache"))?;
+            trace!("sent dummy response to cache task");
         }
 
         Ok(LMResponse {
@@ -499,6 +647,12 @@ impl DummyLM {
     }
 
     /// Returns cached entries just like [`LM::inspect_history`].
+    #[tracing::instrument(
+        name = "dsrs.lm.dummy.inspect_history",
+        level = "trace",
+        skip(self),
+        fields(n)
+    )]
     pub async fn inspect_history(&self, n: usize) -> Vec<CacheEntry> {
         self.cache_handler
             .as_ref()

--- a/crates/dspy-rs/src/evaluate/evaluator.rs
+++ b/crates/dspy-rs/src/evaluate/evaluator.rs
@@ -1,6 +1,7 @@
 use crate::core::Module;
 use crate::data::{example::Example, prediction::Prediction};
 use futures::stream::{self, StreamExt};
+use tracing::{debug, warn};
 
 #[allow(async_fn_in_trait)]
 pub trait Evaluator: Module {
@@ -9,28 +10,50 @@ pub trait Evaluator: Module {
 
     async fn metric(&self, example: &Example, prediction: &Prediction) -> f32;
 
+    #[tracing::instrument(
+        name = "dsrs.evaluate",
+        level = "debug",
+        skip(self, examples),
+        fields(
+            examples = examples.len(),
+            max_concurrency = Self::MAX_CONCURRENCY,
+            display_progress = Self::DISPLAY_PROGRESS
+        )
+    )]
     async fn evaluate(&self, examples: Vec<Example>) -> f32 {
-        let predictions = self
+        let predictions = match self
             .batch(
                 examples.clone(),
                 Self::MAX_CONCURRENCY,
                 Self::DISPLAY_PROGRESS,
             )
             .await
-            .unwrap();
+        {
+            Ok(predictions) => predictions,
+            Err(err) => {
+                warn!(error = %err, "evaluation failed while generating predictions");
+                panic!("evaluation failed: {err}");
+            }
+        };
 
         let total = examples.len();
 
         // Pair examples with predictions and evaluate with controlled concurrency
         let metrics: Vec<f32> = stream::iter(examples.iter().zip(predictions.iter()).enumerate())
-            .map(|(_, (example, prediction))| {
+            .map(|(idx, (example, prediction))| {
                 let prediction = prediction.clone();
-                async move { self.metric(example, &prediction).await }
+                async move {
+                    let score = self.metric(example, &prediction).await;
+                    debug!(idx, score, "evaluation metric computed");
+                    score
+                }
             })
             .buffer_unordered(Self::MAX_CONCURRENCY)
             .collect()
             .await;
 
-        metrics.iter().sum::<f32>() / total as f32
+        let average_score = metrics.iter().sum::<f32>() / total as f32;
+        debug!(average_score, "evaluation complete");
+        average_score
     }
 }

--- a/crates/dspy-rs/src/trace/context.rs
+++ b/crates/dspy-rs/src/trace/context.rs
@@ -2,17 +2,20 @@ use crate::Prediction;
 use crate::trace::dag::{Graph, NodeType};
 use std::sync::{Arc, Mutex};
 use tokio::task_local;
+use tracing::{debug, trace};
 
 task_local! {
     static CURRENT_TRACE: Arc<Mutex<Graph>>;
 }
 
+#[tracing::instrument(name = "dsrs.trace.scope", level = "debug", skip(f))]
 pub async fn trace<F, Fut, R>(f: F) -> (R, Graph)
 where
     F: FnOnce() -> Fut,
     Fut: std::future::Future<Output = R>,
 {
     let graph = Arc::new(Mutex::new(Graph::new()));
+    debug!("trace scope started");
     let result = CURRENT_TRACE.scope(graph.clone(), f()).await;
 
     // We need to unwrap the graph.
@@ -24,6 +27,7 @@ where
         Ok(mutex) => mutex.into_inner().unwrap(),
         Err(arc) => arc.lock().unwrap().clone(), // Fallback: clone if still shared
     };
+    debug!(node_count = graph.nodes.len(), "trace scope completed");
 
     (result, graph)
 }
@@ -37,10 +41,20 @@ pub fn record_node(
     inputs: Vec<usize>,
     input_data: Option<crate::Example>,
 ) -> Option<usize> {
+    let input_count = inputs.len();
+    let has_input_data = input_data.is_some();
     CURRENT_TRACE
         .try_with(|trace| {
             let mut graph = trace.lock().unwrap();
-            Some(graph.add_node(node_type, inputs, input_data))
+            let node_id = graph.add_node(node_type.clone(), inputs, input_data);
+            trace!(
+                node_id,
+                ?node_type,
+                input_count,
+                has_input_data,
+                "trace node recorded"
+            );
+            Some(node_id)
         })
         .unwrap_or(None)
 }
@@ -49,5 +63,6 @@ pub fn record_output(node_id: usize, output: Prediction) {
     let _ = CURRENT_TRACE.try_with(|trace| {
         let mut graph = trace.lock().unwrap();
         graph.set_output(node_id, output);
+        trace!(node_id, "trace output recorded");
     });
 }

--- a/crates/dspy-rs/src/utils/mod.rs
+++ b/crates/dspy-rs/src/utils/mod.rs
@@ -1,5 +1,7 @@
 pub mod cache;
 pub mod serde_utils;
+pub mod telemetry;
 
 pub use cache::{Cache, CacheEntry, ResponseCache};
 pub use serde_utils::get_iter_from_value;
+pub use telemetry::{TelemetryInitError, init_tracing, truncate};

--- a/crates/dspy-rs/src/utils/telemetry.rs
+++ b/crates/dspy-rs/src/utils/telemetry.rs
@@ -1,0 +1,69 @@
+use std::sync::OnceLock;
+use thiserror::Error;
+use tracing_subscriber::EnvFilter;
+
+const DEFAULT_PRETTY_FILTER: &str = "dspy_rs=debug";
+static TRACING_INITIALIZED: OnceLock<()> = OnceLock::new();
+
+#[derive(Debug, Error)]
+pub enum TelemetryInitError {
+    #[error("invalid tracing filter directive `{directive}`: {source}")]
+    InvalidFilter {
+        directive: String,
+        source: tracing_subscriber::filter::ParseError,
+    },
+    #[error("failed to install tracing subscriber: {0}")]
+    SetGlobalDefault(#[from] tracing::subscriber::SetGlobalDefaultError),
+}
+
+/// Installs process-global, pretty tracing output for DSRs.
+///
+/// Behavior:
+/// - Uses `RUST_LOG` when present.
+/// - Falls back to `dspy_rs=debug` when `RUST_LOG` is unset/invalid.
+/// - Is idempotent: repeated calls are no-ops after first successful init.
+pub fn init_tracing() -> Result<(), TelemetryInitError> {
+    if TRACING_INITIALIZED.get().is_some() {
+        return Ok(());
+    }
+
+    let filter = resolve_filter()?;
+    let subscriber = tracing_subscriber::fmt()
+        .pretty()
+        .with_env_filter(filter)
+        .with_target(false)
+        .with_thread_ids(false)
+        .with_thread_names(false)
+        .with_file(false)
+        .with_line_number(false)
+        .finish();
+
+    tracing::subscriber::set_global_default(subscriber)?;
+    let _ = TRACING_INITIALIZED.set(());
+    Ok(())
+}
+
+fn resolve_filter() -> Result<EnvFilter, TelemetryInitError> {
+    match EnvFilter::try_from_default_env() {
+        Ok(filter) => Ok(filter),
+        Err(_) => EnvFilter::try_new(DEFAULT_PRETTY_FILTER).map_err(|source| {
+            TelemetryInitError::InvalidFilter {
+                directive: DEFAULT_PRETTY_FILTER.to_string(),
+                source,
+            }
+        }),
+    }
+}
+
+pub fn truncate(value: &str, max_chars: usize) -> &str {
+    if value.chars().count() <= max_chars {
+        value
+    } else {
+        let cutoff = value
+            .char_indices()
+            .nth(max_chars)
+            .map(|(idx, _)| idx)
+            .unwrap_or(value.len());
+        &value[..cutoff]
+    }
+}

--- a/docs/docs/building-blocks/lm.mdx
+++ b/docs/docs/building-blocks/lm.mdx
@@ -48,10 +48,12 @@ The `LM::builder()` must be awaited with `.build().await` because client initial
 ### Basic usage
 
 ```rust
-use dspy_rs::LM;
+use dspy_rs::{init_tracing, LM};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    init_tracing()?;
+
     // OpenAI - API key automatically read from OPENAI_API_KEY env var
     let lm = LM::builder()
         .model("gpt-4o-mini".to_string())
@@ -116,8 +118,12 @@ You can browse the full `LM` module reference on [docs.rs](https://docs.rs/dspy-
   <Tab title="Async (Tokio)">
 
 ```rust
+use dspy_rs::{init_tracing, LM};
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    init_tracing()?;
+
     let lm = LM::builder()
         .model("gpt-4o-mini".to_string())
         .build()
@@ -131,6 +137,8 @@ async fn main() -> anyhow::Result<()> {
 
 ```rust
 fn main() -> anyhow::Result<()> {
+    dspy_rs::init_tracing()?;
+
     let rt = tokio::runtime::Runtime::new()?;
     rt.block_on(async move {
         let lm = LM::builder()

--- a/docs/docs/getting-started/quickstart.mdx
+++ b/docs/docs/getting-started/quickstart.mdx
@@ -7,6 +7,7 @@ icon: "rocket"
 DSRs lets you call language models with typed Rust structs. Define your inputs and outputs as a struct, and the library handles prompt formatting and response parsing.
 
 This guide walks you through building your first typed LM pipeline.
+Call `init_tracing()` once at startup in your app examples.
 
 <Steps>
 <Step title="Install DSRs">
@@ -33,10 +34,12 @@ cargo add dspy-rs tokio anyhow
 Tell DSRs which model to use. This sets a global default that all predictors will use:
 
 ```rust
-use dspy_rs::{configure, ChatAdapter, LM};
+use dspy_rs::{configure, init_tracing, ChatAdapter, LM};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    init_tracing()?;
+
     configure(
         LM::builder()
             .model("openai:gpt-4o-mini".to_string())
@@ -106,7 +109,7 @@ The `#[derive(Signature)]` macro generates `QAInput` from your `#[input]` fields
 ## Complete example
 
 ```rust
-use dspy_rs::{configure, ChatAdapter, LM, Predict, Signature};
+use dspy_rs::{configure, init_tracing, ChatAdapter, LM, Predict, Signature};
 
 /// Answer questions accurately and concisely.
 #[derive(Signature, Clone, Debug)]
@@ -120,6 +123,8 @@ struct QA {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    init_tracing()?;
+
     configure(
         LM::builder()
             .model("openai:gpt-4o-mini".to_string())

--- a/docs/docs/optimizers/copro.mdx
+++ b/docs/docs/optimizers/copro.mdx
@@ -29,7 +29,7 @@ let copro = COPRO::builder()
 ## Usage Example
 
 ```rust
-use dspy_rs::{COPRO, Optimizer};
+use dspy_rs::{COPRO, Optimizer, init_tracing};
 
 #[derive(Builder, Optimizable)]
 struct MyModule {
@@ -56,6 +56,8 @@ impl Evaluator for MyModule {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    init_tracing()?;
+
     // API key automatically read from OPENAI_API_KEY env var
     configure(
         LM::builder()


### PR DESCRIPTION
## Summary
- add tracing instrumentation spans/events across the dspy runtime hot paths:
  - `core/lm` (build/init/call/tool loop)
  - `core/lm/client_registry`
  - `predictors` (typed + legacy)
  - `adapter/chat` (format/call/typed+legacy parse)
  - `utils/cache`
  - batch/evaluate paths (`core/module`, `predictors/mod`, `evaluate/evaluator`)
  - data loading paths (`data/dataloader`)
  - trace context lifecycle (`trace/context`)
- perform a full tracing cleanup to reduce long-term boilerplate/LOC:
  - convert boundary instrumentation to idiomatic `#[tracing::instrument(...)]`
  - remove manual span-wrapper patterns (`let span ... async move ... .instrument(span)`)
  - keep only intentional manual propagation on spawned tasks (`.instrument(Span::current())`)
- keep explicit inner-loop `debug!`/`trace!` events for high-signal behavior:
  - tool-loop iteration/execution details
  - typed/legacy parse diagnostics, checks/assert summaries
- keep parse failures as hard failures in legacy adapter parsing:
  - invalid JSON for non-string outputs fails
  - missing required output fields fails
- restore visible `verbose=true` progress output in `DataLoader::load_hf` while also emitting tracing events
- harden tool execution error handling in `LM` tool loop by returning errors instead of panicking
- add regression tests for legacy parse hard-failure behavior

## Follow-ups
- preexisting tool-loop iteration edge case tracked in [#61](https://github.com/krypticmouse/DSRs/issues/61)

## Testing
- `cargo fmt`
- `cargo test -p dspy-rs`
- `cargo check -p dspy-rs --examples`
