### PR TITLE
refactor: harden LM transcript fidelity, unify Predicted return shape, collapse call API

### DIFF
--- a/crates/dspy-rs/examples/01-simple.rs
+++ b/crates/dspy-rs/examples/01-simple.rs
@@ -17,8 +17,8 @@ use anyhow::Result;
 use bon::Builder;
 use dspy_rs::data::RawExample;
 use dspy_rs::{
-    CallMetadata, ChatAdapter, Example, LM, LmError, Module, Predict, PredictError, Predicted,
-    Prediction, configure, init_tracing,
+    CallMetadata, Chat, ChatAdapter, Example, LM, LmError, Module, Predict, PredictError,
+    Predicted, Prediction, configure, init_tracing,
 };
 
 const QA_INSTRUCTION: &str = "Answer the question step by step.";
@@ -115,7 +115,11 @@ impl Module for QARater {
             .data
             .insert("rating".into(), rate_result.rating.into());
 
-        Ok(Predicted::new(combined, CallMetadata::default()))
+        Ok(Predicted::new(
+            combined,
+            CallMetadata::default(),
+            Chat::new(vec![]),
+        ))
     }
 }
 
@@ -147,7 +151,7 @@ async fn main() -> Result<()> {
     println!("Reasoning: {}", output.reasoning);
     println!("Answer: {}", output.answer);
 
-    // Predicted carries both typed output and metadata.
+    // Predicted carries typed output, metadata, and chat history.
     let result = predict.call(input).await?;
     println!("\nWith metadata:");
     println!(

--- a/crates/dspy-rs/examples/12-tracing.rs
+++ b/crates/dspy-rs/examples/12-tracing.rs
@@ -11,8 +11,8 @@ use anyhow::Result;
 use bon::Builder;
 use dspy_rs::data::RawExample;
 use dspy_rs::{
-    CallMetadata, ChatAdapter, LM, LmUsage, Module, Predict, PredictError, Predicted, Prediction,
-    Signature, configure, init_tracing,
+    CallMetadata, Chat, ChatAdapter, LM, LmUsage, Module, Predict, PredictError, Predicted,
+    Prediction, Signature, configure, init_tracing,
     trace::{self, Executor},
 };
 use serde_json::json;
@@ -83,7 +83,11 @@ impl Module for QARater {
             },
         );
 
-        Ok(Predicted::new(prediction, CallMetadata::default()))
+        Ok(Predicted::new(
+            prediction,
+            CallMetadata::default(),
+            Chat::new(vec![]),
+        ))
     }
 }
 

--- a/crates/dspy-rs/examples/93-smoke-slice4-react-operational.rs
+++ b/crates/dspy-rs/examples/93-smoke-slice4-react-operational.rs
@@ -83,7 +83,7 @@ async fn main() -> Result<()> {
         }
         anyhow::anyhow!("slice4 smoke failed")
     })?;
-    let (output, metadata) = predicted.into_parts();
+    let (output, metadata, _chat) = predicted.into_parts();
 
     println!("tool_calls: {}", metadata.tool_calls.len());
     println!("tool_executions: {}", metadata.tool_executions.len());

--- a/crates/dspy-rs/src/adapter/chat.rs
+++ b/crates/dspy-rs/src/adapter/chat.rs
@@ -15,7 +15,7 @@ use tracing::{debug, trace};
 use super::Adapter;
 use crate::CallMetadata;
 use crate::{
-    BamlType, BamlValue, ConstraintLevel, ConstraintResult, FieldMeta, Flag, InputRenderSpec,
+    BamlType, BamlValue, Chat, ConstraintLevel, ConstraintResult, FieldMeta, Flag, InputRenderSpec,
     JsonishError, Message, OutputFormatContent, ParseError, PredictError, Predicted, RenderOptions,
     Signature, TypeIR,
 };
@@ -844,7 +844,7 @@ impl ChatAdapter {
             None,
             field_meta,
         );
-        Ok(Predicted::new(output, metadata))
+        Ok(Predicted::new(output, metadata, Chat::new(vec![response])))
     }
 }
 

--- a/crates/dspy-rs/src/core/lm/mod.rs
+++ b/crates/dspy-rs/src/core/lm/mod.rs
@@ -194,7 +194,10 @@ struct ToolLoopResult {
 /// Reasoning blocks are preserved in `full_content` for faithful history replay.
 enum ChoiceAction {
     /// Terminal text response (possibly preceded by reasoning).
-    Text(String),
+    Text {
+        text: String,
+        full_content: Box<rig::OneOrMany<AssistantContent>>,
+    },
     /// One or more tool calls to execute. Carries the full `OneOrMany` so
     /// reasoning blocks are preserved when we push the assistant turn into
     /// chat history. Supports parallel tool calling (Anthropic multi-tool-use,
@@ -235,7 +238,10 @@ fn classify_choice(choice: rig::OneOrMany<AssistantContent>) -> ChoiceAction {
     }
 
     if let Some(t) = text {
-        return ChoiceAction::Text(t);
+        return ChoiceAction::Text {
+            text: t,
+            full_content: Box::new(choice),
+        };
     }
 
     // Fallback: only reasoning blocks — extract display text
@@ -247,7 +253,10 @@ fn classify_choice(choice: rig::OneOrMany<AssistantContent>) -> ChoiceAction {
         })
         .collect::<Vec<_>>()
         .join("\n");
-    ChoiceAction::Text(display)
+    ChoiceAction::Text {
+        text: display,
+        full_content: Box::new(choice),
+    }
 }
 
 /// Look up a tool by name in the tool list and execute it.
@@ -277,6 +286,24 @@ impl LM {
             chat.push_message(Message::from(message.clone()));
         }
         chat
+    }
+
+    fn to_request_chat_history(
+        chat_history: Vec<rig::message::Message>,
+    ) -> Result<rig::OneOrMany<rig::message::Message>> {
+        match chat_history.len() {
+            0 => Err(anyhow::anyhow!(
+                "chat must contain at least one non-system message"
+            )),
+            1 => Ok(rig::OneOrMany::one(
+                chat_history
+                    .into_iter()
+                    .next()
+                    .ok_or_else(|| anyhow::anyhow!("chat history unexpectedly empty"))?,
+            )),
+            _ => rig::OneOrMany::many(chat_history)
+                .map_err(|_| anyhow::anyhow!("chat must contain at least one message")),
+        }
     }
 
     /// Execute all tool calls in a batch, returning results paired with their calls.
