### PR TITLE
[codex] Facet runtime API cleanup and adapter boundary hardening

### DIFF
--- a/crates/bamltype-derive/src/lib.rs
+++ b/crates/bamltype-derive/src/lib.rs
@@ -724,12 +724,12 @@ fn normalize_field_attrs(
     if let Some(adapter) = compat.with_adapter {
         let with_expr = quote! {
             &#runtime_crate::facet_ext::WithAdapterFns {
-                type_ir: || <#adapter as #runtime_crate::compat::BamlAdapter<#field_ty>>::type_ir(),
-                register: |reg| <#adapter as #runtime_crate::compat::BamlAdapter<#field_ty>>::register(reg),
+                type_ir: || <#adapter as #runtime_crate::adapters::FieldCodec<#field_ty>>::type_ir(),
+                register: |reg| <#adapter as #runtime_crate::adapters::FieldCodec<#field_ty>>::register(reg),
                 apply: |partial, value, path| {
-                    let converted = <#adapter as #runtime_crate::compat::BamlAdapter<#field_ty>>::try_from_baml(value, path)?;
+                    let converted = <#adapter as #runtime_crate::adapters::FieldCodec<#field_ty>>::try_from_baml(value, path)?;
                     partial.set(converted).map_err(|err| {
-                        #runtime_crate::compat::BamlConvertError::new(
+                        #runtime_crate::BamlConvertError::new(
                             ::std::vec::Vec::new(),
                             "compatible type",
                             err.to_string(),

--- a/crates/bamltype/src/adapters.rs
+++ b/crates/bamltype/src/adapters.rs
@@ -1,0 +1,15 @@
+//! Adapter extension points for advanced field-level conversions.
+
+use baml_types::{BamlValue, TypeIR};
+
+use crate::BamlConvertError;
+
+/// Registry type used by field codecs to register custom schema artifacts.
+pub type AdapterSchemaRegistry = crate::schema_registry::SchemaRegistry;
+
+/// Field-level conversion + schema representation hook.
+pub trait FieldCodec<T> {
+    fn type_ir() -> TypeIR;
+    fn register(_reg: &mut AdapterSchemaRegistry) {}
+    fn try_from_baml(value: BamlValue, path: Vec<String>) -> Result<T, BamlConvertError>;
+}

--- a/crates/bamltype/src/convert.rs
+++ b/crates/bamltype/src/convert.rs
@@ -10,7 +10,7 @@ use facet_reflect::{HasFields, HeapValue, Partial, Peek, ReflectError, ScalarTyp
 use indexmap::IndexMap;
 
 use crate::BamlValueWithFlags;
-use crate::compat::BamlConvertError;
+use crate::runtime::BamlConvertError;
 use crate::schema_builder::internal_name_for_shape;
 
 /// Error during BamlValue conversion.

--- a/crates/bamltype/src/facet_ext.rs
+++ b/crates/bamltype/src/facet_ext.rs
@@ -2,7 +2,8 @@
 
 use baml_types::{BamlValue, TypeIR};
 
-use crate::compat::{BamlConvertError, Registry};
+use crate::adapters::AdapterSchemaRegistry;
+use crate::runtime::BamlConvertError;
 
 /// Field-level adapter application function.
 pub type AdapterApplyFn = fn(
@@ -18,7 +19,7 @@ pub struct WithAdapterFns {
     /// Schema type representation callback.
     pub type_ir: fn() -> TypeIR,
     /// Schema registration callback.
-    pub register: fn(&mut Registry),
+    pub register: fn(&mut AdapterSchemaRegistry),
     /// Value conversion callback.
     pub apply: AdapterApplyFn,
 }

--- a/crates/bamltype/src/lib.rs
+++ b/crates/bamltype/src/lib.rs
@@ -55,12 +55,16 @@ pub use schema_builder::*;
 mod convert;
 pub use convert::{ConvertError, from_baml_value, from_baml_value_with_flags, to_baml_value};
 
-pub mod compat;
-pub mod facet_ext;
-pub use compat::{
-    BamlAdapter, BamlConvertError, BamlTypeInternal, BamlTypeTrait, BamlValueConvert, Registry,
-    ToBamlValue, default_streaming_behavior, get_field, with_constraints,
+mod runtime;
+pub use runtime::{
+    BamlConvertError, BamlTypeInternal, BamlTypeTrait, BamlValueConvert, ToBamlValue,
+    default_streaming_behavior, get_field,
 };
+
+pub mod adapters;
+mod schema_registry;
+
+pub mod facet_ext;
 
 /// A bundle containing everything needed to render schemas and parse LLM output.
 #[derive(Debug, Clone)]
@@ -91,10 +95,7 @@ pub trait BamlSchema: for<'a> facet::Facet<'a> {
     fn baml_schema() -> &'static SchemaBundle;
 }
 
-/// Back-compat trait mirroring legacy bridge's `BamlType`.
-///
-/// This sits alongside the `#[BamlType]` attribute macro and offers the same
-/// runtime trait entry points users expect from the old API.
+/// Runtime trait for types that expose BAML schema + conversion entry points.
 pub trait BamlType: BamlTypeInternal + BamlValueConvert + Sized + 'static {
     fn baml_output_format() -> &'static OutputFormatContent;
 

--- a/crates/bamltype/src/runtime.rs
+++ b/crates/bamltype/src/runtime.rs
@@ -1,0 +1,164 @@
+//! Facet runtime traits and conversion helpers.
+
+use baml_types::{BamlMap, BamlValue, TypeIR, type_meta};
+use facet::Facet;
+use internal_baml_jinja::types::OutputFormatContent;
+
+use crate::BamlSchema;
+use crate::convert;
+use crate::schema_builder::build_type_ir_from_shape;
+
+/// Error during BamlValue ↔ Rust conversion.
+#[derive(Debug, Clone)]
+pub struct BamlConvertError {
+    pub path: Vec<String>,
+    pub expected: &'static str,
+    pub got: String,
+    pub message: String,
+}
+
+impl BamlConvertError {
+    pub fn new(
+        path: Vec<String>,
+        expected: &'static str,
+        got: impl Into<String>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            path,
+            expected,
+            got: got.into(),
+            message: message.into(),
+        }
+    }
+
+    pub fn with_path(mut self, segment: impl Into<String>) -> Self {
+        self.path.push(segment.into());
+        self
+    }
+
+    pub fn path_string(&self) -> String {
+        if self.path.is_empty() {
+            "<root>".to_string()
+        } else {
+            self.path.join(".")
+        }
+    }
+}
+
+impl std::fmt::Display for BamlConvertError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{} (expected {}, got {}) at {}",
+            self.message,
+            self.expected,
+            self.got,
+            self.path_string()
+        )
+    }
+}
+
+impl std::error::Error for BamlConvertError {}
+
+impl From<convert::ConvertError> for BamlConvertError {
+    fn from(err: convert::ConvertError) -> Self {
+        match err {
+            convert::ConvertError::Adapter(inner) => inner,
+            other => Self {
+                path: Vec::new(),
+                expected: "compatible type",
+                got: other.to_string(),
+                message: other.to_string(),
+            },
+        }
+    }
+}
+
+/// Internal type metadata.
+pub trait BamlTypeInternal {
+    fn baml_internal_name() -> &'static str;
+    fn baml_type_ir() -> TypeIR;
+}
+
+/// Convert from BamlValue to Rust.
+pub trait BamlValueConvert: Sized {
+    fn try_from_baml_value(value: BamlValue, path: Vec<String>) -> Result<Self, BamlConvertError>;
+}
+
+/// Convert from Rust to BamlValue.
+pub trait ToBamlValue {
+    fn to_baml_value(&self) -> BamlValue;
+}
+
+/// Runtime trait used by schema rendering and parsing.
+///
+/// Named `BamlTypeTrait` to avoid collision with the `#[BamlType]` attribute macro.
+pub trait BamlTypeTrait: BamlTypeInternal + BamlValueConvert + Sized + 'static {
+    fn baml_output_format() -> &'static OutputFormatContent;
+
+    fn baml_internal_name() -> &'static str {
+        <Self as BamlTypeInternal>::baml_internal_name()
+    }
+
+    fn baml_type_ir() -> TypeIR {
+        <Self as BamlTypeInternal>::baml_type_ir()
+    }
+}
+
+impl<T: Facet<'static>> BamlTypeInternal for T {
+    fn baml_internal_name() -> &'static str {
+        for attr in T::SHAPE.attributes {
+            if attr.ns != Some("bamltype") || attr.key != "internal_name" {
+                continue;
+            }
+
+            if let Some(name) = attr.get_as::<&'static str>() {
+                return name;
+            }
+        }
+
+        if let Some(name) = T::SHAPE.get_builtin_attr_value::<&'static str>("internal_name") {
+            name
+        } else {
+            std::any::type_name::<T>()
+        }
+    }
+
+    fn baml_type_ir() -> TypeIR {
+        build_type_ir_from_shape(T::SHAPE)
+    }
+}
+
+impl<T: Facet<'static>> BamlValueConvert for T {
+    fn try_from_baml_value(value: BamlValue, _path: Vec<String>) -> Result<Self, BamlConvertError> {
+        convert::from_baml_value(value).map_err(BamlConvertError::from)
+    }
+}
+
+impl<T: Facet<'static>> ToBamlValue for T {
+    fn to_baml_value(&self) -> BamlValue {
+        convert::to_baml_value(self).unwrap_or(BamlValue::Null)
+    }
+}
+
+impl<T: BamlSchema> BamlTypeTrait for T {
+    fn baml_output_format() -> &'static OutputFormatContent {
+        &T::baml_schema().output_format
+    }
+}
+
+/// Default streaming behavior helper.
+pub fn default_streaming_behavior() -> type_meta::base::StreamingBehavior {
+    type_meta::base::StreamingBehavior::default()
+}
+
+/// Lookup helper matching legacy bridge semantics (`name` then optional alias).
+pub fn get_field<'a>(
+    map: &'a BamlMap<String, BamlValue>,
+    name: &str,
+    alias: Option<&str>,
+) -> Option<&'a BamlValue> {
+    map.get(name)
+        .or_else(|| alias.and_then(|alias| map.get(alias)))
+}

