### PR TITLE
feat: multi-turn Predict + grouped Message model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1236,6 +1236,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "temp-env",
  "tempfile",
  "thiserror 2.0.17",
  "tokio",
@@ -4238,6 +4239,16 @@ name = "target-triple"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ac9aa371f599d22256307c24a9d748c041e548cbf599f35d890f9d365361790"
+
+[[package]]
+name = "temp-env"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
+dependencies = [
+ "futures",
+ "parking_lot",
+]
 
 [[package]]
 name = "tempfile"

--- a/crates/dspy-rs/Cargo.toml
+++ b/crates/dspy-rs/Cargo.toml
@@ -51,3 +51,6 @@ ignored = ["rig-core"]
 
 [features]
 default = []
+
+[dev-dependencies]
+temp-env = { version = "0.3.6", features = ["async_closure"] }

--- a/crates/dspy-rs/src/adapter/chat.rs
+++ b/crates/dspy-rs/src/adapter/chat.rs
@@ -625,7 +625,7 @@ impl ChatAdapter {
     where
         O: BamlType + for<'a> facet::Facet<'a>,
     {
-        let content = response.content();
+        let content = response.text_content();
         let output_format = schema.output_format();
         let sections = parse_sections(&content);
 

--- a/crates/dspy-rs/tests/test_caller_managed_conversation.rs
+++ b/crates/dspy-rs/tests/test_caller_managed_conversation.rs
@@ -1,0 +1,215 @@
+//! CallerManaged + tools + conversation flow test.
+//!
+//! This is the RLM critical path: the caller controls tool execution and
+//! manages the conversation loop, not the LM layer's auto tool loop.
+
+use dspy_rs::{
+    ChatAdapter, LM, LMClient, Message, Predict, Role, Signature, TestCompletionModel,
+    ToolLoopMode, configure,
+};
+use rig::completion::AssistantContent;
+use rig::message::{Text, ToolCall, ToolFunction};
+use std::sync::LazyLock;
+use tokio::sync::Mutex;
+
+static SETTINGS_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+fn response_with_fields(fields: &[(&str, &str)]) -> String {
+    let mut response = String::new();
+    for (name, value) in fields {
+        response.push_str(&format!("[[ ## {name} ## ]]\n{value}\n\n"));
+    }
+    response.push_str("[[ ## completed ## ]]\n");
+    response
+}
+
+fn text_response(text: impl Into<String>) -> AssistantContent {
+    AssistantContent::Text(Text { text: text.into() })
+}
+
+async fn build_test_lm(responses: Vec<AssistantContent>) -> (LM, TestCompletionModel) {
+    let client = TestCompletionModel::new(responses);
+    let lm = temp_env::async_with_vars(
+        [("OPENAI_API_KEY", Some("test"))],
+        LM::builder()
+            .model("openai:gpt-4o-mini".to_string())
+            .build(),
+    )
+    .await
+    .unwrap()
+    .with_client(LMClient::Test(client.clone()))
+    .await
+    .unwrap();
+    (lm, client)
+}
+
+#[derive(Signature, Clone, Debug, PartialEq)]
+/// Code execution signature for RLM-style interaction.
+struct CodeExec {
+    #[input]
+    prompt: String,
+
+    #[output]
+    result: String,
+}
+
+/// The full RLM-style loop:
+/// 1. Predict builds initial chat → calls LM → model requests a tool call
+/// 2. CallerManaged mode: LM returns the tool call without executing it
+/// 3. Caller manually executes the tool, appends result to chat
+/// 4. Caller calls forward_continue → LM returns the final text answer
+///
+/// This is the exact pattern RLM will use for Python REPL interaction.
+#[cfg_attr(miri, ignore = "MIRI has issues with tokio's I/O driver")]
+#[tokio::test]
+async fn caller_managed_tool_loop_with_conversation() {
+    let _lock = SETTINGS_LOCK.lock().await;
+
+    // Response 1: model wants to call a tool (returned as text since TestCompletionModel
+    // only supports single-content responses via AssistantContent)
+    let tool_call_response =
+        text_response("[[ ## result ## ]]\nNeed to execute code first\n\n[[ ## completed ## ]]\n");
+    // Response 2: after seeing tool result, model gives final answer
+    let final_response = text_response(response_with_fields(&[("result", "42")]));
+
+    let (lm, _client) = build_test_lm(vec![tool_call_response, final_response]).await;
+    configure(lm, ChatAdapter {});
+
+    let predict = Predict::<CodeExec>::new();
+    let input = CodeExecInput {
+        prompt: "Calculate 6 * 7".to_string(),
+    };
+
+    // Turn 1: Build chat and call LM
+    let chat = predict
+        .build_chat(&input)
+        .expect("build_chat should succeed");
+    let (first_result, mut chat) = predict
+        .call_and_parse(chat)
+        .await
+        .expect("first turn should succeed");
+    assert_eq!(
+        first_result.into_inner().result,
+        "Need to execute code first"
+    );
+
+    // Caller simulates tool execution: append user message with result
+    chat.push_message(Message::user("Tool output: 42"));
+
+    // Turn 2: Continue the conversation
+    let (second_result, final_chat) = predict
+        .forward_continue(chat)
+        .await
+        .expect("second turn should succeed");
+    assert_eq!(second_result.into_inner().result, "42");
+
+    // Verify chat grew across turns
+    assert!(
+        final_chat.len() >= 5,
+        "chat should have system + user + asst + user + asst, got {}",
+        final_chat.len()
+    );
+
+    // Verify turn ordering
+    assert_eq!(final_chat.messages[0].role, Role::System);
+    assert_eq!(final_chat.messages[1].role, Role::User);
+    assert_eq!(final_chat.messages[2].role, Role::Assistant);
+    assert_eq!(final_chat.messages[3].role, Role::User); // caller's tool result
+    assert_eq!(final_chat.messages[4].role, Role::Assistant); // final answer
+}
+
+/// Tests the LM-level CallerManaged mode directly: when a tool call is requested
+/// with CallerManaged mode, the LM returns the tool calls without executing them
+/// and the caller controls what happens next.
+#[cfg_attr(miri, ignore = "MIRI has issues with tokio's I/O driver")]
+#[tokio::test]
+async fn lm_caller_managed_returns_tool_calls_in_chat_history() {
+    let _lock = SETTINGS_LOCK.lock().await;
+
+    // Model responds with a tool call
+    let tool_call_content = AssistantContent::ToolCall(ToolCall::new(
+        "tc-1".to_string(),
+        ToolFunction {
+            name: "python_repl".to_string(),
+            arguments: serde_json::json!({"code": "print(6 * 7)"}),
+        },
+    ));
+
+    let (lm, _client) = build_test_lm(vec![tool_call_content]).await;
+
+    let chat = dspy_rs::Chat::new(vec![Message::user("Run some code")]);
+    let response = lm
+        .call_with_tool_loop_mode(chat, vec![], ToolLoopMode::CallerManaged)
+        .await
+        .expect("caller-managed call should succeed");
+
+    // Tool calls returned but NOT executed
+    assert_eq!(response.tool_calls.len(), 1);
+    assert_eq!(response.tool_calls[0].function.name, "python_repl");
+    assert!(
+        response.tool_executions.is_empty(),
+        "CallerManaged should not execute tools"
+    );
+
+    // Chat history should contain the tool call message
+    assert!(
+        response.chat.messages.iter().any(|m| m.has_tool_calls()),
+        "chat history should include the tool call message"
+    );
+}
+
+/// Multi-turn with parse failure on second turn verifies that errors
+/// include the correct raw_response from the continuation, not the first turn.
+#[cfg_attr(miri, ignore = "MIRI has issues with tokio's I/O driver")]
+#[tokio::test]
+async fn parse_failure_on_second_turn_includes_correct_raw_response() {
+    let _lock = SETTINGS_LOCK.lock().await;
+
+    let good_response = text_response(response_with_fields(&[("result", "first answer")]));
+    // Second response is malformed — no field markers
+    let bad_response = text_response("This response has no field markers at all.");
+
+    let (lm, _client) = build_test_lm(vec![good_response, bad_response]).await;
+    configure(lm, ChatAdapter {});
+
+    let predict = Predict::<CodeExec>::new();
+    let input = CodeExecInput {
+        prompt: "test".to_string(),
+    };
+
+    // Turn 1: succeeds
+    let chat = predict.build_chat(&input).expect("build_chat");
+    let (first_result, mut chat) = predict.call_and_parse(chat).await.expect("turn 1");
+    assert_eq!(first_result.into_inner().result, "first answer");
+
+    // Turn 2: should fail with parse error containing the bad response
+    chat.push_message(Message::user("follow up"));
+    let err = predict
+        .forward_continue(chat)
+        .await
+        .expect_err("second turn should fail");
+
+    match err {
+        dspy_rs::PredictError::Parse {
+            raw_response,
+            source,
+            ..
+        } => {
+            assert!(
+                raw_response.contains("no field markers"),
+                "raw_response should be from the second turn, got: {}",
+                raw_response
+            );
+            // The error should mention the missing field
+            let fields = source.fields();
+            assert!(
+                !fields.is_empty() || source.field().is_some(),
+                "parse error should identify which field(s) failed"
+            );
+        }
+        other => panic!(
+            "expected PredictError::Parse, got: {:?}",
+            std::mem::discriminant(&other)
+        ),
+    }
+}

--- a/crates/dspy-rs/tests/test_chain_of_thought_swap.rs
+++ b/crates/dspy-rs/tests/test_chain_of_thought_swap.rs
@@ -23,19 +23,18 @@ fn text_response(text: impl Into<String>) -> AssistantContent {
 }
 
 async fn configure_test_lm(responses: Vec<String>) {
-    unsafe {
-        std::env::set_var("OPENAI_API_KEY", "test");
-    }
-
     let client = TestCompletionModel::new(responses.into_iter().map(text_response));
-    let lm = LM::builder()
-        .model("openai:gpt-4o-mini".to_string())
-        .build()
-        .await
-        .unwrap()
-        .with_client(LMClient::Test(client))
-        .await
-        .unwrap();
+    let lm = temp_env::async_with_vars(
+        [("OPENAI_API_KEY", Some("test"))],
+        LM::builder()
+            .model("openai:gpt-4o-mini".to_string())
+            .build(),
+    )
+    .await
+    .unwrap()
+    .with_client(LMClient::Test(client))
+    .await
+    .unwrap();
 
     configure(lm, ChatAdapter {});
 }

--- a/crates/dspy-rs/tests/test_lm.rs
+++ b/crates/dspy-rs/tests/test_lm.rs
@@ -84,16 +84,15 @@ fn test_lm_usage_add() {
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
 async fn test_lm_with_cache_enabled() {
-    unsafe {
-        std::env::set_var("OPENAI_API_KEY", "test");
-    }
-    // Create LM with cache enabled
-    let lm = LM::builder()
-        .model("openai:gpt-4o-mini".to_string())
-        .cache(true)
-        .build()
-        .await
-        .unwrap();
+    let lm = temp_env::async_with_vars(
+        [("OPENAI_API_KEY", Some("test"))],
+        LM::builder()
+            .model("openai:gpt-4o-mini".to_string())
+            .cache(true)
+            .build(),
+    )
+    .await
+    .unwrap();
 
     // Verify cache handler is initialized
     assert!(lm.cache_handler.is_some());
@@ -102,16 +101,15 @@ async fn test_lm_with_cache_enabled() {
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
 async fn test_lm_with_cache_disabled() {
-    unsafe {
-        std::env::set_var("OPENAI_API_KEY", "test");
-    }
-    // Create LM with cache explicitly disabled
-    let lm = LM::builder()
-        .model("openai:gpt-4o-mini".to_string())
-        .cache(false)
-        .build()
-        .await
-        .unwrap();
+    let lm = temp_env::async_with_vars(
+        [("OPENAI_API_KEY", Some("test"))],
+        LM::builder()
+            .model("openai:gpt-4o-mini".to_string())
+            .cache(false)
+            .build(),
+    )
+    .await
+    .unwrap();
 
     // Verify cache handler is NOT initialized when cache is disabled
     assert!(lm.cache_handler.is_none());
@@ -120,16 +118,15 @@ async fn test_lm_with_cache_disabled() {
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
 async fn test_lm_cache_initialization_on_first_call() {
-    unsafe {
-        std::env::set_var("OPENAI_API_KEY", "test");
-    }
-    // Create LM with cache enabled
-    let lm = LM::builder()
-        .model("openai:gpt-4o-mini".to_string())
-        .cache(true)
-        .build()
-        .await
-        .unwrap();
+    let lm = temp_env::async_with_vars(
+        [("OPENAI_API_KEY", Some("test"))],
+        LM::builder()
+            .model("openai:gpt-4o-mini".to_string())
+            .cache(true)
+            .build(),
+    )
+    .await
+    .unwrap();
 
     // After build, cache_handler should be initialized
     assert!(lm.cache_handler.is_some());
@@ -138,20 +135,19 @@ async fn test_lm_cache_initialization_on_first_call() {
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
 async fn test_lm_cache_direct_operations() {
-    unsafe {
-        std::env::set_var("OPENAI_API_KEY", "test");
-    }
     use dspy_rs::Prediction;
     use dspy_rs::data::RawExample;
     use std::collections::HashMap;
 
-    // Create LM with cache enabled
-    let lm = LM::builder()
-        .model("openai:gpt-4o-mini".to_string())
-        .cache(true)
-        .build()
-        .await
-        .unwrap();
+    let lm = temp_env::async_with_vars(
+        [("OPENAI_API_KEY", Some("test"))],
+        LM::builder()
+            .model("openai:gpt-4o-mini".to_string())
+            .cache(true)
+            .build(),
+    )
+    .await
+    .unwrap();
 
     // Get cache handler
     let cache = lm
@@ -207,20 +203,19 @@ async fn test_lm_cache_direct_operations() {
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
 async fn test_lm_cache_with_different_models() {
-    unsafe {
-        std::env::set_var("OPENAI_API_KEY", "test");
-        std::env::set_var("ANTHROPIC_API_KEY", "test");
-    }
     // Test that cache works with different model configurations
     let models = vec!["openai:gpt-3.5-turbo", "anthropic:claude-3-haiku-20240307"];
 
     for model in models {
-        let lm = LM::builder()
-            .model(model.to_string())
-            .cache(true)
-            .build()
-            .await
-            .unwrap();
+        let lm = temp_env::async_with_vars(
+            [
+                ("OPENAI_API_KEY", Some("test")),
+                ("ANTHROPIC_API_KEY", Some("test")),
+            ],
+            LM::builder().model(model.to_string()).cache(true).build(),
+        )
+        .await
+        .unwrap();
 
         // Cache should be initialized regardless of model
         assert!(
@@ -234,20 +229,19 @@ async fn test_lm_cache_with_different_models() {
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
 async fn test_cache_with_complex_inputs() {
-    unsafe {
-        std::env::set_var("OPENAI_API_KEY", "test");
-    }
     use dspy_rs::Prediction;
     use dspy_rs::data::RawExample;
     use std::collections::HashMap;
 
-    // Create LM with cache enabled
-    let lm = LM::builder()
-        .model("openai:gpt-4o-mini".to_string())
-        .cache(true)
-        .build()
-        .await
-        .unwrap();
+    let lm = temp_env::async_with_vars(
+        [("OPENAI_API_KEY", Some("test"))],
+        LM::builder()
+            .model("openai:gpt-4o-mini".to_string())
+            .cache(true)
+            .build(),
+    )
+    .await
+    .unwrap();
 
     let cache = lm
         .cache_handler

--- a/crates/dspy-rs/tests/test_message_roundtrip.rs
+++ b/crates/dspy-rs/tests/test_message_roundtrip.rs
@@ -1,0 +1,345 @@
+//! Round-trip tests for the new Message model.
+//!
+//! Verifies that the grouped Role + ContentBlock representation preserves
+//! all content through: DSRs Message → rig Message → DSRs Message, and
+//! through JSON serialization/deserialization.
+
+use dspy_rs::core::lm::chat::{Chat, ContentBlock, Message, Role};
+use rig::OneOrMany;
+use rig::message::{
+    Message as RigMessage, Reasoning, ToolCall, ToolFunction, ToolResult, ToolResultContent,
+};
+use serde_json::json;
+
+// ---------------------------------------------------------------------------
+// Reasoning continuity round-trip
+// ---------------------------------------------------------------------------
+
+/// Anthropic's thinking turns produce [Reasoning, Reasoning, ToolCall] in a
+/// single assistant turn. The entire chain of thought must survive:
+///   DSRs Message → rig → DSRs Message
+#[test]
+fn reasoning_chain_survives_rig_roundtrip() {
+    let original = Message::with_content(
+        Role::Assistant,
+        vec![
+            ContentBlock::reasoning(Reasoning::new("step 1: analyze the query")),
+            ContentBlock::reasoning(Reasoning::new("step 2: plan the search")),
+            ContentBlock::tool_call(ToolCall::new(
+                "tc-1".to_string(),
+                ToolFunction {
+                    name: "search".to_string(),
+                    arguments: json!({"q": "rust ownership"}),
+                },
+            )),
+        ],
+    );
+
+    // Forward: DSRs → rig
+    let rig_msg = original
+        .to_rig_message()
+        .expect("assistant message should convert to rig");
+
+    // Backward: rig → DSRs
+    let roundtripped = Message::from(rig_msg);
+
+    assert_eq!(roundtripped.role, Role::Assistant);
+    assert_eq!(
+        roundtripped.content.len(),
+        3,
+        "all three content blocks must survive: got {:?}",
+        roundtripped.content
+    );
+
+    assert!(
+        matches!(&roundtripped.content[0], ContentBlock::Reasoning { reasoning } if reasoning.display_text().contains("step 1")),
+        "first reasoning block lost"
+    );
+    assert!(
+        matches!(&roundtripped.content[1], ContentBlock::Reasoning { reasoning } if reasoning.display_text().contains("step 2")),
+        "second reasoning block lost"
+    );
+    assert!(
+        matches!(&roundtripped.content[2], ContentBlock::ToolCall { tool_call } if tool_call.function.name == "search"),
+        "tool call lost"
+    );
+}
+
+/// A reasoning-only assistant turn (no text, no tool call) must round-trip.
+#[test]
+fn reasoning_only_turn_roundtrips() {
+    let original = Message::with_content(
+        Role::Assistant,
+        vec![ContentBlock::reasoning(Reasoning::new(
+            "just thinking out loud",
+        ))],
+    );
+
+    let rig_msg = original.to_rig_message().unwrap();
+    let roundtripped = Message::from(rig_msg);
+
+    assert_eq!(roundtripped.role, Role::Assistant);
+    assert_eq!(roundtripped.content.len(), 1);
+    assert!(roundtripped.has_reasoning());
+    assert!(!roundtripped.has_tool_calls());
+}
+
+// ---------------------------------------------------------------------------
+// Multi-content user messages
+// ---------------------------------------------------------------------------
+
+/// A user message with both text and a tool result must preserve both.
+#[test]
+fn user_text_plus_tool_result_roundtrips() {
+    let original = Message::with_content(
+        Role::User,
+        vec![
+            ContentBlock::text("Here is context"),
+            ContentBlock::tool_result(ToolResult {
+                id: "tr-1".to_string(),
+                call_id: Some("tc-1".to_string()),
+                content: OneOrMany::one(ToolResultContent::text("search result")),
+            }),
+        ],
+    );
+
+    let rig_msg = original.to_rig_message().unwrap();
+    let roundtripped = Message::from(rig_msg);
+
+    assert_eq!(roundtripped.role, Role::User);
+    assert_eq!(
+        roundtripped.content.len(),
+        2,
+        "both text and tool result must survive"
+    );
+    assert!(matches!(
+        &roundtripped.content[0],
+        ContentBlock::Text { text } if text == "Here is context"
+    ));
+    assert!(roundtripped.has_tool_results());
+}
+
+// ---------------------------------------------------------------------------
+// Multi-turn conversation with reasoning in history
+// ---------------------------------------------------------------------------
+
+/// Build a multi-turn conversation where an earlier assistant turn has
+/// reasoning blocks. Convert the full chat to rig format and back.
+/// The reasoning from earlier turns must be preserved.
+#[test]
+fn multi_turn_conversation_preserves_earlier_reasoning() {
+    let chat = Chat::new(vec![
+        Message::system("You are a helpful assistant."),
+        Message::user("What is the capital of France?"),
+        // Turn 1 reply: reasoning + text answer
+        Message::with_content(
+            Role::Assistant,
+            vec![
+                ContentBlock::reasoning(Reasoning::new("The user is asking about geography.")),
+                ContentBlock::text("The capital of France is Paris."),
+            ],
+        ),
+        // User follow-up
+        Message::user("And Germany?"),
+        // Turn 2 reply: just text
+        Message::assistant("The capital of Germany is Berlin."),
+    ]);
+
+    // Convert to rig and back
+    let rig_history = chat.to_rig_chat_history();
+    // rig_history should have 4 messages (system excluded)
+    assert_eq!(rig_history.len(), 4);
+
+    // Reconstruct from rig history
+    let mut reconstructed = Chat::new(vec![Message::system(chat.system_prompt())]);
+    for rig_msg in rig_history {
+        reconstructed.push_message(Message::from(rig_msg));
+    }
+
+    assert_eq!(reconstructed.len(), 5);
+
+    // Verify turn 1's reasoning survived
+    let turn1_reply = &reconstructed.messages[2];
+    assert_eq!(turn1_reply.role, Role::Assistant);
+    assert!(
+        turn1_reply.has_reasoning(),
+        "turn 1 reasoning must survive rig round-trip"
+    );
+    assert_eq!(
+        turn1_reply.content.len(),
+        2,
+        "turn 1 must have both reasoning and text"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// JSON serialization round-trip
+// ---------------------------------------------------------------------------
+
+/// Full multi-content message survives JSON serialization.
+#[test]
+fn grouped_message_json_roundtrip() {
+    let original = Chat::new(vec![
+        Message::system("Be helpful"),
+        Message::with_content(
+            Role::Assistant,
+            vec![
+                ContentBlock::reasoning(Reasoning::new("let me think")),
+                ContentBlock::text("the answer is 42"),
+                ContentBlock::tool_call(ToolCall::new(
+                    "tc-1".to_string(),
+                    ToolFunction {
+                        name: "verify".to_string(),
+                        arguments: json!({"answer": 42}),
+                    },
+                )),
+            ],
+        ),
+        Message::with_content(
+            Role::User,
+            vec![
+                ContentBlock::tool_result(ToolResult {
+                    id: "tc-1".to_string(),
+                    call_id: None,
+                    content: OneOrMany::one(ToolResultContent::text("confirmed")),
+                }),
+                ContentBlock::text("Thanks! Can you also check 43?"),
+            ],
+        ),
+    ]);
+
+    let json = original.to_json();
+    let reparsed = Chat::new(vec![]).from_json(json).unwrap();
+
+    assert_eq!(reparsed.len(), 3);
+
+    // Verify the assistant message preserved all 3 content blocks
+    let asst = &reparsed.messages[1];
+    assert_eq!(asst.role, Role::Assistant);
+    assert_eq!(asst.content.len(), 3);
+    assert!(asst.has_reasoning());
+    assert!(asst.has_tool_calls());
+
+    // Verify the user message preserved both blocks
+    let user = &reparsed.messages[2];
+    assert_eq!(user.role, Role::User);
+    assert_eq!(user.content.len(), 2);
+    assert!(user.has_tool_results());
+}
+
+/// Legacy JSON format (content as plain string) still parses correctly.
+#[test]
+fn legacy_plain_string_json_parses_into_new_model() {
+    let legacy_json = json!([
+        {"role": "system", "content": "Be helpful"},
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "Hi there!"}
+    ]);
+
+    let chat = Chat::new(vec![]).from_json(legacy_json).unwrap();
+    assert_eq!(chat.len(), 3);
+    assert_eq!(chat.messages[0].role, Role::System);
+    assert_eq!(chat.messages[0].content(), "Be helpful");
+    assert_eq!(chat.messages[2].text_content(), "Hi there!");
+}
+
+// ---------------------------------------------------------------------------
+// Accessor correctness
+// ---------------------------------------------------------------------------
+
+#[test]
+fn text_content_excludes_non_text_blocks() {
+    let msg = Message::with_content(
+        Role::Assistant,
+        vec![
+            ContentBlock::reasoning(Reasoning::new("internal monologue")),
+            ContentBlock::text("visible answer"),
+            ContentBlock::tool_call(ToolCall::new(
+                "tc".to_string(),
+                ToolFunction {
+                    name: "search".to_string(),
+                    arguments: json!({}),
+                },
+            )),
+        ],
+    );
+
+    assert_eq!(msg.text_content(), "visible answer");
+    // content() includes everything
+    let full = msg.content();
+    assert!(full.contains("internal monologue"));
+    assert!(full.contains("visible answer"));
+    assert!(full.contains("search"));
+}
+
+#[test]
+fn tool_calls_accessor_returns_all_tool_calls() {
+    let msg = Message::with_content(
+        Role::Assistant,
+        vec![
+            ContentBlock::reasoning(Reasoning::new("planning")),
+            ContentBlock::tool_call(ToolCall::new(
+                "tc-1".to_string(),
+                ToolFunction {
+                    name: "search".to_string(),
+                    arguments: json!({"q": "a"}),
+                },
+            )),
+            ContentBlock::tool_call(ToolCall::new(
+                "tc-2".to_string(),
+                ToolFunction {
+                    name: "calculate".to_string(),
+                    arguments: json!({"expr": "1+1"}),
+                },
+            )),
+        ],
+    );
+
+    let calls = msg.tool_calls();
+    assert_eq!(calls.len(), 2);
+    assert_eq!(calls[0].function.name, "search");
+    assert_eq!(calls[1].function.name, "calculate");
+}
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+/// Empty content vec (pathological) should not panic.
+#[test]
+fn empty_content_message_does_not_panic() {
+    let msg = Message::with_content(Role::Assistant, vec![]);
+    assert_eq!(msg.content(), "");
+    assert_eq!(msg.text_content(), "");
+    assert!(!msg.has_tool_calls());
+    assert!(!msg.has_reasoning());
+
+    // Rig conversion should produce an assistant message with empty text
+    let rig_msg = msg.to_rig_message().unwrap();
+    match rig_msg {
+        RigMessage::Assistant { content, .. } => {
+            assert_eq!(content.iter().count(), 1); // empty text fallback
+        }
+        _ => panic!("expected assistant message"),
+    }
+}
+
+/// System messages return None from to_rig_message (handled as preamble).
+#[test]
+fn system_message_excluded_from_rig_conversion() {
+    let msg = Message::system("You are helpful");
+    assert!(msg.to_rig_message().is_none());
+}
+
+/// Message ID (e.g. Anthropic thinking turn IDs) survives round-trip.
+#[test]
+fn message_id_survives_rig_roundtrip() {
+    let mut msg = Message::assistant("some text");
+    msg.id = Some("msg_abc123".to_string());
+
+    let rig_msg = msg.to_rig_message().unwrap();
+    let roundtripped = Message::from(rig_msg);
+
+    // Note: rig's User messages don't carry IDs, but Assistant messages do
+    assert_eq!(roundtripped.id, Some("msg_abc123".to_string()));
+}

--- a/crates/dspy-rs/tests/test_predict_conversation.rs
+++ b/crates/dspy-rs/tests/test_predict_conversation.rs
@@ -1,0 +1,159 @@
+use dspy_rs::{
+    ChatAdapter, LM, LMClient, Message, Predict, Role, Signature, TestCompletionModel, configure,
+};
+use rig::completion::{AssistantContent, CompletionRequest};
+use rig::message::{Message as RigMessage, Text, UserContent};
+use std::sync::LazyLock;
+use tokio::sync::Mutex;
+
+static SETTINGS_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+fn response_with_fields(fields: &[(&str, &str)]) -> String {
+    let mut response = String::new();
+    for (name, value) in fields {
+        response.push_str(&format!("[[ ## {name} ## ]]\n{value}\n\n"));
+    }
+    response.push_str("[[ ## completed ## ]]\n");
+    response
+}
+
+fn text_response(text: impl Into<String>) -> AssistantContent {
+    AssistantContent::Text(Text { text: text.into() })
+}
+
+async fn configure_test_lm(responses: Vec<String>) -> TestCompletionModel {
+    let client = TestCompletionModel::new(responses.into_iter().map(text_response));
+    let lm = temp_env::async_with_vars(
+        [("OPENAI_API_KEY", Some("test"))],
+        LM::builder()
+            .model("openai:gpt-4o-mini".to_string())
+            .build(),
+    )
+    .await
+    .unwrap()
+    .with_client(LMClient::Test(client.clone()))
+    .await
+    .unwrap();
+
+    configure(lm, ChatAdapter {});
+
+    client
+}
+
+fn request_contains_text(request: &CompletionRequest, needle: &str) -> bool {
+    if request
+        .preamble
+        .as_ref()
+        .is_some_and(|preamble| preamble.contains(needle))
+    {
+        return true;
+    }
+
+    for message in request.chat_history.iter() {
+        match message {
+            RigMessage::User { content } => {
+                for item in content.iter() {
+                    if let UserContent::Text(text) = item
+                        && text.text.contains(needle)
+                    {
+                        return true;
+                    }
+                }
+            }
+            RigMessage::Assistant { content, .. } => {
+                for item in content.iter() {
+                    match item {
+                        AssistantContent::Text(text) if text.text.contains(needle) => return true,
+                        AssistantContent::Reasoning(reasoning)
+                            if reasoning.display_text().contains(needle) =>
+                        {
+                            return true;
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+    }
+
+    false
+}
+
+#[derive(Signature, Clone, Debug, PartialEq)]
+/// Conversational QA test signature.
+struct ConversationQA {
+    #[input]
+    question: String,
+
+    #[output]
+    answer: String,
+}
+
+#[cfg_attr(miri, ignore = "MIRI has issues with tokio's I/O driver")]
+#[tokio::test]
+async fn forward_returns_chat_and_prediction() {
+    let _lock = SETTINGS_LOCK.lock().await;
+    let response = response_with_fields(&[("answer", "Paris")]);
+    let _client = configure_test_lm(vec![response]).await;
+
+    let predict = Predict::<ConversationQA>::new();
+    let input = ConversationQAInput {
+        question: "What is the capital of France?".to_string(),
+    };
+
+    let chat = predict
+        .build_chat(&input)
+        .expect("build_chat should succeed");
+    let (predicted, chat) = predict
+        .call_and_parse(chat)
+        .await
+        .expect("first turn should succeed");
+
+    assert_eq!(predicted.into_inner().answer, "Paris");
+    assert_eq!(chat.len(), 3);
+    assert_eq!(chat.messages[0].role, Role::System);
+    assert_eq!(chat.messages[1].role, Role::User);
+    assert_eq!(chat.messages[2].role, Role::Assistant);
+}
+
+#[cfg_attr(miri, ignore = "MIRI has issues with tokio's I/O driver")]
+#[tokio::test]
+async fn forward_continue_supports_two_turn_roundtrip() {
+    let _lock = SETTINGS_LOCK.lock().await;
+    let first_response = response_with_fields(&[("answer", "First turn answer")]);
+    let second_response = response_with_fields(&[("answer", "Second turn answer")]);
+    let client = configure_test_lm(vec![first_response, second_response]).await;
+
+    let predict = Predict::<ConversationQA>::new();
+    let first_input = ConversationQAInput {
+        question: "Turn 1 question".to_string(),
+    };
+
+    // First turn: build fresh chat
+    let chat = predict
+        .build_chat(&first_input)
+        .expect("build_chat should succeed");
+    let (first_predicted, mut chat) = predict
+        .call_and_parse(chat)
+        .await
+        .expect("first turn should succeed");
+    assert_eq!(first_predicted.into_inner().answer, "First turn answer");
+
+    // Second turn: append follow-up, continue conversation
+    let caller_follow_up = "Caller follow-up message";
+    chat.push_message(Message::user(caller_follow_up));
+
+    let (second_predicted, second_chat) = predict
+        .forward_continue(chat)
+        .await
+        .expect("second turn should succeed");
+
+    assert_eq!(second_predicted.into_inner().answer, "Second turn answer");
+    assert!(second_chat.len() >= 5);
+
+    // Verify the follow-up text was sent to the LM
+    let last_request = client
+        .last_request()
+        .expect("test model should capture last request");
+    assert!(request_contains_text(&last_request, caller_follow_up));
+}

--- a/crates/dspy-rs/tests/test_predict_conversation_live.rs
+++ b/crates/dspy-rs/tests/test_predict_conversation_live.rs
@@ -1,0 +1,65 @@
+use dspy_rs::{ChatAdapter, LM, Message, Predict, Signature, configure};
+use std::sync::LazyLock;
+use tokio::sync::Mutex;
+
+static SETTINGS_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+#[derive(Signature, Clone, Debug, PartialEq)]
+/// Live multi-turn conversation signature.
+struct LiveConversation {
+    #[input]
+    prompt: String,
+
+    #[output]
+    answer: String,
+}
+
+#[tokio::test]
+#[ignore] // Requires real network access and provider API key(s)
+async fn live_forward_continue_two_turn_roundtrip() {
+    let _lock = SETTINGS_LOCK.lock().await;
+
+    let lm = LM::builder()
+        .model("openai:gpt-4o-mini".to_string())
+        .temperature(0.0)
+        .max_tokens(256)
+        .build()
+        .await
+        .expect("failed to build LM for live smoke test");
+    configure(lm, ChatAdapter {});
+
+    let predict = Predict::<LiveConversation>::new();
+
+    // First turn: build and call
+    let first_input = LiveConversationInput {
+        prompt: "Reply with the word ONE.".to_string(),
+    };
+    let chat = predict
+        .build_chat(&first_input)
+        .expect("build_chat should succeed");
+    let (first, mut chat) = predict
+        .call_and_parse(chat)
+        .await
+        .expect("first turn failed");
+    assert!(
+        !first.answer.trim().is_empty(),
+        "first turn answer should not be empty"
+    );
+
+    // Second turn: append follow-up, continue
+    chat.push_message(Message::user(
+        "Now reply with the word TWO. Use the same answer field format.",
+    ));
+
+    let (second, chat2) = predict
+        .forward_continue(chat)
+        .await
+        .expect("second turn failed");
+
+    assert!(
+        second.answer.to_ascii_lowercase().contains("two"),
+        "second turn answer should include 'two', got: {}",
+        second.answer
+    );
+    assert!(chat2.len() >= 5, "chat should grow across turns");
+}

--- a/crates/dspy-rs/tests/test_react_builder.rs
+++ b/crates/dspy-rs/tests/test_react_builder.rs
@@ -31,19 +31,18 @@ fn parse_calculator_args(args: &str) -> (i64, i64) {
 }
 
 async fn configure_test_lm(responses: Vec<String>) {
-    unsafe {
-        std::env::set_var("OPENAI_API_KEY", "test");
-    }
-
     let client = TestCompletionModel::new(responses.into_iter().map(text_response));
-    let lm = LM::builder()
-        .model("openai:gpt-4o-mini".to_string())
-        .build()
-        .await
-        .unwrap()
-        .with_client(LMClient::Test(client))
-        .await
-        .unwrap();
+    let lm = temp_env::async_with_vars(
+        [("OPENAI_API_KEY", Some("test"))],
+        LM::builder()
+            .model("openai:gpt-4o-mini".to_string())
+            .build(),
+    )
+    .await
+    .unwrap()
+    .with_client(LMClient::Test(client))
+    .await
+    .unwrap();
 
     configure(lm, ChatAdapter {});
 }

--- a/crates/dspy-rs/tests/test_settings.rs
+++ b/crates/dspy-rs/tests/test_settings.rs
@@ -3,31 +3,27 @@ use dspy_rs::{ChatAdapter, LM, configure, get_lm};
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
 async fn test_settings() {
-    unsafe {
-        std::env::set_var("OPENAI_API_KEY", "test");
-    }
-    configure(
+    let lm1 = temp_env::async_with_vars(
+        [("OPENAI_API_KEY", Some("test"))],
         LM::builder()
             .model("openai:gpt-4o-mini".to_string())
-            .build()
-            .await
-            .unwrap(),
-        ChatAdapter {},
-    );
+            .build(),
+    )
+    .await
+    .unwrap();
+    configure(lm1, ChatAdapter {});
 
     let lm = get_lm();
     assert_eq!(lm.model, "openai:gpt-4o-mini");
 
-    configure(
-        LM::builder()
-            .model("openai:gpt-4o".to_string())
-            .build()
-            .await
-            .unwrap(),
-        ChatAdapter {},
-    );
+    let lm2 = temp_env::async_with_vars(
+        [("OPENAI_API_KEY", Some("test"))],
+        LM::builder().model("openai:gpt-4o".to_string()).build(),
+    )
+    .await
+    .unwrap();
+    configure(lm2, ChatAdapter {});
 
     let lm = get_lm();
-
     assert_eq!(lm.model, "openai:gpt-4o");
 }

--- a/crates/dspy-rs/tests/test_tool_call.rs
+++ b/crates/dspy-rs/tests/test_tool_call.rs
@@ -108,13 +108,10 @@ async fn test_tool_call_with_no_tools() {
     }
 
     let response = response.unwrap();
-    match response.output {
-        Message::Assistant { content } => {
-            // The response should contain some mention of 4
-            println!("Assistant response: {}", content);
-        }
-        _ => panic!("Expected assistant message"),
-    }
+    assert_eq!(response.output.role, dspy_rs::Role::Assistant);
+    let content = response.output.content();
+    // The response should contain some mention of 4
+    println!("Assistant response: {}", content);
 }
 
 #[tokio::test]
@@ -140,12 +137,9 @@ async fn test_tool_call_with_calculator() {
     // Call with the calculator tool
     let response = lm.call(chat, tools).await.unwrap();
 
-    match response.output {
-        Message::Assistant { content } => {
-            println!("Assistant response after tool use: {}", content);
-            // The response should mention the result (100) or that the tool was called
-            assert!(content.contains("100") || content.contains("Tool call"));
-        }
-        _ => panic!("Expected assistant message"),
-    }
+    assert_eq!(response.output.role, dspy_rs::Role::Assistant);
+    let content = response.output.content();
+    println!("Assistant response after tool use: {}", content);
+    // The response should mention the result (100) or that the tool was called
+    assert!(content.contains("100") || content.contains("Tool call"));
 }

--- a/crates/dspy-rs/tests/typed_integration.rs
+++ b/crates/dspy-rs/tests/typed_integration.rs
@@ -23,19 +23,18 @@ fn text_response(text: impl Into<String>) -> AssistantContent {
 }
 
 async fn configure_test_lm(responses: Vec<String>) -> TestCompletionModel {
-    unsafe {
-        std::env::set_var("OPENAI_API_KEY", "test");
-    }
-
     let client = TestCompletionModel::new(responses.into_iter().map(text_response));
-    let lm = LM::builder()
-        .model("openai:gpt-4o-mini".to_string())
-        .build()
-        .await
-        .unwrap()
-        .with_client(LMClient::Test(client.clone()))
-        .await
-        .unwrap();
+    let lm = temp_env::async_with_vars(
+        [("OPENAI_API_KEY", Some("test"))],
+        LM::builder()
+            .model("openai:gpt-4o-mini".to_string())
+            .build(),
+    )
+    .await
+    .unwrap()
+    .with_client(LMClient::Test(client.clone()))
+    .await
+    .unwrap();
 
     configure(lm, ChatAdapter {});
 


### PR DESCRIPTION
## Summary
- Refactor Message from flat enum to Role + Vec<ContentBlock>
- Preserve reasoning continuity through rig round-trips
- Make From<RigMessage> trivial (no data loss) and remove RigChatMessage
- Split Predict API into forward(input) and forward_continue(chat)
- Add ToolLoopMode::CallerManaged for caller-controlled loops
- Return full conversation history in LMResponse.chat
- Replace unsafe set_var usage in tests with temp_env
- Add 14 tests covering round-trip conversion, CallerManaged conversation flow, and reasoning preservation

## Notes
- Branch: multi-turn-predict