@@ -364,7 +391,6 @@ impl LM {
         system_prompt: String,
         accumulated_usage: &mut LmUsage,
     ) -> Result<ToolLoopResult> {
-        use rig::OneOrMany;
         use rig::completion::CompletionRequest;
 
         let max_iterations = self.max_tool_iterations as usize;
@@ -393,11 +419,7 @@ impl LM {
             let request = CompletionRequest {
                 model: None,
                 preamble: Some(system_prompt.clone()),
-                chat_history: if chat_history.len() == 1 {
-                    OneOrMany::one(chat_history.clone().into_iter().next().unwrap())
-                } else {
-                    OneOrMany::many(chat_history.clone()).expect("chat_history should not be empty")
-                },
+                chat_history: Self::to_request_chat_history(chat_history.clone())?,
                 documents: Vec::new(),
                 tools: tool_definitions.clone(),
                 temperature: Some(self.temperature as f64),
@@ -428,10 +450,13 @@ impl LM {
             // Scan ALL content blocks — don't just look at .first(), since
             // responses can be [Reasoning, ToolCall] or [Reasoning, Text].
             match classify_choice(response.choice) {
-                ChoiceAction::Text(text) => {
+                ChoiceAction::Text { full_content, .. } => {
                     debug!(iteration, "tool loop completed with text");
+                    let content = *full_content;
+                    let message =
+                        Message::from(rig::message::Message::Assistant { id: None, content });
                     return Ok(ToolLoopResult {
-                        message: Message::assistant(&text),
+                        message,
                         chat_history,
                         tool_calls: all_tool_calls,
                         tool_executions: all_tool_executions,
@@ -464,13 +489,8 @@ impl LM {
         Err(anyhow::anyhow!("Max tool iterations reached"))
     }
 
-    pub async fn call(&self, messages: Chat, tools: Vec<Arc<dyn ToolDyn>>) -> Result<LMResponse> {
-        self.call_with_tool_loop_mode(messages, tools, ToolLoopMode::Auto)
-            .await
-    }
-
     #[tracing::instrument(
-        name = "dsrs.lm.call_with_tool_loop_mode",
+        name = "dsrs.lm.call",
         level = "debug",
         skip(self, messages, tools),
         fields(
@@ -481,13 +501,12 @@ impl LM {
             tool_loop_mode = ?tool_loop_mode
         )
     )]
-    pub async fn call_with_tool_loop_mode(
+    pub async fn call(
         &self,
         messages: Chat,
         tools: Vec<Arc<dyn ToolDyn>>,
         tool_loop_mode: ToolLoopMode,
     ) -> Result<LMResponse> {
-        use rig::OneOrMany;
         use rig::completion::CompletionRequest;
         let system_prompt = messages.system_prompt();
         let chat_history = messages.to_rig_chat_history();
@@ -505,11 +524,7 @@ impl LM {
         let request = CompletionRequest {
             model: None,
             preamble: Some(system_prompt.clone()),
-            chat_history: if chat_history.len() == 1 {
-                OneOrMany::one(chat_history.clone().into_iter().next().unwrap())
-            } else {
-                OneOrMany::many(chat_history.clone()).expect("chat_history should not be empty")
-            },
+            chat_history: Self::to_request_chat_history(chat_history.clone())?,
             documents: Vec::new(),
             tools: tool_definitions.clone(),
             temperature: Some(self.temperature as f64),
@@ -550,7 +565,15 @@ impl LM {
         let mut append_output_after_history = false;
         let classified = classify_choice(response.choice.clone());
         let first_choice = match classified {
-            ChoiceAction::Text(text) => Message::assistant(&text),
+            ChoiceAction::Text { text, full_content } => {
+                let content = *full_content;
+                assistant_content_for_history = Some(content.clone());
+                output_override = Some(Message::from(rig::message::Message::Assistant {
+                    id: None,
+                    content,
+                }));
+                Message::assistant(&text)
+            }
             ChoiceAction::ToolCalls {
                 calls,
                 full_content,
@@ -573,20 +596,21 @@ impl LM {
                 append_output_after_history = true;
                 message
             }
-            ChoiceAction::ToolCalls { calls, .. }
-                if tool_loop_mode == ToolLoopMode::Auto && tools.is_empty() =>
-            {
+            ChoiceAction::ToolCalls {
+                calls,
+                assistant_text,
+                full_content,
+            } if tool_loop_mode == ToolLoopMode::Auto && tools.is_empty() => {
                 let names: Vec<_> = calls.iter().map(|tc| tc.function.name.as_str()).collect();
                 warn!(?names, "tools requested but no tools available");
-                let msg = format!("Tool calls requested: {:?}, but no tools available", names);
-                assistant_content_for_history = Some(rig::OneOrMany::many(
-                    calls
-                        .into_iter()
-                        .map(AssistantContent::ToolCall)
-                        .collect::<Vec<_>>(),
-                )?);
-                append_output_after_history = true;
-                Message::assistant(&msg)
+                returned_tool_calls = calls.clone();
+                let content = *full_content;
+                assistant_content_for_history = Some(content.clone());
+                output_override = Some(Message::from(rig::message::Message::Assistant {
+                    id: None,
+                    content,
+                }));
+                Message::assistant(assistant_text.unwrap_or_default())
             }
             ChoiceAction::ToolCalls {
                 calls,
@@ -810,7 +834,10 @@ mod tests {
     fn classify_text_only() {
         let choice = OneOrMany::one(make_text("hello"));
         match classify_choice(choice) {
-            ChoiceAction::Text(t) => assert_eq!(t, "hello"),
+            ChoiceAction::Text { text, full_content } => {
+                assert_eq!(text, "hello");
+                assert_eq!(full_content.iter().count(), 1);
+            }
             ChoiceAction::ToolCalls { .. } => panic!("expected Text, got ToolCalls"),
         }
     }
@@ -829,7 +856,7 @@ mod tests {
                 assert_eq!(full_content.iter().count(), 1);
                 assert!(assistant_text.is_none());
             }
-            ChoiceAction::Text(_) => panic!("expected ToolCalls, got Text"),
+            ChoiceAction::Text { .. } => panic!("expected ToolCalls, got Text"),
         }
     }
 
@@ -853,7 +880,7 @@ mod tests {
                 assert_eq!(full_content.iter().count(), 2);
                 assert!(assistant_text.is_none());
             }
-            ChoiceAction::Text(_) => panic!("expected ToolCalls, got Text"),
+            ChoiceAction::Text { .. } => panic!("expected ToolCalls, got Text"),
         }
     }
 
@@ -866,7 +893,10 @@ mod tests {
         .unwrap();
 
         match classify_choice(choice) {
-            ChoiceAction::Text(t) => assert_eq!(t, "the answer is 42"),
+            ChoiceAction::Text { text, full_content } => {
+                assert_eq!(text, "the answer is 42");
+                assert_eq!(full_content.iter().count(), 2);
+            }
             ChoiceAction::ToolCalls { .. } => panic!("expected Text, got ToolCalls"),
         }
     }
@@ -875,7 +905,10 @@ mod tests {
     fn classify_reasoning_only_fallback() {
         let choice = OneOrMany::one(make_reasoning("just thinking"));
         match classify_choice(choice) {
-            ChoiceAction::Text(t) => assert_eq!(t, "just thinking"),
+            ChoiceAction::Text { text, full_content } => {
+                assert_eq!(text, "just thinking");
+                assert_eq!(full_content.iter().count(), 1);
+            }
             ChoiceAction::ToolCalls { .. } => panic!("expected Text, got ToolCalls"),
         }
     }
@@ -895,7 +928,7 @@ mod tests {
                 assert_eq!(calls[0].function.name, "search");
                 assert_eq!(assistant_text.as_deref(), Some("some text"));
             }
-            ChoiceAction::Text(_) => panic!("expected ToolCalls, got Text"),
+            ChoiceAction::Text { .. } => panic!("expected ToolCalls, got Text"),
         }
     }
 
@@ -920,7 +953,7 @@ mod tests {
                 assert_eq!(full_content.iter().count(), 3);
                 assert!(assistant_text.is_none());
             }
-            ChoiceAction::Text(_) => panic!("expected ToolCalls, got Text"),
+            ChoiceAction::Text { .. } => panic!("expected ToolCalls, got Text"),
         }
     }
 
@@ -930,7 +963,10 @@ mod tests {
             rig::completion::message::Image::default(),
         ));
         match classify_choice(choice) {
-            ChoiceAction::Text(t) => assert!(t.is_empty()),
+            ChoiceAction::Text { text, full_content } => {
+                assert!(text.is_empty());
+                assert_eq!(full_content.iter().count(), 1);
+            }
             ChoiceAction::ToolCalls { .. } => panic!("expected Text, got ToolCalls"),
         }
     }
@@ -1000,7 +1036,7 @@ mod tests {
 
         let chat = Chat::new(vec![Message::user("Use the counter tool")]);
         let response = lm
-            .call_with_tool_loop_mode(chat, tools, ToolLoopMode::CallerManaged)
+            .call(chat, tools, ToolLoopMode::CallerManaged)
             .await
             .expect("caller-managed call should succeed");
 
@@ -1025,7 +1061,7 @@ mod tests {
 
         let chat = Chat::new(vec![Message::user("Use the counter tool")]);
         let response = lm
-            .call(chat, tools)
+            .call(chat, tools, ToolLoopMode::Auto)
             .await
             .expect("auto call should succeed");
 
@@ -1037,5 +1073,57 @@ mod tests {
         assert!(response.chat.messages[1].has_tool_calls());
         assert!(response.chat.messages[2].has_tool_results());
         assert_eq!(response.chat.messages[3].role, Role::Assistant);
+    }
+
+    #[tokio::test]
+    async fn call_auto_mode_with_no_tools_returns_requested_tool_calls() {
+        let model = TestCompletionModel::new([make_tool_call("counter")]);
+        let lm = test_lm_with_model(model);
+
+        let chat = Chat::new(vec![Message::user("Use the counter tool")]);
+        let response = lm
+            .call(chat, vec![], ToolLoopMode::Auto)
+            .await
+            .expect("auto call should succeed");
+
+        assert_eq!(response.tool_calls.len(), 1);
+        assert_eq!(response.tool_calls[0].function.name, "counter");
+        assert!(response.tool_executions.is_empty());
+        assert!(response.chat.messages.iter().any(Message::has_tool_calls));
+    }
+
+    #[test]
+    fn text_choice_with_reasoning_preserves_grouped_content_for_output_conversion() {
+        let choice = OneOrMany::many(vec![make_reasoning("thinking"), make_text("done")]).unwrap();
+
+        let (text, full_content) = match classify_choice(choice) {
+            ChoiceAction::Text { text, full_content } => (text, full_content),
+            ChoiceAction::ToolCalls { .. } => panic!("expected Text, got ToolCalls"),
+        };
+
+        assert_eq!(text, "done");
+
+        let output = Message::from(rig::message::Message::Assistant {
+            id: None,
+            content: *full_content,
+        });
+        assert!(output.has_reasoning());
+        assert_eq!(output.text_content(), "done");
+    }
+
+    #[tokio::test]
+    async fn call_with_only_system_message_returns_error() {
+        let model = TestCompletionModel::new([make_text("unused")]);
+        let lm = test_lm_with_model(model);
+        let chat = Chat::new(vec![Message::system("system only")]);
+
+        let err = lm
+            .call(chat, vec![], ToolLoopMode::Auto)
+            .await
+            .expect_err("system-only chat should fail");
+        assert!(
+            err.to_string()
+                .contains("chat must contain at least one non-system message")
+        );
     }
 }

--- a/crates/dspy-rs/src/core/mod.rs
+++ b/crates/dspy-rs/src/core/mod.rs
@@ -7,7 +7,8 @@
 //! input, returns a predicted output) so that strategies are interchangeable.
 //!
 //! [`Predicted`] wraps a typed output with [`CallMetadata`] (raw response text, token
-//! usage, per-field parse results). The error hierarchy — [`PredictError`], [`ParseError`],
+//! usage, per-field parse results) and [`Chat`] (the conversation history from the LM
+//! call). The error hierarchy — [`PredictError`], [`ParseError`],
 //! [`LmError`] — distinguishes LM failures from parse failures so callers can handle
 //! retries differently. [`LM`] is the language model client itself.
 //!

--- a/crates/dspy-rs/src/core/module.rs
+++ b/crates/dspy-rs/src/core/module.rs
@@ -17,13 +17,15 @@ type IndexedForwardResult<T> = (usize, Result<Predicted<T>, PredictError>);
 /// implementors. `call` currently just delegates to `forward` — the split exists so we
 /// can add hooks or tracing around `call` without breaking module implementations.
 ///
-/// # Two kinds of output data
+/// # Three kinds of output data
 ///
 /// Every call returns [`Predicted<Output>`](crate::Predicted), which carries:
 /// - **`Output`** — what the LM was asked to produce. Shaped by your signature and any
 ///   augmentations. Accessible directly via `Deref`: `result.answer`, `result.reasoning`.
 /// - **[`CallMetadata`](crate::CallMetadata)** — what the runtime observed. Token counts,
 ///   raw response, constraint results. Never enters a prompt. Via `result.metadata()`.
+/// - **[`Chat`](crate::Chat)** — conversation history for the call, including the assistant
+///   response turn, so callers can continue multi-turn interactions via `result.chat()`.
 ///
 /// This drives the type system: [`ChainOfThought`](crate::ChainOfThought) changes `Output`
 /// because it modifies the prompt (adds a `reasoning` field). A wrapper like `BestOfN` keeps

--- a/crates/dspy-rs/src/core/module_ext.rs
+++ b/crates/dspy-rs/src/core/module_ext.rs
@@ -77,8 +77,8 @@ where
 
     async fn forward(&self, input: Self::Input) -> Result<Predicted<Self::Output>, PredictError> {
         let predicted = self.inner.call(input).await?;
-        let (output, metadata) = predicted.into_parts();
-        Ok(Predicted::new((self.map)(output), metadata))
+        let (output, metadata, chat) = predicted.into_parts();
+        Ok(Predicted::new((self.map)(output), metadata, chat))
     }
 }
 
@@ -107,8 +107,8 @@ where
 
     async fn forward(&self, input: Self::Input) -> Result<Predicted<Self::Output>, PredictError> {
         let predicted = self.inner.call(input).await?;
-        let (output, metadata) = predicted.into_parts();
+        let (output, metadata, chat) = predicted.into_parts();
         let transformed = (self.and_then)(output)?;
-        Ok(Predicted::new(transformed, metadata))
+        Ok(Predicted::new(transformed, metadata, chat))
     }
 }

--- a/crates/dspy-rs/src/modules/react.rs
+++ b/crates/dspy-rs/src/modules/react.rs
@@ -158,7 +158,7 @@ where
                 ReActActionStepInput::new(serialized_input.clone(), trajectory_text.clone());
 
             let action_predicted = self.action.call(action_input).await?;
-            let (action_output, mut action_metadata) = action_predicted.into_parts();
+            let (action_output, mut action_metadata, _action_chat) = action_predicted.into_parts();
             tool_calls.append(&mut action_metadata.tool_calls);
             tool_executions.append(&mut action_metadata.tool_executions);
 
@@ -220,12 +220,16 @@ where
         let extract_input = ReActExtractStepInput::new(serialized_input, trajectory_text);
 
         let extract_predicted = self.extract.call(extract_input).await?;
-        let (extract_output, mut extract_metadata) = extract_predicted.into_parts();
+        let (extract_output, mut extract_metadata, extract_chat) = extract_predicted.into_parts();
         extract_metadata.tool_calls.extend(tool_calls);
         extract_metadata.tool_executions.extend(tool_executions);
 
         let output: ReActExtractStepOutput<S::Output> = extract_output;
-        Ok(Predicted::new(output.output, extract_metadata))
+        Ok(Predicted::new(
+            output.output,
+            extract_metadata,
+            extract_chat,
+        ))
     }
 }
 

--- a/crates/dspy-rs/src/optimizer/copro.rs
+++ b/crates/dspy-rs/src/optimizer/copro.rs
@@ -216,7 +216,7 @@ mod tests {
 
     use super::*;
     use crate::evaluate::{MetricOutcome, TypedMetric};
-    use crate::{CallMetadata, Predict, PredictError, Predicted, Signature};
+    use crate::{CallMetadata, Chat, Predict, PredictError, Predicted, Signature};
 
     #[derive(Signature, Clone, Debug)]
     struct CoproStateSig {
@@ -246,6 +246,7 @@ mod tests {
                     answer: input.prompt,
                 },
                 CallMetadata::default(),
+                Chat::new(vec![]),
             ))
         }
     }

--- a/crates/dspy-rs/src/optimizer/gepa.rs
+++ b/crates/dspy-rs/src/optimizer/gepa.rs
@@ -506,7 +506,7 @@ mod tests {
 
     use super::*;
     use crate::evaluate::{MetricOutcome, TypedMetric};
-    use crate::{CallMetadata, Predict, PredictError, Predicted, Signature};
+    use crate::{CallMetadata, Chat, Predict, PredictError, Predicted, Signature};
 
     #[derive(Signature, Clone, Debug)]
     struct GepaStateSig {
@@ -536,6 +536,7 @@ mod tests {
                     answer: input.prompt,
                 },
                 CallMetadata::default(),
+                Chat::new(vec![]),
             ))
         }
     }

--- a/crates/dspy-rs/src/optimizer/mipro.rs
+++ b/crates/dspy-rs/src/optimizer/mipro.rs
@@ -184,7 +184,7 @@ impl MIPROv2 {
             let input = example.input.clone();
             let predicted = module.call(input).await.map_err(|err| anyhow!("{err}"))?;
             let outcome = metric.evaluate(example, &predicted).await?;
-            let (output, _) = predicted.into_parts();
+            let (output, _, _) = predicted.into_parts();
             traces.push(Trace::new(
                 example.input.clone(),
                 output.to_baml_value(),
@@ -417,7 +417,7 @@ mod tests {
 
     use super::*;
     use crate::evaluate::{MetricOutcome, TypedMetric};
-    use crate::{CallMetadata, Predict, PredictError, Predicted, Signature};
+    use crate::{CallMetadata, Chat, Predict, PredictError, Predicted, Signature};
 
     #[derive(Signature, Clone, Debug)]
     struct MiproStateSig {
@@ -447,6 +447,7 @@ mod tests {
                     answer: input.prompt,
                 },
                 CallMetadata::default(),
+                Chat::new(vec![]),
             ))
         }
     }

--- a/crates/dspy-rs/tests/test_call_outcome.rs
+++ b/crates/dspy-rs/tests/test_call_outcome.rs
@@ -1,5 +1,5 @@
 use dspy_rs::{
-    CallMetadata, ConstraintResult, FieldMeta, LmUsage, ParseError, PredictError, Predicted,
+    CallMetadata, Chat, ConstraintResult, FieldMeta, LmUsage, ParseError, PredictError, Predicted,
 };
 use indexmap::IndexMap;
 
@@ -60,7 +60,7 @@ fn predicted_exposes_field_metadata() {
         field_meta,
     );
 
-    let predicted = Predicted::new("Paris".to_string(), metadata);
+    let predicted = Predicted::new("Paris".to_string(), metadata, Chat::new(vec![]));
     assert_eq!(predicted.metadata().field_raw("answer"), Some("Paris"));
     assert!(!predicted.metadata().has_failed_checks());
 

--- a/crates/dspy-rs/tests/test_caller_managed_conversation.rs
+++ b/crates/dspy-rs/tests/test_caller_managed_conversation.rs
@@ -81,10 +81,11 @@ async fn caller_managed_tool_loop_with_conversation() {
     };
 
     // Turn 1
-    let (first_result, chat) = predict
+    let first_result = predict
         .forward(input, None)
         .await
         .expect("first turn forward should succeed");
+    let chat = first_result.chat().clone();
     assert_eq!(
         first_result.into_inner().result,
         "Need to execute code first"
@@ -94,10 +95,11 @@ async fn caller_managed_tool_loop_with_conversation() {
     let follow_up = CodeExecInput {
         prompt: "Tool output: 42".to_string(),
     };
-    let (second_result, final_chat) = predict
+    let second_result = predict
         .forward(follow_up, Some(chat))
         .await
         .expect("second turn forward should succeed");
+    let final_chat = second_result.chat().clone();
     assert_eq!(second_result.into_inner().result, "42");
 
     // Verify chat grew across turns
@@ -136,7 +138,7 @@ async fn lm_caller_managed_returns_tool_calls_in_chat_history() {
 
     let chat = dspy_rs::Chat::new(vec![Message::user("Run some code")]);
     let response = lm
-        .call_with_tool_loop_mode(chat, vec![], ToolLoopMode::CallerManaged)
+        .call(chat, vec![], ToolLoopMode::CallerManaged)
         .await
         .expect("caller-managed call should succeed");
 
@@ -175,7 +177,8 @@ async fn parse_failure_on_second_turn_includes_correct_raw_response() {
     };
 
     // Turn 1: succeeds
-    let (first_result, chat) = predict.forward(input, None).await.expect("turn 1");
+    let first_result = predict.forward(input, None).await.expect("turn 1");
+    let chat = first_result.chat().clone();
     assert_eq!(first_result.into_inner().result, "first answer");
 
     // Turn 2: should fail with parse error containing the bad response

--- a/crates/dspy-rs/tests/test_chat.rs
+++ b/crates/dspy-rs/tests/test_chat.rs
@@ -67,22 +67,14 @@ fn test_chat_to_json_and_back() {
 }
 
 #[rstest]
-fn test_chat_from_legacy_json() {
-    // Legacy format: "content" is a plain string
+fn test_chat_from_json_requires_grouped_content() {
     let json = json!([
         {"role":"system","content":"You are a helpful assistant."},
         {"role":"user","content":"Hello, world!"},
         {"role":"assistant","content":"Hello, world to you!"}
     ]);
-    let chat = Chat::new(vec![]).from_json(json).unwrap();
-
-    assert_eq!(chat.len(), 3);
-    assert_eq!(chat.messages[0].role, Role::System);
-    assert_eq!(chat.messages[0].content(), "You are a helpful assistant.");
-    assert_eq!(chat.messages[1].role, Role::User);
-    assert_eq!(chat.messages[1].content(), "Hello, world!");
-    assert_eq!(chat.messages[2].role, Role::Assistant);
-    assert_eq!(chat.messages[2].content(), "Hello, world to you!");
+    let err = Chat::new(vec![]).from_json(json).unwrap_err();
+    assert!(err.to_string().contains("content must be an array"));
 }
 
 #[rstest]

--- a/crates/dspy-rs/tests/test_chat.rs
+++ b/crates/dspy-rs/tests/test_chat.rs
@@ -28,7 +28,7 @@ fn test_chat_init() {
 #[rstest]
 fn test_chat_push() {
     let mut chat = Chat::new(vec![]);
-    chat.push("user", "Hello, world!");
+    chat.push(Role::User, "Hello, world!");
 
     assert_eq!(chat.len(), 1);
     assert_eq!(chat.messages[0].role, Role::User);
@@ -38,7 +38,7 @@ fn test_chat_push() {
 #[rstest]
 fn test_chat_pop() {
     let mut chat = Chat::new(vec![]);
-    chat.push("user", "Hello, world!");
+    chat.push(Role::User, "Hello, world!");
     chat.pop();
 
     assert_eq!(chat.len(), 0);
@@ -159,28 +159,6 @@ fn test_new_variants_round_trip_json() {
 }
 
 #[rstest]
-fn test_system_prompt_and_rig_chat_history() {
-    let chat = Chat::new(vec![
-        Message::system("Be helpful"),
-        Message::user("Hello"),
-        Message::assistant("Hi!"),
-    ]);
-
-    assert_eq!(chat.system_prompt(), "Be helpful");
-    let history = chat.to_rig_chat_history();
-    assert_eq!(history.len(), 2); // system excluded
-}
-
-#[rstest]
-fn test_empty_chat_system_prompt_and_rig_history() {
-    let chat = Chat::new(vec![]);
-
-    assert_eq!(chat.system_prompt(), "");
-    let history = chat.to_rig_chat_history();
-    assert!(history.is_empty());
-}
-
-#[rstest]
 fn test_from_rig_message_preserves_all_content() {
     // User with text + tool result — both preserved
     let user_msg = RigMessage::User {
@@ -224,38 +202,6 @@ fn test_from_rig_message_preserves_all_content() {
     assert_eq!(converted.content.len(), 2);
     assert!(converted.has_reasoning());
     assert!(converted.has_tool_calls());
-}
-
-#[rstest]
-fn test_rig_round_trip_preserves_grouped_content() {
-    // Create a grouped assistant message with reasoning + tool call
-    let original_rig = RigMessage::Assistant {
-        id: None,
-        content: OneOrMany::many(vec![
-            AssistantContent::Reasoning(Reasoning::new("thinking")),
-            AssistantContent::ToolCall(ToolCall::new(
-                "tc-1".to_string(),
-                ToolFunction {
-                    name: "search".to_string(),
-                    arguments: json!({"q": "rust"}),
-                },
-            )),
-        ])
-        .unwrap(),
-    };
-
-    // Convert to DSRs Message
-    let dsrs_msg = Message::from(original_rig);
-    assert_eq!(dsrs_msg.content.len(), 2);
-
-    // Convert back to rig message
-    let round_tripped = dsrs_msg.to_rig_message().unwrap();
-    match round_tripped {
-        RigMessage::Assistant { content, .. } => {
-            assert_eq!(content.iter().count(), 2); // Both blocks preserved!
-        }
-        _ => panic!("expected assistant message"),
-    }
 }
 
 #[rstest]

--- a/crates/dspy-rs/tests/test_chat_adapter_schema.rs
+++ b/crates/dspy-rs/tests/test_chat_adapter_schema.rs
@@ -1,4 +1,4 @@
-use dspy_rs::{CallMetadata, ChatAdapter, Message, Predicted, Signature};
+use dspy_rs::{CallMetadata, Chat, ChatAdapter, Message, Predicted, Signature};
 
 #[derive(Signature, Clone, Debug)]
 /// Adapter schema parse fixture.
@@ -42,7 +42,7 @@ fn parse_response_typed_uses_schema_field_names() {
         None,
         field_meta,
     );
-    let predicted = Predicted::new(output, metadata);
+    let predicted = Predicted::new(output, metadata, Chat::new(vec![]));
 
     assert_eq!(predicted.metadata().field_raw("answer"), Some("Paris"));
     assert!(!predicted.metadata().has_failed_checks());

--- a/crates/dspy-rs/tests/test_dataloader.rs
+++ b/crates/dspy-rs/tests/test_dataloader.rs
@@ -4,7 +4,7 @@ use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
 use bon::Builder;
 use dspy_rs::{
-    COPRO, CallMetadata, DataLoader, Example, MetricOutcome, Module, Optimizer, Predict,
+    COPRO, CallMetadata, Chat, DataLoader, Example, MetricOutcome, Module, Optimizer, Predict,
     PredictError, Predicted, Signature, TypedLoadOptions, TypedMetric, UnknownFieldPolicy,
     average_score, evaluate_trainset,
 };
@@ -54,6 +54,7 @@ impl Module for EchoModule {
                 answer: input.question,
             },
             CallMetadata::default(),
+            Chat::new(vec![]),
         ))
     }
 }

--- a/crates/dspy-rs/tests/test_evaluate_trainset_typed.rs
+++ b/crates/dspy-rs/tests/test_evaluate_trainset_typed.rs
@@ -1,7 +1,7 @@
 use anyhow::{Result, anyhow};
 use dspy_rs::{
-    CallMetadata, Example, MetricOutcome, Module, PredictError, Predicted, Signature, TypedMetric,
-    average_score, evaluate_trainset,
+    CallMetadata, Chat, Example, MetricOutcome, Module, PredictError, Predicted, Signature,
+    TypedMetric, average_score, evaluate_trainset,
 };
 use std::sync::{Arc, Mutex};
 
@@ -26,6 +26,7 @@ impl Module for EchoModule {
                 answer: input.prompt,
             },
             CallMetadata::default(),
+            Chat::new(vec![]),
         ))
     }
 }

--- a/crates/dspy-rs/tests/test_gepa_typed_metric_feedback.rs
+++ b/crates/dspy-rs/tests/test_gepa_typed_metric_feedback.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use dspy_rs::{
-    CallMetadata, Example, FeedbackMetric, GEPA, MetricOutcome, Module, Optimizer, Predict,
+    CallMetadata, Chat, Example, FeedbackMetric, GEPA, MetricOutcome, Module, Optimizer, Predict,
     PredictError, Predicted, Signature, TypedMetric,
 };
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -35,6 +35,7 @@ impl Module for InstructionEchoModule {
                 answer: input.prompt,
             },
             CallMetadata::default(),
+            Chat::new(vec![]),
         ))
     }
 }

--- a/crates/dspy-rs/tests/test_message_roundtrip.rs
+++ b/crates/dspy-rs/tests/test_message_roundtrip.rs
@@ -227,20 +227,17 @@ fn grouped_message_json_roundtrip() {
     assert!(user.has_tool_results());
 }
 
-/// Legacy JSON format (content as plain string) still parses correctly.
+/// Legacy JSON format (content as plain string) is rejected.
 #[test]
-fn legacy_plain_string_json_parses_into_new_model() {
+fn legacy_plain_string_json_is_rejected() {
     let legacy_json = json!([
         {"role": "system", "content": "Be helpful"},
         {"role": "user", "content": "Hello"},
         {"role": "assistant", "content": "Hi there!"}
     ]);
 
-    let chat = Chat::new(vec![]).from_json(legacy_json).unwrap();
-    assert_eq!(chat.len(), 3);
-    assert_eq!(chat.messages[0].role, Role::System);
-    assert_eq!(chat.messages[0].content(), "Be helpful");
-    assert_eq!(chat.messages[2].text_content(), "Hi there!");
+    let err = Chat::new(vec![]).from_json(legacy_json).unwrap_err();
+    assert!(err.to_string().contains("content must be an array"));
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/dspy-rs/tests/test_message_roundtrip.rs
+++ b/crates/dspy-rs/tests/test_message_roundtrip.rs
@@ -1,182 +1,14 @@
-//! Round-trip tests for the new Message model.
+//! Public-API tests for the grouped Message model.
 //!
-//! Verifies that the grouped Role + ContentBlock representation preserves
-//! all content through: DSRs Message → rig Message → DSRs Message, and
-//! through JSON serialization/deserialization.
+//! These tests validate message/content behavior through stable public methods
+//! (`to_json`/`from_json`, content accessors) without calling crate-internal
+//! rig conversion helpers.
 
-use dspy_rs::core::lm::chat::{Chat, ContentBlock, Message, Role};
+use dspy_rs::{Chat, ContentBlock, Message, Role};
 use rig::OneOrMany;
-use rig::message::{
-    Message as RigMessage, Reasoning, ToolCall, ToolFunction, ToolResult, ToolResultContent,
-};
+use rig::message::{Reasoning, ToolCall, ToolFunction, ToolResult, ToolResultContent};
 use serde_json::json;
 
-// ---------------------------------------------------------------------------
-// Reasoning continuity round-trip
-// ---------------------------------------------------------------------------
-
-/// Anthropic's thinking turns produce [Reasoning, Reasoning, ToolCall] in a
-/// single assistant turn. The entire chain of thought must survive:
-///   DSRs Message → rig → DSRs Message
-#[test]
-fn reasoning_chain_survives_rig_roundtrip() {
-    let original = Message::with_content(
-        Role::Assistant,
-        vec![
-            ContentBlock::reasoning(Reasoning::new("step 1: analyze the query")),
-            ContentBlock::reasoning(Reasoning::new("step 2: plan the search")),
-            ContentBlock::tool_call(ToolCall::new(
-                "tc-1".to_string(),
-                ToolFunction {
-                    name: "search".to_string(),
-                    arguments: json!({"q": "rust ownership"}),
-                },
-            )),
-        ],
-    );
-
-    // Forward: DSRs → rig
-    let rig_msg = original
-        .to_rig_message()
-        .expect("assistant message should convert to rig");
-
-    // Backward: rig → DSRs
-    let roundtripped = Message::from(rig_msg);
-
-    assert_eq!(roundtripped.role, Role::Assistant);
-    assert_eq!(
-        roundtripped.content.len(),
-        3,
-        "all three content blocks must survive: got {:?}",
-        roundtripped.content
-    );
-
-    assert!(
-        matches!(&roundtripped.content[0], ContentBlock::Reasoning { reasoning } if reasoning.display_text().contains("step 1")),
-        "first reasoning block lost"
-    );
-    assert!(
-        matches!(&roundtripped.content[1], ContentBlock::Reasoning { reasoning } if reasoning.display_text().contains("step 2")),
-        "second reasoning block lost"
-    );
-    assert!(
-        matches!(&roundtripped.content[2], ContentBlock::ToolCall { tool_call } if tool_call.function.name == "search"),
-        "tool call lost"
-    );
-}
-
-/// A reasoning-only assistant turn (no text, no tool call) must round-trip.
-#[test]
-fn reasoning_only_turn_roundtrips() {
-    let original = Message::with_content(
-        Role::Assistant,
-        vec![ContentBlock::reasoning(Reasoning::new(
-            "just thinking out loud",
-        ))],
-    );
-
-    let rig_msg = original.to_rig_message().unwrap();
-    let roundtripped = Message::from(rig_msg);
-
-    assert_eq!(roundtripped.role, Role::Assistant);
-    assert_eq!(roundtripped.content.len(), 1);
-    assert!(roundtripped.has_reasoning());
-    assert!(!roundtripped.has_tool_calls());
-}
-
-// ---------------------------------------------------------------------------
-// Multi-content user messages
-// ---------------------------------------------------------------------------
-
-/// A user message with both text and a tool result must preserve both.
-#[test]
-fn user_text_plus_tool_result_roundtrips() {
-    let original = Message::with_content(
-        Role::User,
-        vec![
-            ContentBlock::text("Here is context"),
-            ContentBlock::tool_result(ToolResult {
-                id: "tr-1".to_string(),
-                call_id: Some("tc-1".to_string()),
-                content: OneOrMany::one(ToolResultContent::text("search result")),
-            }),
-        ],
-    );
-
-    let rig_msg = original.to_rig_message().unwrap();
-    let roundtripped = Message::from(rig_msg);
-
-    assert_eq!(roundtripped.role, Role::User);
-    assert_eq!(
-        roundtripped.content.len(),
-        2,
-        "both text and tool result must survive"
-    );
-    assert!(matches!(
-        &roundtripped.content[0],
-        ContentBlock::Text { text } if text == "Here is context"
-    ));
-    assert!(roundtripped.has_tool_results());
-}
-
-// ---------------------------------------------------------------------------
-// Multi-turn conversation with reasoning in history
-// ---------------------------------------------------------------------------
-
-/// Build a multi-turn conversation where an earlier assistant turn has
-/// reasoning blocks. Convert the full chat to rig format and back.
-/// The reasoning from earlier turns must be preserved.
-#[test]
-fn multi_turn_conversation_preserves_earlier_reasoning() {
-    let chat = Chat::new(vec![
-        Message::system("You are a helpful assistant."),
-        Message::user("What is the capital of France?"),
-        // Turn 1 reply: reasoning + text answer
-        Message::with_content(
-            Role::Assistant,
-            vec![
-                ContentBlock::reasoning(Reasoning::new("The user is asking about geography.")),
-                ContentBlock::text("The capital of France is Paris."),
-            ],
-        ),
-        // User follow-up
-        Message::user("And Germany?"),
-        // Turn 2 reply: just text
-        Message::assistant("The capital of Germany is Berlin."),
-    ]);
-
-    // Convert to rig and back
-    let rig_history = chat.to_rig_chat_history();
-    // rig_history should have 4 messages (system excluded)
-    assert_eq!(rig_history.len(), 4);
-
-    // Reconstruct from rig history
-    let mut reconstructed = Chat::new(vec![Message::system(chat.system_prompt())]);
-    for rig_msg in rig_history {
-        reconstructed.push_message(Message::from(rig_msg));
-    }
-
-    assert_eq!(reconstructed.len(), 5);
-
-    // Verify turn 1's reasoning survived
-    let turn1_reply = &reconstructed.messages[2];
-    assert_eq!(turn1_reply.role, Role::Assistant);
-    assert!(
-        turn1_reply.has_reasoning(),
-        "turn 1 reasoning must survive rig round-trip"
-    );
-    assert_eq!(
-        turn1_reply.content.len(),
-        2,
-        "turn 1 must have both reasoning and text"
-    );
-}
-
-// ---------------------------------------------------------------------------
-// JSON serialization round-trip
-// ---------------------------------------------------------------------------
-
-/// Full multi-content message survives JSON serialization.
 #[test]
 fn grouped_message_json_roundtrip() {
     let original = Chat::new(vec![
@@ -213,21 +45,43 @@ fn grouped_message_json_roundtrip() {
 
     assert_eq!(reparsed.len(), 3);
 
-    // Verify the assistant message preserved all 3 content blocks
     let asst = &reparsed.messages[1];
     assert_eq!(asst.role, Role::Assistant);
     assert_eq!(asst.content.len(), 3);
     assert!(asst.has_reasoning());
     assert!(asst.has_tool_calls());
 
-    // Verify the user message preserved both blocks
     let user = &reparsed.messages[2];
     assert_eq!(user.role, Role::User);
     assert_eq!(user.content.len(), 2);
     assert!(user.has_tool_results());
 }
 
-/// Legacy JSON format (content as plain string) is rejected.
+#[test]
+fn multi_turn_json_roundtrip_preserves_earlier_reasoning() {
+    let chat = Chat::new(vec![
+        Message::system("You are a helpful assistant."),
+        Message::user("What is the capital of France?"),
+        Message::with_content(
+            Role::Assistant,
+            vec![
+                ContentBlock::reasoning(Reasoning::new("The user is asking about geography.")),
+                ContentBlock::text("The capital of France is Paris."),
+            ],
+        ),
+        Message::user("And Germany?"),
+        Message::assistant("The capital of Germany is Berlin."),
+    ]);
+
+    let reparsed = Chat::new(vec![]).from_json(chat.to_json()).unwrap();
+    assert_eq!(reparsed.len(), 5);
+
+    let turn1_reply = &reparsed.messages[2];
+    assert_eq!(turn1_reply.role, Role::Assistant);
+    assert!(turn1_reply.has_reasoning());
+    assert_eq!(turn1_reply.content.len(), 2);
+}
+
 #[test]
 fn legacy_plain_string_json_is_rejected() {
     let legacy_json = json!([
@@ -239,10 +93,6 @@ fn legacy_plain_string_json_is_rejected() {
     let err = Chat::new(vec![]).from_json(legacy_json).unwrap_err();
     assert!(err.to_string().contains("content must be an array"));
 }
-
-// ---------------------------------------------------------------------------
-// Accessor correctness
-// ---------------------------------------------------------------------------
 
 #[test]
 fn text_content_excludes_non_text_blocks() {
@@ -262,7 +112,6 @@ fn text_content_excludes_non_text_blocks() {
     );
 
     assert_eq!(msg.text_content(), "visible answer");
-    // content() includes everything
     let full = msg.content();
     assert!(full.contains("internal monologue"));
     assert!(full.contains("visible answer"));
@@ -298,11 +147,6 @@ fn tool_calls_accessor_returns_all_tool_calls() {
     assert_eq!(calls[1].function.name, "calculate");
 }
 
-// ---------------------------------------------------------------------------
-// Edge cases
-// ---------------------------------------------------------------------------
-
-/// Empty content vec (pathological) should not panic.
 #[test]
 fn empty_content_message_does_not_panic() {
     let msg = Message::with_content(Role::Assistant, vec![]);
@@ -310,33 +154,16 @@ fn empty_content_message_does_not_panic() {
     assert_eq!(msg.text_content(), "");
     assert!(!msg.has_tool_calls());
     assert!(!msg.has_reasoning());
-
-    // Rig conversion should produce an assistant message with empty text
-    let rig_msg = msg.to_rig_message().unwrap();
-    match rig_msg {
-        RigMessage::Assistant { content, .. } => {
-            assert_eq!(content.iter().count(), 1); // empty text fallback
-        }
-        _ => panic!("expected assistant message"),
-    }
 }
 
-/// System messages return None from to_rig_message (handled as preamble).
 #[test]
-fn system_message_excluded_from_rig_conversion() {
-    let msg = Message::system("You are helpful");
-    assert!(msg.to_rig_message().is_none());
-}
-
-/// Message ID (e.g. Anthropic thinking turn IDs) survives round-trip.
-#[test]
-fn message_id_survives_rig_roundtrip() {
+fn message_id_survives_json_roundtrip() {
     let mut msg = Message::assistant("some text");
     msg.id = Some("msg_abc123".to_string());
 
-    let rig_msg = msg.to_rig_message().unwrap();
-    let roundtripped = Message::from(rig_msg);
+    let chat = Chat::new(vec![msg]);
+    let reparsed = Chat::new(vec![]).from_json(chat.to_json()).unwrap();
 
-    // Note: rig's User messages don't carry IDs, but Assistant messages do
-    assert_eq!(roundtripped.id, Some("msg_abc123".to_string()));
+    assert_eq!(reparsed.messages.len(), 1);
+    assert_eq!(reparsed.messages[0].id, Some("msg_abc123".to_string()));
 }

--- a/crates/dspy-rs/tests/test_module_ext.rs
+++ b/crates/dspy-rs/tests/test_module_ext.rs
@@ -1,4 +1,6 @@
-use dspy_rs::{BamlType, CallMetadata, Module, ModuleExt, ParseError, PredictError, Predicted};
+use dspy_rs::{
+    BamlType, CallMetadata, Chat, Module, ModuleExt, ParseError, PredictError, Predicted,
+};
 
 struct MaybeFails;
 
@@ -44,6 +46,7 @@ impl Module for MaybeFails {
                     value: input_value * 2,
                 },
                 metadata,
+                Chat::new(vec![]),
             ))
         }
     }

--- a/crates/dspy-rs/tests/test_module_forward_all.rs
+++ b/crates/dspy-rs/tests/test_module_forward_all.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use dspy_rs::{BamlType, CallMetadata, Module, PredictError, Predicted, forward_all};
+use dspy_rs::{BamlType, CallMetadata, Chat, Module, PredictError, Predicted, forward_all};
 use tokio::time::sleep;
 
 struct DelayEcho;
@@ -27,6 +27,7 @@ impl Module for DelayEcho {
         Ok(Predicted::new(
             DelayOutput { value: input.value },
             CallMetadata::default(),
+            Chat::new(vec![]),
         ))
     }
 }

--- a/crates/dspy-rs/tests/test_optimizer_named_parameters_integration.rs
+++ b/crates/dspy-rs/tests/test_optimizer_named_parameters_integration.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use dspy_rs::{
-    COPRO, CallMetadata, Example, MetricOutcome, Module, Optimizer, Predict, PredictError,
+    COPRO, CallMetadata, Chat, Example, MetricOutcome, Module, Optimizer, Predict, PredictError,
     Predicted, Signature, TypedMetric,
 };
 
@@ -33,6 +33,7 @@ impl Module for InstructionEchoModule {
                 answer: input.prompt,
             },
             CallMetadata::default(),
+            Chat::new(vec![]),
         ))
     }
 }

--- a/crates/dspy-rs/tests/test_optimizer_typed_metric.rs
+++ b/crates/dspy-rs/tests/test_optimizer_typed_metric.rs
@@ -1,7 +1,7 @@
 use anyhow::{Result, anyhow};
 use dspy_rs::{
-    COPRO, CallMetadata, Example, MIPROv2, MetricOutcome, Module, Optimizer, Predict, PredictError,
-    Predicted, Signature, TypedMetric,
+    COPRO, CallMetadata, Chat, Example, MIPROv2, MetricOutcome, Module, Optimizer, Predict,
+    PredictError, Predicted, Signature, TypedMetric,
 };
 use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
@@ -35,6 +35,7 @@ impl Module for InstructionEchoModule {
                 answer: input.prompt,
             },
             CallMetadata::default(),
+            Chat::new(vec![]),
         ))
     }
 }