--- a/crates/bamltype/src/schema_builder.rs
+++ b/crates/bamltype/src/schema_builder.rs
@@ -9,8 +9,8 @@ use facet::{Attr, ConstTypeId, Def, Field, Shape, Type, UserType};
 use internal_baml_jinja::types::{Class, Enum, Name, OutputFormatContent};
 
 use crate::SchemaBundle;
-use crate::compat::Registry;
 use crate::facet_ext;
+use crate::schema_registry::SchemaRegistry;
 
 /// Build a SchemaBundle from a facet Shape.
 pub fn build_schema_bundle(shape: &'static Shape) -> SchemaBundle {
@@ -25,7 +25,7 @@ pub fn build_schema_bundle(shape: &'static Shape) -> SchemaBundle {
 
 /// Build a TypeIR from a facet Shape (without building full schema).
 ///
-/// Used by the compat layer to provide `BamlTypeInternal::baml_type_ir()`
+/// Used by runtime trait implementations to provide `BamlTypeInternal::baml_type_ir()`
 /// for any `Facet` type.
 pub fn build_type_ir_from_shape(shape: &'static Shape) -> TypeIR {
     let mut builder = SchemaBuilder::new();
@@ -70,7 +70,7 @@ struct SchemaBuilder {
     visited: HashMap<ConstTypeId, (String, TypeIR)>,
 
     /// Collected schema elements.
-    registry: Registry,
+    registry: SchemaRegistry,
 
     /// Track which internal names are already used (for collision handling)
     used_internal_names: HashMap<String, ConstTypeId>,
@@ -104,7 +104,7 @@ impl SchemaBuilder {
     fn new() -> Self {
         Self {
             visited: HashMap::new(),
-            registry: Registry::new(),
+            registry: SchemaRegistry::new(),
             used_internal_names: HashMap::new(),
             name_counter: 0,
         }

--- a/crates/bamltype/src/schema_registry.rs
+++ b/crates/bamltype/src/schema_registry.rs
@@ -1,86 +1,14 @@
-//! Compatibility layer providing legacy bridge-compatible traits and helpers.
+//! Schema registry for collected BAML classes/enums during shape traversal.
 
 use std::collections::{HashMap, HashSet};
 
-use baml_types::{BamlMap, BamlValue, Constraint, StreamingMode, TypeIR, type_meta};
-use facet::Facet;
+use baml_types::{StreamingMode, TypeIR};
 use indexmap::{IndexMap, IndexSet};
 use internal_baml_jinja::types::{Class, Enum, OutputFormatContent};
 
-use crate::BamlSchema;
-use crate::convert;
-use crate::schema_builder::build_type_ir_from_shape;
-
-/// Error during BamlValue ↔ Rust conversion (legacy bridge compatible).
-#[derive(Debug, Clone)]
-pub struct BamlConvertError {
-    pub path: Vec<String>,
-    pub expected: &'static str,
-    pub got: String,
-    pub message: String,
-}
-
-impl BamlConvertError {
-    pub fn new(
-        path: Vec<String>,
-        expected: &'static str,
-        got: impl Into<String>,
-        message: impl Into<String>,
-    ) -> Self {
-        Self {
-            path,
-            expected,
-            got: got.into(),
-            message: message.into(),
-        }
-    }
-
-    pub fn with_path(mut self, segment: impl Into<String>) -> Self {
-        self.path.push(segment.into());
-        self
-    }
-
-    pub fn path_string(&self) -> String {
-        if self.path.is_empty() {
-            "<root>".to_string()
-        } else {
-            self.path.join(".")
-        }
-    }
-}
-
-impl std::fmt::Display for BamlConvertError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{} (expected {}, got {}) at {}",
-            self.message,
-            self.expected,
-            self.got,
-            self.path_string()
-        )
-    }
-}
-
-impl std::error::Error for BamlConvertError {}
-
-impl From<convert::ConvertError> for BamlConvertError {
-    fn from(err: convert::ConvertError) -> Self {
-        match err {
-            convert::ConvertError::Adapter(inner) => inner,
-            other => Self {
-                path: Vec::new(),
-                expected: "compatible type",
-                got: other.to_string(),
-                message: other.to_string(),
-            },
-        }
-    }
-}
-
-/// Registry for schema elements (legacy bridge compatible).
+/// Registry for schema elements generated from facet shapes.
 #[derive(Debug, Default)]
-pub struct Registry {
+pub struct SchemaRegistry {
     enums: IndexMap<String, Enum>,
     classes: IndexMap<(String, StreamingMode), Class>,
     class_deps: IndexMap<String, IndexSet<String>>,
@@ -88,7 +16,7 @@ pub struct Registry {
     registered: HashSet<String>,
 }
 
-impl Registry {
+impl SchemaRegistry {
     pub fn new() -> Self {
         Self::default()
     }
@@ -147,108 +75,6 @@ impl Registry {
             .structural_recursive_aliases(self.structural_recursive_aliases)
             .build()
     }
-}
-
-/// Internal type metadata (legacy bridge compatible).
-pub trait BamlTypeInternal {
-    fn baml_internal_name() -> &'static str;
-    fn baml_type_ir() -> TypeIR;
-    fn register(_reg: &mut Registry) {}
-}
-
-/// Convert from BamlValue to Rust (legacy bridge compatible).
-pub trait BamlValueConvert: Sized {
-    fn try_from_baml_value(value: BamlValue, path: Vec<String>) -> Result<Self, BamlConvertError>;
-}
-
-/// Convert from Rust to BamlValue (legacy bridge compatible).
-pub trait ToBamlValue {
-    fn to_baml_value(&self) -> BamlValue;
-}
-
-/// Adapter for custom field-level conversion / schema representation.
-pub trait BamlAdapter<T> {
-    fn type_ir() -> TypeIR;
-    fn register(_reg: &mut Registry) {}
-    fn try_from_baml(value: BamlValue, path: Vec<String>) -> Result<T, BamlConvertError>;
-}
-
-/// Full BamlType trait (legacy bridge compatible).
-///
-/// Named `BamlTypeTrait` to avoid collision with the `#[BamlType]` attribute macro.
-pub trait BamlTypeTrait: BamlTypeInternal + BamlValueConvert + Sized + 'static {
-    fn baml_output_format() -> &'static OutputFormatContent;
-
-    fn baml_internal_name() -> &'static str {
-        <Self as BamlTypeInternal>::baml_internal_name()
-    }
-
-    fn baml_type_ir() -> TypeIR {
-        <Self as BamlTypeInternal>::baml_type_ir()
-    }
-}
-
-impl<T: Facet<'static>> BamlTypeInternal for T {
-    fn baml_internal_name() -> &'static str {
-        for attr in T::SHAPE.attributes {
-            if attr.ns != Some("bamltype") || attr.key != "internal_name" {
-                continue;
-            }
-
-            if let Some(name) = attr.get_as::<&'static str>() {
-                return name;
-            }
-        }
-
-        if let Some(name) = T::SHAPE.get_builtin_attr_value::<&'static str>("internal_name") {
-            name
-        } else {
-            std::any::type_name::<T>()
-        }
-    }
-
-    fn baml_type_ir() -> TypeIR {
-        build_type_ir_from_shape(T::SHAPE)
-    }
-}
-
-impl<T: Facet<'static>> BamlValueConvert for T {
-    fn try_from_baml_value(value: BamlValue, _path: Vec<String>) -> Result<Self, BamlConvertError> {
-        convert::from_baml_value(value).map_err(BamlConvertError::from)
-    }
-}
-
-impl<T: Facet<'static>> ToBamlValue for T {
-    fn to_baml_value(&self) -> BamlValue {
-        convert::to_baml_value(self).unwrap_or(BamlValue::Null)
-    }
-}
-
-impl<T: BamlSchema> BamlTypeTrait for T {
-    fn baml_output_format() -> &'static OutputFormatContent {
-        &T::baml_schema().output_format
-    }
-}
-
-/// Add constraints to a TypeIR (legacy bridge compatible).
-pub fn with_constraints(mut type_ir: TypeIR, constraints: Vec<Constraint>) -> TypeIR {
-    type_ir.meta_mut().constraints.extend(constraints);
-    type_ir
-}
-
-/// Default streaming behavior helper (legacy bridge compatible).
-pub fn default_streaming_behavior() -> type_meta::base::StreamingBehavior {
-    type_meta::base::StreamingBehavior::default()
-}
-
-/// Lookup helper matching legacy bridge semantics (`name` then optional alias).
-pub fn get_field<'a>(
-    map: &'a BamlMap<String, BamlValue>,
-    name: &str,
-    alias: Option<&str>,
-) -> Option<&'a BamlValue> {
-    map.get(name)
-        .or_else(|| alias.and_then(|alias| map.get(alias)))
 }
 
 fn collect_class_refs(field_type: &TypeIR, deps: &mut IndexSet<String>) {

--- a/crates/bamltype/tests/contract_frozen_oracle.rs
+++ b/crates/bamltype/tests/contract_frozen_oracle.rs
@@ -222,12 +222,12 @@ enum FacetAsUnionColor {
 
 struct FacetI64ObjectAdapter;
 
-impl facet_runtime::BamlAdapter<i64> for FacetI64ObjectAdapter {
+impl facet_runtime::adapters::FieldCodec<i64> for FacetI64ObjectAdapter {
     fn type_ir() -> TypeIR {
         TypeIR::class("AdapterI64Wrapper")
     }
 
-    fn register(reg: &mut facet_runtime::Registry) {
+    fn register(reg: &mut facet_runtime::adapters::AdapterSchemaRegistry) {
         use facet_runtime::internal_baml_jinja::types::{Class, Name};
 
         if !reg.mark_type("AdapterI64Wrapper") {
@@ -1040,13 +1040,12 @@ where
     T: Clone
         + std::fmt::Debug
         + PartialEq
-        + facet_runtime::compat::ToBamlValue
-        + facet_runtime::compat::BamlValueConvert,
+        + facet_runtime::ToBamlValue
+        + facet_runtime::BamlValueConvert,
 {
-    let baml = facet_runtime::compat::ToBamlValue::to_baml_value(&value);
-    let back =
-        <T as facet_runtime::compat::BamlValueConvert>::try_from_baml_value(baml, Vec::new())
-            .expect("roundtrip");
+    let baml = facet_runtime::ToBamlValue::to_baml_value(&value);
+    let back = <T as facet_runtime::BamlValueConvert>::try_from_baml_value(baml, Vec::new())
+        .expect("roundtrip");
     assert_eq!(back, value);
 }
 
@@ -1102,7 +1101,7 @@ fn contract_default_adapter_error_shape_fixture() {
             .collect(),
     );
 
-    let err = <FacetUnsigned32 as facet_runtime::compat::BamlValueConvert>::try_from_baml_value(
+    let err = <FacetUnsigned32 as facet_runtime::BamlValueConvert>::try_from_baml_value(
         invalid,
         Vec::new(),
     )
@@ -1128,7 +1127,7 @@ fn contract_default_adapter_error_shape_fixture() {
 
 #[test]
 fn contract_direct_integer_string_conversion_error_fixture() {
-    let err = <i64 as facet_runtime::compat::BamlValueConvert>::try_from_baml_value(
+    let err = <i64 as facet_runtime::BamlValueConvert>::try_from_baml_value(
         BamlValue::String("123".into()),
         Vec::new(),
     )
@@ -1162,12 +1161,11 @@ fn contract_direct_map_pairs_conversion_error_fixture() {
     );
     let raw = BamlValue::List(vec![pair_entry]);
 
-    let err =
-        <HashMap<String, i64> as facet_runtime::compat::BamlValueConvert>::try_from_baml_value(
-            raw,
-            Vec::new(),
-        )
-        .expect_err("should reject");
+    let err = <HashMap<String, i64> as facet_runtime::BamlValueConvert>::try_from_baml_value(
+        raw,
+        Vec::new(),
+    )
+    .expect_err("should reject");
 
     let snapshot = serde_json::to_string_pretty(&json!({
         "expected": err.expected,

--- a/crates/bamltype/tests/property_parity.rs
+++ b/crates/bamltype/tests/property_parity.rs
@@ -39,12 +39,12 @@ struct RecursiveNode {
 
 struct PropertyI64Adapter;
 
-impl facet_runtime::BamlAdapter<i64> for PropertyI64Adapter {
+impl facet_runtime::adapters::FieldCodec<i64> for PropertyI64Adapter {
     fn type_ir() -> TypeIR {
         TypeIR::class("PropertyAdapterI64Wrapper")
     }
 
-    fn register(reg: &mut facet_runtime::Registry) {
+    fn register(reg: &mut facet_runtime::adapters::AdapterSchemaRegistry) {
         use facet_runtime::internal_baml_jinja::types::{Class, Name};
 
         if !reg.mark_type("PropertyAdapterI64Wrapper") {

--- a/crates/dspy-rs/src/adapter/chat.rs
+++ b/crates/dspy-rs/src/adapter/chat.rs
@@ -8,7 +8,6 @@ use std::sync::{Arc, LazyLock};
 use tracing::{Instrument, debug, trace};
 
 use super::Adapter;
-use crate::bamltype::compat::{BamlTypeTrait, BamlValueConvert, ToBamlValue};
 use crate::bamltype::jsonish;
 use crate::bamltype::jsonish::BamlValueWithFlags;
 use crate::bamltype::jsonish::deserializer::coercer::run_user_checks;
@@ -16,9 +15,9 @@ use crate::bamltype::jsonish::deserializer::deserialize_flags::DeserializerCondi
 use crate::serde_utils::get_iter_from_value;
 use crate::utils::cache::CacheEntry;
 use crate::{
-    BamlValue, Cache, Chat, ConstraintLevel, ConstraintResult, Example, FieldMeta, Flag,
-    JsonishError, LM, Message, MetaSignature, OutputFormatContent, ParseError, Prediction,
-    RenderOptions, Signature, TypeIR,
+    BamlTypeTrait, BamlValue, BamlValueConvert, Cache, Chat, ConstraintLevel, ConstraintResult,
+    Example, FieldMeta, Flag, JsonishError, LM, Message, MetaSignature, OutputFormatContent,
+    ParseError, Prediction, RenderOptions, Signature, ToBamlValue, TypeIR,
 };
 
 #[derive(Default, Clone)]

--- a/crates/dspy-rs/src/core/signature.rs
+++ b/crates/dspy-rs/src/core/signature.rs
@@ -1,4 +1,4 @@
-use crate::{Example, OutputFormatContent, TypeIR};
+use crate::{BamlTypeTrait, Example, OutputFormatContent, TypeIR};
 use anyhow::Result;
 use serde_json::Value;
 
@@ -37,8 +37,8 @@ pub trait MetaSignature: Send + Sync {
 }
 
 pub trait Signature: Send + Sync + 'static {
-    type Input: bamltype::compat::BamlTypeTrait + Send + Sync;
-    type Output: bamltype::compat::BamlTypeTrait + Send + Sync;
+    type Input: BamlTypeTrait + Send + Sync;
+    type Output: BamlTypeTrait + Send + Sync;
 
     fn instruction() -> &'static str;
     fn input_fields() -> &'static [FieldSpec];

--- a/crates/dspy-rs/src/lib.rs
+++ b/crates/dspy-rs/src/lib.rs
@@ -27,14 +27,12 @@ pub use bamltype::BamlType; // attribute macro
 pub use bamltype::baml_types::{
     BamlValue, Constraint, ConstraintLevel, ResponseCheck, StreamingMode, TypeIR,
 };
-pub use bamltype::compat::BamlConvertError;
-pub use bamltype::compat::{
-    BamlAdapter, BamlTypeInternal, BamlTypeTrait, BamlValueConvert, Registry, ToBamlValue,
-    with_constraints,
-};
 pub use bamltype::facet;
 pub use bamltype::internal_baml_jinja::types::{OutputFormatContent, RenderOptions};
 pub use bamltype::jsonish::deserializer::deserialize_flags::Flag;
+pub use bamltype::{
+    BamlConvertError, BamlTypeInternal, BamlTypeTrait, BamlValueConvert, ToBamlValue,
+};
 pub use dsrs_macros::*;
 
 #[deprecated(

--- a/crates/dspy-rs/src/predictors/predict.rs
+++ b/crates/dspy-rs/src/predictors/predict.rs
@@ -9,11 +9,10 @@ use tracing::{debug, trace};
 
 use crate::adapter::Adapter;
 use crate::bamltype::baml_types::BamlMap;
-use crate::bamltype::compat::{BamlValueConvert, ToBamlValue};
 use crate::core::{FieldSpec, MetaSignature, Module, Optimizable, Signature};
 use crate::{
-    BamlValue, CallResult, Chat, ChatAdapter, Example, GLOBAL_SETTINGS, LM, LmError, LmUsage,
-    PredictError, Prediction,
+    BamlValue, BamlValueConvert, CallResult, Chat, ChatAdapter, Example, GLOBAL_SETTINGS, LM,
+    LmError, LmUsage, PredictError, Prediction, ToBamlValue,
 };
 
 pub struct Predict<S: Signature> {

--- a/crates/dspy-rs/tests/test_input_format.rs
+++ b/crates/dspy-rs/tests/test_input_format.rs
@@ -1,5 +1,4 @@
-use dspy_rs::bamltype::compat::ToBamlValue;
-use dspy_rs::{BamlType, BamlTypeTrait, BamlValue, ChatAdapter, Signature};
+use dspy_rs::{BamlType, BamlTypeTrait, BamlValue, ChatAdapter, Signature, ToBamlValue};
 
 #[derive(Clone, Debug)]
 #[BamlType]

--- a/crates/dsrs-macros/tests/signature_derive.rs
+++ b/crates/dsrs-macros/tests/signature_derive.rs
@@ -68,7 +68,7 @@ fn test_from_parts_into_parts() {
 
 #[test]
 fn test_baml_type_impl() {
-    let _ = <TestSig as dspy_rs::bamltype::compat::BamlTypeTrait>::baml_output_format();
+    let _ = <TestSig as dspy_rs::BamlTypeTrait>::baml_output_format();
 }
 
 #[test]


### PR DESCRIPTION
## Summary

This PR performs a one-shot facet-only compatibility sweep and then hardens the long-term public API boundary based on an adversarial audit.

Primary changes:

- Removes `bamltype::compat` usage from typed/runtime/macro paths.
- Promotes schema registration internals into a dedicated core module and runtime traits module.
- Renames adapter trait from `BamlAdapter` to `FieldCodec`.
- Removes the public `with_constraints` helper and inlines constraint attachment in generated macro output.
- Adds an explicit adapter extension namespace (`bamltype::adapters`) and moves adapter-oriented API there.
- Keeps core runtime surface focused (`BamlType*`, conversion, rendering/parsing), with adapter hooks intentionally namespaced out of the top-level API.

## Why

The repository is early-stage and not constrained by strict back-compat requirements, so this is a deliberate cleanup to avoid carrying bridge-era artifacts forward.

The adversarial audit found that leaving registry+adapter hooks as root-level core APIs would create long-term semver lock-in around internals likely to evolve. This PR incorporates the follow-up hardening to avoid that lock-in.

## Detailed changes

### bamltype core

- Added `crates/bamltype/src/runtime.rs` for runtime traits/error types.
- Renamed/moved registry implementation into `crates/bamltype/src/schema_registry.rs` (`SchemaRegistry`) and wired schema builder to it.
- Added `crates/bamltype/src/adapters.rs`:
  - `adapters::FieldCodec`
  - `adapters::AdapterSchemaRegistry`
- Removed `crates/bamltype/src/compat.rs`.
- Updated `facet_ext`, `convert`, and `schema_builder` to new module boundaries.

### macro integration

- `crates/dsrs-macros/src/lib.rs`:
  - Stops generating `bamltype::compat::*` paths.
  - Inlines TypeIR constraint extension instead of using `with_constraints`.
  - Drops generated `BamlTypeInternal::register(...)` delegation.
- `crates/bamltype-derive/src/lib.rs`:
  - Uses `runtime_crate::adapters::FieldCodec` in generated adapter hooks.

### dspy-rs integration

- Removed compat-path usage in typed interfaces and runtime code.
- Updated root exports to canonical bamltype symbols only.

### tests

- Updated all adapter/registry path usage to `bamltype::adapters::*` (and corresponding `facet_runtime::adapters::*` paths).
- Updated compat-path imports in macro and dspy tests.

## Validation

- `cargo fmt --all`
- `cargo check --workspace`
- `cargo test -p bamltype --tests`
- `cargo test -p dsrs_macros --tests`
- `cargo test -p dspy-rs --tests`
- `cargo test --workspace`

All passed.

## User impact

This is intentionally breaking for old compat paths and root-level adapter/registry imports. The result is a cleaner facet-native API surface and a clearer extension boundary for custom field codecs.
