### PR TITLE
[codex] add input field render facet with jinja templates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1190,6 +1190,7 @@ dependencies = [
  "hf-hub",
  "indexmap",
  "kdam",
+ "minijinja",
  "parquet",
  "rand 0.8.5",
  "rayon",
@@ -1212,6 +1213,7 @@ name = "dsrs_macros"
 version = "0.7.2"
 dependencies = [
  "dspy-rs",
+ "minijinja",
  "proc-macro-crate",
  "proc-macro2",
  "quote",

--- a/crates/bamltype/tests/ui/non_string_literal_attr.stderr
+++ b/crates/bamltype/tests/ui/non_string_literal_attr.stderr
@@ -2,4 +2,4 @@ error: expected string literal; hint: wrap the value in quotes
  --> tests/ui/non_string_literal_attr.rs:4:8
   |
 4 | #[baml(name = 123)]
-  |        ^^^^
+  |        ^^^^^^^^^^

--- a/crates/dspy-rs/Cargo.toml
+++ b/crates/dspy-rs/Cargo.toml
@@ -43,6 +43,7 @@ rig-core = { git = "https://github.com/0xPlaygrounds/rig", rev="e7849df" }
 enum_dispatch = "0.3.13"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter", "fmt"] }
+minijinja = { git = "https://github.com/boundaryml/minijinja.git", branch = "main", default-features = false, features = ["builtins", "serde"] }
 
 [package.metadata.cargo-machete]
 ignored = ["rig-core"]

--- a/crates/dspy-rs/src/core/signature.rs
+++ b/crates/dspy-rs/src/core/signature.rs
@@ -2,6 +2,13 @@ use crate::{Example, OutputFormatContent, TypeIR};
 use anyhow::Result;
 use serde_json::Value;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InputRenderSpec {
+    Default,
+    Format(&'static str),
+    Jinja(&'static str),
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct FieldSpec {
     pub name: &'static str,
@@ -9,7 +16,7 @@ pub struct FieldSpec {
     pub description: &'static str,
     pub type_ir: fn() -> TypeIR,
     pub constraints: &'static [ConstraintSpec],
-    pub format: Option<&'static str>,
+    pub input_render: InputRenderSpec,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/dspy-rs/src/predictors/predict.rs
+++ b/crates/dspy-rs/src/predictors/predict.rs
@@ -10,7 +10,7 @@ use tracing::{debug, trace};
 use crate::adapter::Adapter;
 use crate::bamltype::baml_types::BamlMap;
 use crate::bamltype::compat::{BamlValueConvert, ToBamlValue};
-use crate::core::{FieldSpec, MetaSignature, Module, Optimizable, Signature};
+use crate::core::{FieldSpec, InputRenderSpec, MetaSignature, Module, Optimizable, Signature};
 use crate::{
     BamlValue, CallResult, Chat, ChatAdapter, Example, GLOBAL_SETTINGS, LM, LmError, LmUsage,
     PredictError, Prediction,
@@ -258,8 +258,14 @@ fn field_specs_to_value(fields: &[FieldSpec], field_type: &'static str) -> Value
         meta.insert("desc".to_string(), json!(field.description));
         meta.insert("schema".to_string(), json!(""));
         meta.insert("__dsrs_field_type".to_string(), json!(field_type));
-        if let Some(format) = field.format {
-            meta.insert("format".to_string(), json!(format));
+        match field.input_render {
+            InputRenderSpec::Default => {}
+            InputRenderSpec::Format(format) => {
+                meta.insert("format".to_string(), json!(format));
+            }
+            InputRenderSpec::Jinja(template) => {
+                meta.insert("render".to_string(), json!({ "jinja": template }));
+            }
         }
         result.insert(field.rust_name.to_string(), Value::Object(meta));
     }

--- a/crates/dsrs-macros/Cargo.toml
+++ b/crates/dsrs-macros/Cargo.toml
@@ -19,6 +19,7 @@ quote = "1"
 proc-macro2 = "1"
 proc-macro-crate = "3.2"
 serde_json = { version = "1.0.143", features = ["preserve_order"] }
+minijinja = { git = "https://github.com/boundaryml/minijinja.git", branch = "main", default-features = false, features = ["serde"] }
 
 [dev-dependencies]
 dspy-rs = { path = "../dspy-rs" }

--- a/crates/dsrs-macros/tests/ui/alias_conflict.rs
+++ b/crates/dsrs-macros/tests/ui/alias_conflict.rs
@@ -1,0 +1,16 @@
+use dsrs_macros::Signature;
+
+#[derive(Signature)]
+struct AliasConflict {
+    #[input]
+    first: String,
+
+    #[input]
+    #[alias("first")]
+    second: String,
+
+    #[output]
+    answer: String,
+}
+
+fn main() {}

--- a/crates/dsrs-macros/tests/ui/alias_conflict.stderr
+++ b/crates/dsrs-macros/tests/ui/alias_conflict.stderr
@@ -1,0 +1,7 @@
+error: duplicate input field name `first` after aliasing; conflicts between `first` and `second`
+ --> tests/ui/alias_conflict.rs:3:10
+  |
+3 | #[derive(Signature)]
+  |          ^^^^^^^^^
+  |
+  = note: this error originates in the derive macro `Signature` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/dsrs-macros/tests/ui/format_render_conflict.rs
+++ b/crates/dsrs-macros/tests/ui/format_render_conflict.rs
@@ -1,0 +1,14 @@
+use dsrs_macros::Signature;
+
+#[derive(Signature)]
+struct FormatRenderConflict {
+    #[input]
+    #[format("json")]
+    #[render(jinja = "{{ this }}")]
+    context: String,
+
+    #[output]
+    answer: String,
+}
+
+fn main() {}

--- a/crates/dsrs-macros/tests/ui/format_render_conflict.stderr
+++ b/crates/dsrs-macros/tests/ui/format_render_conflict.stderr
@@ -1,0 +1,8 @@
+error: #[format] and #[render] cannot be combined on the same field
+ --> tests/ui/format_render_conflict.rs:5:5
+  |
+5 | /     #[input]
+6 | |     #[format("json")]
+7 | |     #[render(jinja = "{{ this }}")]
+8 | |     context: String,
+  | |___________________^

--- a/crates/dsrs-macros/tests/ui/render_duplicate.rs
+++ b/crates/dsrs-macros/tests/ui/render_duplicate.rs
@@ -1,0 +1,14 @@
+use dsrs_macros::Signature;
+
+#[derive(Signature)]
+struct RenderDuplicate {
+    #[input]
+    #[render(jinja = "{{ this }}")]
+    #[render(jinja = "{{ this }}")]
+    context: String,
+
+    #[output]
+    answer: String,
+}
+
+fn main() {}

--- a/crates/dsrs-macros/tests/ui/render_duplicate.stderr
+++ b/crates/dsrs-macros/tests/ui/render_duplicate.stderr
@@ -1,0 +1,5 @@
+error: #[render] can only be specified once per field
+ --> tests/ui/render_duplicate.rs:7:5
+  |
+7 |     #[render(jinja = "{{ this }}")]
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/dsrs-macros/tests/ui/render_invalid_jinja.rs
+++ b/crates/dsrs-macros/tests/ui/render_invalid_jinja.rs
@@ -1,0 +1,13 @@
+use dsrs_macros::Signature;
+
+#[derive(Signature)]
+struct RenderInvalidJinja {
+    #[input]
+    #[render(jinja = "{{ this ")]
+    context: String,
+
+    #[output]
+    answer: String,
+}
+
+fn main() {}

--- a/crates/dsrs-macros/tests/ui/render_invalid_jinja.stderr
+++ b/crates/dsrs-macros/tests/ui/render_invalid_jinja.stderr
@@ -1,0 +1,5 @@
+error: invalid Jinja syntax in #[render(jinja = "...")]
+ --> tests/ui/render_invalid_jinja.rs:6:5
+  |
+6 |     #[render(jinja = "{{ this ")]
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/dsrs-macros/tests/ui/render_invalid_key.rs
+++ b/crates/dsrs-macros/tests/ui/render_invalid_key.rs
@@ -1,0 +1,13 @@
+use dsrs_macros::Signature;
+
+#[derive(Signature)]
+struct RenderInvalidKey {
+    #[input]
+    #[render(template = "{{ this }}")]
+    context: String,
+
+    #[output]
+    answer: String,
+}
+
+fn main() {}

--- a/crates/dsrs-macros/tests/ui/render_invalid_key.stderr
+++ b/crates/dsrs-macros/tests/ui/render_invalid_key.stderr
@@ -1,0 +1,5 @@
+error: expected #[render(jinja = "...")]
+ --> tests/ui/render_invalid_key.rs:6:5
+  |
+6 |     #[render(template = "{{ this }}")]
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/dsrs-macros/tests/ui/render_non_literal.rs
+++ b/crates/dsrs-macros/tests/ui/render_non_literal.rs
@@ -1,0 +1,15 @@
+use dsrs_macros::Signature;
+
+const TEMPLATE: &str = "{{ this }}";
+
+#[derive(Signature)]
+struct RenderNonLiteral {
+    #[input]
+    #[render(jinja = TEMPLATE)]
+    context: String,
+
+    #[output]
+    answer: String,
+}
+
+fn main() {}

--- a/crates/dsrs-macros/tests/ui/render_non_literal.stderr
+++ b/crates/dsrs-macros/tests/ui/render_non_literal.stderr
@@ -1,0 +1,5 @@
+error: expected string literal; hint: wrap the value in quotes
+ --> tests/ui/render_non_literal.rs:8:14
+  |
+8 |     #[render(jinja = TEMPLATE)]
+  |              ^^^^^^^^^^^^^^^^

--- a/crates/dsrs-macros/tests/ui/render_on_output.rs
+++ b/crates/dsrs-macros/tests/ui/render_on_output.rs
@@ -1,0 +1,13 @@
+use dsrs_macros::Signature;
+
+#[derive(Signature)]
+struct RenderOnOutput {
+    #[input]
+    question: String,
+
+    #[output]
+    #[render(jinja = "{{ this }}")]
+    answer: String,
+}
+
+fn main() {}

--- a/crates/dsrs-macros/tests/ui/render_on_output.stderr
+++ b/crates/dsrs-macros/tests/ui/render_on_output.stderr
@@ -1,0 +1,7 @@
+error: #[render] is only supported on #[input] fields
+  --> tests/ui/render_on_output.rs:8:5
+   |
+ 8 | /     #[output]
+ 9 | |     #[render(jinja = "{{ this }}")]
+10 | |     answer: String,
+   | |__________________^

--- a/docs/docs/building-blocks/adapter.mdx
+++ b/docs/docs/building-blocks/adapter.mdx
@@ -148,7 +148,7 @@ This is useful for understanding what the LM sees.
 
 ## Input formatting options
 
-The `#[format]` attribute on input fields controls serialization:
+Input fields support two rendering paths:
 
 ```rust
 #[derive(Signature, Clone, Debug)]
@@ -160,12 +160,27 @@ struct Search {
     #[format("yaml")]
     filters: Vec<Filter>,  // serialized as YAML
 
+    #[input]
+    #[render(jinja = "{{ this.text }}\nQuestion: {{ input.query }}")]
+    context: Context,  // custom Jinja rendering
+
     #[output]
     results: Vec<Result>,
 }
 ```
 
-Options: `"json"` (default for complex types), `"yaml"`, `"toon"`
+- `#[format("json" | "yaml" | "toon")]`: serialize a field using that format.
+- `#[render(jinja = "...")]`: render a field with a MiniJinja template.
+- `#[format]` and `#[render]` are mutually exclusive on the same field.
+
+`#[render]` context in `ChatAdapter`:
+- `this`: current field value
+- `input`: full input object (rust names and aliases)
+- `field`: `{ name, rust_name, type }`
+- `vars`: adapter/surface vars (currently `{}` in `ChatAdapter`)
+
+`ChatAdapter` configures MiniJinja with strict undefined behavior.
+If template rendering fails at runtime (for example, missing variables), the field renders as `<error>` so prompt construction still completes.
 
 ## Real example: Insurance claim extraction
 

--- a/docs/docs/building-blocks/signature.mdx
+++ b/docs/docs/building-blocks/signature.mdx
@@ -172,6 +172,28 @@ context: Vec<Document>,
 
 Options: `"json"`, `"yaml"`, `"toon"`
 
+### `#[render]` - Custom input rendering (Jinja)
+
+```rust
+#[input]
+#[render(jinja = "{{ this.title }}\n{{ this.body | truncate(300) }}")]
+ticket: Ticket,
+```
+
+Use this when you need custom text rendering for an input field.
+
+- Only valid on `#[input]` fields
+- Template must be a string literal
+- Jinja syntax is validated at compile time
+- Cannot be combined with `#[format]` on the same field
+- Runtime uses strict undefined behavior; missing variables render as `<error>`
+
+Template context:
+- `this` - Current field value as JSON-like data
+- `input` - Full input object (available via rust field names and aliases)
+- `field` - Metadata object with `name`, `rust_name`, and `type`
+- `vars` - Adapter/surface variables (currently empty in `ChatAdapter`)
+
 ### `#[check]` - Soft constraint
 
 ```rust

--- a/docs/docs/getting-started/quickstart.mdx
+++ b/docs/docs/getting-started/quickstart.mdx
@@ -222,6 +222,11 @@ struct Rating {
 }
 ```
 
+### Input formatting and rendering
+
+Use `#[format("json" | "yaml" | "toon")]` for serialization, or `#[render(jinja = "...")]` for custom field text.
+See the full attribute reference in [Signatures](/docs/building-blocks/signature) and runtime behavior in [Adapter](/docs/building-blocks/adapter).
+
 ### Multi-step pipelines
 
 Compose [modules](/docs/building-blocks/module) for complex workflows:


### PR DESCRIPTION
## Summary
This PR adds first-class input-field rendering facets for typed signatures, including custom Jinja templates, while preserving the existing `#[format("json"|"yaml"|"toon")]` path.

## Problem
Input rendering previously relied on a stringly `FieldSpec.format` and only supported a fixed format list. There was no explicit way to define per-input Jinja rendering templates from the signature macro.

That made custom prompt shaping hard, and it also made validation/error reporting less precise for invalid render declarations.

## Root Cause
The signature metadata and derive macro only modeled input formatting as `Option<&'static str>`, and the typed chat renderer only consumed that format string.

There was no first-class render spec enum, no macro grammar for Jinja templates, and no compile-time Jinja syntax validation.

## What Changed
1. Added `InputRenderSpec` to signature metadata with `Default`, `Format(&'static str)`, and `Jinja(&'static str)`.
2. Extended `#[derive(Signature)]` with `#[render(jinja = "...")]` for `#[input]` fields.
3. Added compile-time Jinja syntax validation in macro expansion.
4. Centralized typed input rendering in `ChatAdapter` and added strict-undefined Jinja runtime context:
   - `this`
   - `input`
   - `field` (`name`, `rust_name`, `type`)
   - `vars`
5. Preserved backward compatibility for existing `#[format(...)]` input behavior.
6. Added duplicate post-alias field-name validation to reject ambiguous input/output field names at compile time.
7. Updated metadata projection to expose Jinja render metadata in typed->legacy conversion paths.

## Behavior Notes
- Default non-string typed rendering continues to use `OutputFormatContent`-aware JSON rendering.
- Jinja `input` context includes both rust names and alias names at top level for input fields.

## Validation
Ran:
- `cargo fmt --all`
- `cargo test -p dsrs_macros`
- `cargo test -p dspy-rs --test test_input_format`
- `cargo test -p dspy-rs --test test_adapters`

Also ran adversarial review passes and fixed the findings before opening this PR.