--- a/crates/dspy-rs/tests/test_predict_conversation_live.rs
+++ b/crates/dspy-rs/tests/test_predict_conversation_live.rs
@@ -34,10 +34,11 @@ async fn live_forward_with_history_two_turn_roundtrip() {
     let first_input = LiveConversationInput {
         prompt: "Reply with the word ONE.".to_string(),
     };
-    let (first, chat) = predict
+    let first = predict
         .forward(first_input, None)
         .await
         .expect("first turn forward failed");
+    let chat = first.chat().clone();
     assert!(
         !first.answer.trim().is_empty(),
         "first turn answer should not be empty"
@@ -48,10 +49,11 @@ async fn live_forward_with_history_two_turn_roundtrip() {
         prompt: "Now reply with the word TWO. Use the same answer field format.".to_string(),
     };
 
-    let (second, chat2) = predict
+    let second = predict
         .forward(second_input, Some(chat))
         .await
         .expect("second turn forward failed");
+    let chat2 = second.chat();
 
     assert!(
         second.answer.to_ascii_lowercase().contains("two"),

--- a/crates/dspy-rs/tests/test_predict_conversation_live.rs
+++ b/crates/dspy-rs/tests/test_predict_conversation_live.rs
@@ -1,4 +1,4 @@
-use dspy_rs::{ChatAdapter, LM, Message, Predict, Signature, configure};
+use dspy_rs::{ChatAdapter, LM, Predict, Signature, configure};
 use std::sync::LazyLock;
 use tokio::sync::Mutex;
 
@@ -16,7 +16,7 @@ struct LiveConversation {
 
 #[tokio::test]
 #[ignore] // Requires real network access and provider API key(s)
-async fn live_forward_continue_two_turn_roundtrip() {
+async fn live_forward_with_history_two_turn_roundtrip() {
     let _lock = SETTINGS_LOCK.lock().await;
 
     let lm = LM::builder()
@@ -34,27 +34,24 @@ async fn live_forward_continue_two_turn_roundtrip() {
     let first_input = LiveConversationInput {
         prompt: "Reply with the word ONE.".to_string(),
     };
-    let chat = predict
-        .build_chat(&first_input)
-        .expect("build_chat should succeed");
-    let (first, mut chat) = predict
-        .call_and_parse(chat)
+    let (first, chat) = predict
+        .forward(first_input, None)
         .await
-        .expect("first turn failed");
+        .expect("first turn forward failed");
     assert!(
         !first.answer.trim().is_empty(),
         "first turn answer should not be empty"
     );
 
-    // Second turn: append follow-up, continue
-    chat.push_message(Message::user(
-        "Now reply with the word TWO. Use the same answer field format.",
-    ));
+    // Second turn: continue with typed follow-up and prior history
+    let second_input = LiveConversationInput {
+        prompt: "Now reply with the word TWO. Use the same answer field format.".to_string(),
+    };
 
     let (second, chat2) = predict
-        .forward_continue(chat)
+        .forward(second_input, Some(chat))
         .await
-        .expect("second turn failed");
+        .expect("second turn forward failed");
 
     assert!(
         second.answer.to_ascii_lowercase().contains("two"),

--- a/crates/dspy-rs/tests/test_react_builder.rs
+++ b/crates/dspy-rs/tests/test_react_builder.rs
@@ -112,7 +112,7 @@ async fn react_builder_executes_multi_tool_calculator_loop_and_extracts_output()
         .await
         .expect("react call should succeed");
 
-    let (result, metadata) = predicted.into_parts();
+    let (result, metadata, _chat) = predicted.into_parts();
     assert_eq!(
         add_calls.load(Ordering::SeqCst),
         1,
@@ -208,7 +208,7 @@ async fn react_unknown_tool_name_does_not_execute_first_tool() {
         })
         .await
         .expect("react call should succeed");
-    let (_, metadata) = predicted.into_parts();
+    let (_, metadata, _chat) = predicted.into_parts();
 
     assert_eq!(
         add_calls.load(Ordering::SeqCst),

--- a/crates/dspy-rs/tests/test_tool_call.rs
+++ b/crates/dspy-rs/tests/test_tool_call.rs
@@ -1,4 +1,4 @@
-use dspy_rs::{Chat, LM, Message};
+use dspy_rs::{Chat, LM, Message, ToolLoopMode};
 use rig::completion::ToolDefinition;
 use rig::tool::ToolDyn;
 use std::error::Error;
@@ -99,7 +99,7 @@ async fn test_tool_call_with_no_tools() {
     chat.push_message(Message::user("What is 2 + 2?"));
 
     // Call without tools
-    let response = lm.call(chat, vec![]).await;
+    let response = lm.call(chat, vec![], ToolLoopMode::Auto).await;
 
     // Should get a text response (or network error if no real API key)
     if let Err(e) = &response {
@@ -135,7 +135,7 @@ async fn test_tool_call_with_calculator() {
     let tools: Vec<Arc<dyn ToolDyn>> = vec![Arc::new(calculator)];
 
     // Call with the calculator tool
-    let response = lm.call(chat, tools).await.unwrap();
+    let response = lm.call(chat, tools, ToolLoopMode::Auto).await.unwrap();
 
     assert_eq!(response.output.role, dspy_rs::Role::Assistant);
     let content = response.output.content();


### PR DESCRIPTION
## What

Stacked on top of PR #81. Fixes and improvements found during adversarial review.

### LM layer hardening
- **Tool-loop reasoning preservation**: `execute_tool_loop` final text turn now preserves `full_content` (reasoning blocks) instead of dropping them via `Message::assistant(&text)`
- **Auto+no-tools content preservation**: when tools are requested but unavailable, preserves actual provider content instead of injecting synthetic warning text
- **Call API collapse**: `call_with_tool_loop_mode` collapsed to `call(messages, tools, mode)`
- **Panic → Result**: request history construction now returns errors instead of panicking
- **pub(crate) boundaries**: internal rig conversion methods (`to_rig_message`, `system_prompt`, `to_rig_chat_history`) narrowed to crate-internal

### Predicted return shape unification
- `Chat` added as peer field on `Predicted` alongside `output` and `metadata`
- `Predicted::chat()` accessor, `into_parts()` returns `(O, CallMetadata, Chat)`
- `Predict::forward` returns `Predicted` (not tuple) — single return shape
- All call sites updated: optimizers, ReAct, module_ext, examples, tests

### Doc updates
- `core/mod.rs`, `core/module.rs`, `examples/01-simple.rs` updated to document three-channel Predicted (output + metadata + chat)

### Verification
- `cargo fmt --check` ✅
- `cargo clippy --all-targets` ✅
- `cargo test --all` ✅