### PR TITLE
RLM v1 (draft — base API decision needed)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1236,6 +1236,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "temp-env",
  "tempfile",
  "thiserror 2.0.17",
  "tokio",
@@ -4238,6 +4239,16 @@ name = "target-triple"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ac9aa371f599d22256307c24a9d748c041e548cbf599f35d890f9d365361790"
+
+[[package]]
+name = "temp-env"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
+dependencies = [
+ "futures",
+ "parking_lot",
+]
 
 [[package]]
 name = "tempfile"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1227,6 +1227,7 @@ dependencies = [
  "kdam",
  "minijinja",
  "parquet",
+ "pyo3",
  "rand 0.8.5",
  "rayon",
  "regex",
@@ -3253,6 +3254,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "pyo3"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab53c047fcd1a1d2a8820fe84f05d6be69e9526be40cb03b73f86b6b03e6d87d"
+dependencies = [
+ "indoc",
+ "libc",
+ "memoffset",
+ "once_cell",
+ "portable-atomic",
+ "pyo3-build-config",
+ "pyo3-ffi",
+ "pyo3-macros",
+ "unindent",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b455933107de8642b4487ed26d912c2d899dec6114884214a0b3bb3be9261ea6"
+dependencies = [
+ "target-lexicon",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c85c9cbfaddf651b1221594209aed57e9e5cff63c4d11d1feead529b872a089"
+dependencies = [
+ "libc",
+ "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a5b10c9bf9888125d917fb4d2ca2d25c8df94c7ab5a52e13313a07e050a3b02"
+dependencies = [
+ "proc-macro2",
+ "pyo3-macros-backend",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "pyo3-macros-backend"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03b51720d314836e53327f5871d4c0cfb4fb37cc2c4a11cc71907a86342c40f9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "pyo3-build-config",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4235,6 +4297,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-lexicon"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
+
+[[package]]
 name = "target-triple"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4788,6 +4856,12 @@ name = "unicode-width"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
+
+[[package]]
+name = "unindent"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1233,6 +1233,7 @@ dependencies = [
  "regex",
  "reqwest 0.13.2",
  "rig-core",
+ "rlm-derive",
  "rstest 0.25.0",
  "schemars",
  "serde",
@@ -3694,6 +3695,19 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rlm-derive"
+version = "0.1.0"
+dependencies = [
+ "dspy-rs",
+ "facet",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+ "trybuild",
 ]
 
 [[package]]

--- a/INVESTIGATION_facet_baml_bridge.md
+++ b/INVESTIGATION_facet_baml_bridge.md
@@ -1,0 +1,130 @@
+# Investigation: Facet ↔ BAML Bridge Redundancy
+
+## Summary
+
+The codebase has **two independent paths** that produce BAML `TypeIR` from facet type metadata, causing divergence. BAML's native rendering is already used — the problem isn't that we're re-implementing rendering, it's that `SignatureSchema` builds its own TypeIR from raw `facet::Shape` while `bamltype`'s `SchemaBuilder` builds a richer, field-attr-aware TypeIR. These can disagree silently.
+
+## The Two Paths (Root Problem)
+
+### Path 1: `bamltype` SchemaBuilder (full-fidelity)
+```
+#[BamlType] struct → facet::Facet derive → facet attrs (bamltype::*)
+    → SchemaBuilder::build_field_type_ir(field, owner, variant)
+    → checks field attrs: with adapters, int_repr, map_key_repr
+    → registers Classes/Enums into SchemaRegistry
+    → builds OutputFormatContent (with recursive class detection)
+    → cached in BamlSchema::baml_schema() as SchemaBundle
+```
+**Location:** `crates/bamltype/src/schema_builder.rs:453-490` (`build_field_type_ir`)
+
+This path sees `#[baml(with="Codec")]`, `#[baml(int_repr="string")]`, `#[baml(map_key_repr="pairs")]` and transforms the TypeIR accordingly. An adapter can completely replace a field's type. A map can become a list of generated entry classes.
+
+### Path 2: `SignatureSchema` (shape-only, loses field attrs)
+```
+#[derive(Signature)] struct → facet::Shape for Input/Output
+    → collect_fields() iterates struct fields
+    → emit_field() calls build_type_ir_from_shape(field.shape())
+    → TypeIR built from shape alone, NO field attr awareness
+    → stored in FieldSchema.type_ir
+```
+**Location:** `crates/dspy-rs/src/core/schema.rs:337` — the critical line:
+```rust
+let mut type_ir = build_type_ir_from_shape(field.shape());
+```
+
+This calls `schema_builder::build_type_ir_from_shape()` which creates a **fresh SchemaBuilder** and calls `build_type_ir(shape)` — NOT `build_field_type_ir(field, ...)`. It never sees field-level attributes.
+
+### Where They're Used Together (Mismatch Surface)
+
+| Consumer | Uses FieldSchema.type_ir (Path 2) | Uses OutputFormatContent (Path 1) |
+|----------|----------------------------------|----------------------------------|
+| `ChatAdapter::parse_structured_output_with_meta` | ✅ `jsonish::from_str(..., &field.type_ir, ...)` | ✅ `schema.output_format()` |
+| RLM Output Contract (prompt.rs:99) | ✅ `field.type_ir.diagnostic_repr()` | ❌ |
+| RLM py_bridge kwargs coercion | ✅ `field.type_ir` for dispatch | ✅ `output_format` for class/enum lookups |
+| ChatAdapter field schema rendering | ❌ | ✅ `OutputFormatContent::render()` |
+
+When Path 1 and Path 2 disagree (e.g., a field has `int_repr="string"` or `with="Codec"`), `jsonish` gets a TypeIR that says "int" while OutputFormatContent says "string" (or a completely different adapter type). This is a silent correctness bug.
+
+## What BAML "Native" Actually Means Here
+
+BAML's native rendering (`internal-baml-jinja`) is **already used**:
+- `OutputFormatContent::render(options)` — schema prompt text ✅
+- `jsonish::from_str(...)` — LLM output parsing ✅
+- `format_baml_value(...)` — value formatting ✅
+
+The custom bridge (`crates/bamltype`) builds the **inputs** to native rendering:
+- `facet::Shape` → `TypeIR` (the type graph)
+- `facet::Shape` → `OutputFormatContent` (class/enum registry)
+
+You can't remove this bridge without a replacement source of truth (e.g., a BAML compiler, or user-authored BAML schemas).
+
+## RlmType: Not a Schema Divergence
+
+`#[rlm_type]` is a composition macro, not a competing schema system:
+```rust
+// rlm_attr.rs:43-45 — it literally just adds these:
+input.attrs.push(syn::parse_quote!(#[pyclass(...)]));
+input.attrs.push(syn::parse_quote!(#[BamlType]));
+merge_derive(&mut input.attrs, &[syn::parse_quote!(RlmType)]);
+```
+
+`RlmType` derive adds Python interop methods (`__baml__`, `__repr__`, `__iter__`, etc.) that delegate to `BamlType` for conversion. There's no schema divergence here — it's a pure consumer of `bamltype`.
+
+## Internal Name Drift
+
+There's a subtle naming inconsistency between two functions that compute BAML internal names:
+
+**`schema_builder::internal_name_for_shape(shape)`** (schema_builder.rs:44-55):
+```rust
+// Uses module_path::type_identifier
+format!("{module}::{}", shape.type_identifier)
+```
+
+**`runtime::baml_internal_name::<T>()`** (runtime.rs:80-94):
+```rust
+// Falls back to std::any::type_name::<T>()
+std::any::type_name::<T>()
+```
+
+`std::any::type_name` returns e.g. `my_crate::my_module::MyType` while `internal_name_for_shape` returns `my_module::MyType`. These could drift in edge cases, causing class lookup failures in value conversion or formatting.
+
+## Complexity Hotspots
+
+### 1. Adapter Function Pointers in Facet Attrs
+`bamltype-derive` encodes function pointers (`WithAdapterFns`) into facet attribute metadata. These are `fn()` pointers stored as `&'static dyn Any` in compile-time reflection data. This works but is deeply non-obvious and makes the bridge hard to replace.
+
+### 2. Map Key Repr "pairs" Generates Phantom Classes
+`map_key_repr="pairs"` lowers `Map<K,V>` → `List<GeneratedMapEntry>` and registers a generated class. Any code that assumes maps stay maps will break.
+
+### 3. Two Value Conversion Engines
+- `bamltype/src/convert.rs`: Rust value ↔ BamlValue (facet Peek-based)
+- `rlm/py_bridge.rs`: Python value → BamlValue (TypeIR + OutputFormatContent-aware)
+
+Both walk value trees against schemas, both have relaxed parsing heuristics, both could diverge.
+
+## Recommendations
+
+### Fix 1: Make SignatureSchema source TypeIR from bamltype's SchemaBundle (HIGH PRIORITY)
+
+Instead of:
+```rust
+let mut type_ir = build_type_ir_from_shape(field.shape());
+```
+
+Do one of:
+- **Option A**: Look up the field's TypeIR from `<Output as BamlType>::baml_schema().output_format` class definitions
+- **Option B**: Expose `SchemaBuilder::build_field_type_ir` as a public API that `SignatureSchema` can call
+
+This eliminates the "two sources of truth" problem entirely.
+
+### Fix 2: Unify internal name computation
+
+Change `runtime::baml_internal_name::<T>()` fallback from `type_name::<T>()` to `internal_name_for_shape(T::SHAPE)`.
+
+### Fix 3: Use OutputFormatContent::render for RLM Output Contract
+
+Instead of `field.type_ir.diagnostic_repr()` (which uses the divergent Path 2 TypeIR), render the contract using the same native rendering used for structured output prompts.
+
+### Fix 4 (Optional): Consolidate py_bridge coercion through jsonish
+
+Normalize Python values to JSON, then use `jsonish::from_str(output_format, type_ir, ...)` instead of a parallel walker. Keeps one coercion engine.

--- a/crates/dspy-rs/Cargo.toml
+++ b/crates/dspy-rs/Cargo.toml
@@ -51,3 +51,6 @@ ignored = ["rig-core"]
 
 [features]
 default = []
+
+[dev-dependencies]
+temp-env = { version = "0.3.6", features = ["async_closure"] }

--- a/crates/dspy-rs/Cargo.toml
+++ b/crates/dspy-rs/Cargo.toml
@@ -45,12 +45,14 @@ enum_dispatch = "0.3.13"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter", "fmt"] }
 minijinja = { git = "https://github.com/boundaryml/minijinja.git", branch = "main", default-features = false, features = ["builtins", "serde"] }
+pyo3 = { version = "0.27", features = ["auto-initialize"], optional = true }
 
 [package.metadata.cargo-machete]
 ignored = ["rig-core"]
 
 [features]
 default = []
+rlm = ["dep:pyo3"]
 
 [dev-dependencies]
 temp-env = { version = "0.3.6", features = ["async_closure"] }

--- a/crates/dspy-rs/Cargo.toml
+++ b/crates/dspy-rs/Cargo.toml
@@ -46,13 +46,14 @@ tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter", "fmt"] }
 minijinja = { git = "https://github.com/boundaryml/minijinja.git", branch = "main", default-features = false, features = ["builtins", "serde"] }
 pyo3 = { version = "0.27", features = ["auto-initialize"], optional = true }
+rlm-derive = { path = "../rlm-derive", optional = true }
 
 [package.metadata.cargo-machete]
 ignored = ["rig-core"]
 
 [features]
 default = []
-rlm = ["dep:pyo3", "dsrs_macros/rlm"]
+rlm = ["dep:pyo3", "dep:rlm-derive", "dsrs_macros/rlm"]
 
 [dev-dependencies]
 temp-env = { version = "0.3.6", features = ["async_closure"] }

--- a/crates/dspy-rs/Cargo.toml
+++ b/crates/dspy-rs/Cargo.toml
@@ -52,7 +52,7 @@ ignored = ["rig-core"]
 
 [features]
 default = []
-rlm = ["dep:pyo3"]
+rlm = ["dep:pyo3", "dsrs_macros/rlm"]
 
 [dev-dependencies]
 temp-env = { version = "0.3.6", features = ["async_closure"] }

--- a/crates/dspy-rs/examples/01-simple.rs
+++ b/crates/dspy-rs/examples/01-simple.rs
@@ -17,8 +17,8 @@ use anyhow::Result;
 use bon::Builder;
 use dspy_rs::data::RawExample;
 use dspy_rs::{
-    CallMetadata, ChatAdapter, Example, LM, LmError, Module, Predict, PredictError, Predicted,
-    Prediction, configure, init_tracing,
+    CallMetadata, Chat, ChatAdapter, Example, LM, LmError, Module, Predict, PredictError,
+    Predicted, Prediction, configure, init_tracing,
 };
 
 const QA_INSTRUCTION: &str = "Answer the question step by step.";
@@ -115,7 +115,11 @@ impl Module for QARater {
             .data
             .insert("rating".into(), rate_result.rating.into());
 
-        Ok(Predicted::new(combined, CallMetadata::default()))
+        Ok(Predicted::new(
+            combined,
+            CallMetadata::default(),
+            Chat::new(vec![]),
+        ))
     }
 }
 
@@ -147,7 +151,7 @@ async fn main() -> Result<()> {
     println!("Reasoning: {}", output.reasoning);
     println!("Answer: {}", output.answer);
 
-    // Predicted carries both typed output and metadata.
+    // Predicted carries typed output, metadata, and chat history.
     let result = predict.call(input).await?;
     println!("\nWith metadata:");
     println!(

--- a/crates/dspy-rs/examples/01-simple.rs
+++ b/crates/dspy-rs/examples/01-simple.rs
@@ -132,7 +132,7 @@ async fn main() -> Result<()> {
             .model("openai:gpt-4o-mini".to_string())
             .build()
             .await?,
-        ChatAdapter,
+        ChatAdapter::new(),
     );
 
     // =========================================================================

--- a/crates/dspy-rs/examples/02-module-iteration-and-updation.rs
+++ b/crates/dspy-rs/examples/02-module-iteration-and-updation.rs
@@ -83,7 +83,7 @@ async fn main() -> Result<()> {
             .model("openai:gpt-4o-mini".to_string())
             .build()
             .await?,
-        ChatAdapter,
+        ChatAdapter::new(),
     );
 
     let metric = ExactMatch;

--- a/crates/dspy-rs/examples/03-evaluate-hotpotqa.rs
+++ b/crates/dspy-rs/examples/03-evaluate-hotpotqa.rs
@@ -48,7 +48,7 @@ async fn main() -> Result<()> {
             .model("openai:gpt-4o-mini".to_string())
             .build()
             .await?,
-        ChatAdapter,
+        ChatAdapter::new(),
     );
 
     let examples = DataLoader::load_hf::<QA>(

--- a/crates/dspy-rs/examples/04-optimize-hotpotqa.rs
+++ b/crates/dspy-rs/examples/04-optimize-hotpotqa.rs
@@ -65,7 +65,7 @@ async fn main() -> Result<()> {
             .model("openai:gpt-4o-mini".to_string())
             .build()
             .await?,
-        ChatAdapter,
+        ChatAdapter::new(),
     );
 
     let examples = DataLoader::load_hf::<QA>(

--- a/crates/dspy-rs/examples/05-heterogenous-examples.rs
+++ b/crates/dspy-rs/examples/05-heterogenous-examples.rs
@@ -34,7 +34,7 @@ async fn main() -> Result<()> {
             .model("openai:gpt-4o-mini".to_string())
             .build()
             .await?,
-        ChatAdapter,
+        ChatAdapter::new(),
     );
 
     let heterogeneous = RawExample::new(

--- a/crates/dspy-rs/examples/06-other-providers-batch.rs
+++ b/crates/dspy-rs/examples/06-other-providers-batch.rs
@@ -49,7 +49,7 @@ async fn main() -> Result<()> {
             .model("anthropic:claude-sonnet-4-5-20250929".to_string())
             .build()
             .await?,
-        ChatAdapter,
+        ChatAdapter::new(),
     );
 
     let mut anthropic = Vec::new();
@@ -63,7 +63,7 @@ async fn main() -> Result<()> {
             .model("gemini:gemini-2.0-flash".to_string())
             .build()
             .await?,
-        ChatAdapter,
+        ChatAdapter::new(),
     );
 
     let mut gemini = Vec::new();

--- a/crates/dspy-rs/examples/07-inspect-history.rs
+++ b/crates/dspy-rs/examples/07-inspect-history.rs
@@ -27,7 +27,7 @@ async fn main() -> Result<()> {
         .model("openai:gpt-4o-mini".to_string())
         .build()
         .await?;
-    configure(lm, ChatAdapter);
+    configure(lm, ChatAdapter::new());
 
     let predictor = Predict::<QA>::new();
     let output = predictor

--- a/crates/dspy-rs/examples/08-optimize-mipro.rs
+++ b/crates/dspy-rs/examples/08-optimize-mipro.rs
@@ -74,7 +74,7 @@ async fn main() -> Result<()> {
 
     println!("=== MIPROv2 Optimizer Example ===\n");
 
-    configure(LM::default(), ChatAdapter);
+    configure(LM::default(), ChatAdapter::new());
 
     println!("Loading training data from HuggingFace...");
     let train_examples = DataLoader::load_hf::<QuestionAnswering>(

--- a/crates/dspy-rs/examples/09-gepa-sentiment.rs
+++ b/crates/dspy-rs/examples/09-gepa-sentiment.rs
@@ -88,7 +88,10 @@ fn sentiment_example(text: &str, expected: &str) -> Example<SentimentSignature> 
 async fn main() -> Result<()> {
     init_tracing()?;
 
-    configure(LM::builder().temperature(0.7).build().await?, ChatAdapter);
+    configure(
+        LM::builder().temperature(0.7).build().await?,
+        ChatAdapter::new(),
+    );
 
     let trainset = vec![
         sentiment_example(

--- a/crates/dspy-rs/examples/10-gepa-llm-judge.rs
+++ b/crates/dspy-rs/examples/10-gepa-llm-judge.rs
@@ -150,7 +150,10 @@ fn training_example(problem: &str, expected_answer: &str) -> Example<MathWordPro
 async fn main() -> Result<()> {
     init_tracing()?;
 
-    configure(LM::builder().temperature(0.7).build().await?, ChatAdapter);
+    configure(
+        LM::builder().temperature(0.7).build().await?,
+        ChatAdapter::new(),
+    );
 
     let trainset = vec![
         training_example(

--- a/crates/dspy-rs/examples/11-custom-client.rs
+++ b/crates/dspy-rs/examples/11-custom-client.rs
@@ -42,7 +42,7 @@ async fn main() -> Result<()> {
         .with_client(custom_lm_client)
         .await?;
 
-    configure(lm, ChatAdapter);
+    configure(lm, ChatAdapter::new());
 
     let predictor = Predict::<QA>::new();
     let prediction = predictor

--- a/crates/dspy-rs/examples/12-tracing.rs
+++ b/crates/dspy-rs/examples/12-tracing.rs
@@ -11,8 +11,8 @@ use anyhow::Result;
 use bon::Builder;
 use dspy_rs::data::RawExample;
 use dspy_rs::{
-    CallMetadata, ChatAdapter, LM, LmUsage, Module, Predict, PredictError, Predicted, Prediction,
-    Signature, configure, init_tracing,
+    CallMetadata, Chat, ChatAdapter, LM, LmUsage, Module, Predict, PredictError, Predicted,
+    Prediction, Signature, configure, init_tracing,
     trace::{self, Executor},
 };
 use serde_json::json;
@@ -83,7 +83,11 @@ impl Module for QARater {
             },
         );
 
-        Ok(Predicted::new(prediction, CallMetadata::default()))
+        Ok(Predicted::new(
+            prediction,
+            CallMetadata::default(),
+            Chat::new(vec![]),
+        ))
     }
 }
 

--- a/crates/dspy-rs/examples/12-tracing.rs
+++ b/crates/dspy-rs/examples/12-tracing.rs
@@ -100,7 +100,7 @@ async fn main() -> Result<()> {
             .model("openai:gpt-4o-mini".to_string())
             .build()
             .await?,
-        ChatAdapter,
+        ChatAdapter::new(),
     );
 
     let module = QARater::builder().build();

--- a/crates/dspy-rs/examples/15-tools.rs
+++ b/crates/dspy-rs/examples/15-tools.rs
@@ -100,7 +100,7 @@ async fn main() -> Result<()> {
         .model("groq:openai/gpt-oss-120b".to_string())
         .build()
         .await?;
-    configure(lm, ChatAdapter);
+    configure(lm, ChatAdapter::new());
 
     let predictor = Predict::<MathQuestionSignature>::builder()
         .instruction("You must call the calculator tool for arithmetic.")

--- a/crates/dspy-rs/examples/16-insurance-claim-prompt.rs
+++ b/crates/dspy-rs/examples/16-insurance-claim-prompt.rs
@@ -196,7 +196,7 @@ pub struct InsuranceClaimInfo {
 fn main() {
     init_tracing().expect("failed to initialize tracing");
 
-    let adapter = ChatAdapter;
+    let adapter = ChatAdapter::new();
     let system = adapter
         .format_system_message_typed::<InsuranceClaimInfo>()
         .expect("system prompt");

--- a/crates/dspy-rs/examples/90-smoke-slice1-typed-predict.rs
+++ b/crates/dspy-rs/examples/90-smoke-slice1-typed-predict.rs
@@ -18,7 +18,7 @@ async fn main() -> Result<()> {
             .model("openai:gpt-5.2".to_string())
             .build()
             .await?,
-        ChatAdapter,
+        ChatAdapter::new(),
     );
 
     let module = Predict::<SmokeSig>::new();

--- a/crates/dspy-rs/examples/91-smoke-slice2-chain-of-thought.rs
+++ b/crates/dspy-rs/examples/91-smoke-slice2-chain-of-thought.rs
@@ -18,7 +18,7 @@ async fn main() -> Result<()> {
             .model("openai:gpt-5.2".to_string())
             .build()
             .await?,
-        ChatAdapter,
+        ChatAdapter::new(),
     );
 
     let module = ChainOfThought::<SmokeSig>::new();

--- a/crates/dspy-rs/examples/92-smoke-slice3-module-authoring.rs
+++ b/crates/dspy-rs/examples/92-smoke-slice3-module-authoring.rs
@@ -39,7 +39,7 @@ async fn main() -> Result<()> {
             .model("openai:gpt-5.2".to_string())
             .build()
             .await?,
-        ChatAdapter,
+        ChatAdapter::new(),
     );
 
     let module = SmokeModule::new();

--- a/crates/dspy-rs/examples/93-smoke-slice4-react-operational.rs
+++ b/crates/dspy-rs/examples/93-smoke-slice4-react-operational.rs
@@ -83,7 +83,7 @@ async fn main() -> Result<()> {
         }
         anyhow::anyhow!("slice4 smoke failed")
     })?;
-    let (output, metadata) = predicted.into_parts();
+    let (output, metadata, _chat) = predicted.into_parts();
 
     println!("tool_calls: {}", metadata.tool_calls.len());
     println!("tool_executions: {}", metadata.tool_executions.len());

--- a/crates/dspy-rs/examples/93-smoke-slice4-react-operational.rs
+++ b/crates/dspy-rs/examples/93-smoke-slice4-react-operational.rs
@@ -40,7 +40,7 @@ async fn main() -> Result<()> {
             .model("openai:gpt-5.2".to_string())
             .build()
             .await?,
-        ChatAdapter,
+        ChatAdapter::new(),
     );
 
     let module = ReAct::<SmokeSig>::builder()

--- a/crates/dspy-rs/examples/94-smoke-slice5-optimizer-interface.rs
+++ b/crates/dspy-rs/examples/94-smoke-slice5-optimizer-interface.rs
@@ -37,7 +37,7 @@ async fn main() -> Result<()> {
             .model("openai:gpt-5.2".to_string())
             .build()
             .await?,
-        ChatAdapter,
+        ChatAdapter::new(),
     );
 
     let mut module = ChainOfThought::<SmokeSig>::new();

--- a/crates/dspy-rs/src/adapter/chat.rs
+++ b/crates/dspy-rs/src/adapter/chat.rs
@@ -625,7 +625,7 @@ impl ChatAdapter {
     where
         O: BamlType + for<'a> facet::Facet<'a>,
     {
-        let content = response.content();
+        let content = response.text_content();
         let output_format = schema.output_format();
         let sections = parse_sections(&content);
 

--- a/crates/dspy-rs/src/adapter/chat.rs
+++ b/crates/dspy-rs/src/adapter/chat.rs
@@ -15,7 +15,7 @@ use tracing::{debug, trace};
 use super::Adapter;
 use crate::CallMetadata;
 use crate::{
-    BamlType, BamlValue, ConstraintLevel, ConstraintResult, FieldMeta, Flag, InputRenderSpec,
+    BamlType, BamlValue, Chat, ConstraintLevel, ConstraintResult, FieldMeta, Flag, InputRenderSpec,
     JsonishError, Message, OutputFormatContent, ParseError, PredictError, Predicted, RenderOptions,
     Signature, TypeIR,
 };
@@ -844,7 +844,7 @@ impl ChatAdapter {
             None,
             field_meta,
         );
-        Ok(Predicted::new(output, metadata))
+        Ok(Predicted::new(output, metadata, Chat::new(vec![response])))
     }
 }
 

--- a/crates/dspy-rs/src/adapter/chat.rs
+++ b/crates/dspy-rs/src/adapter/chat.rs
@@ -1011,29 +1011,89 @@ fn parse_sections(content: &str) -> IndexMap<String, String> {
 }
 
 fn extract_passthrough_body(response: &Message) -> Option<String> {
-    let text = response.text_content();
+    extract_passthrough_body_from_text(&response.text_content())
+}
+
+fn extract_passthrough_body_from_text(text: &str) -> Option<String> {
     let trimmed = text.trim();
     if trimmed.is_empty() {
         return None;
     }
 
-    if trimmed.starts_with("```") {
-        let mut lines = trimmed.lines();
-        let _opening = lines.next();
-        let mut fence_body = Vec::new();
-        for line in lines {
-            if line.trim_start().starts_with("```") {
-                break;
-            }
-            fence_body.push(line);
-        }
-        let body = fence_body.join("\n").trim().to_string();
-        if !body.is_empty() {
-            return Some(body);
-        }
+    let fenced_blocks = extract_fenced_code_blocks(trimmed);
+    if !fenced_blocks.is_empty() {
+        return Some(fenced_blocks.join("\n\n"));
     }
 
     Some(trimmed.to_string())
+}
+
+fn extract_fenced_code_blocks(text: &str) -> Vec<String> {
+    let mut blocks = Vec::new();
+    let mut in_fence = false;
+    let mut current = Vec::new();
+
+    for line in text.lines() {
+        if line.trim_start().starts_with("```") {
+            if in_fence {
+                let block = current.join("\n").trim().to_string();
+                if !block.is_empty() {
+                    blocks.push(block);
+                }
+                current.clear();
+                in_fence = false;
+            } else {
+                in_fence = true;
+                current.clear();
+            }
+            continue;
+        }
+
+        if in_fence {
+            current.push(line);
+        }
+    }
+
+    if in_fence {
+        let block = current.join("\n").trim().to_string();
+        if !block.is_empty() {
+            blocks.push(block);
+        }
+    }
+
+    blocks
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn passthrough_extracts_all_fenced_blocks() {
+        let text = "```python\nx = 1\n```\n\nSome prose.\n\n```py\ny = 2\n```\n``` \nz = 3\n```";
+        assert_eq!(
+            extract_passthrough_body_from_text(text),
+            Some("x = 1\n\ny = 2\n\nz = 3".to_string())
+        );
+    }
+
+    #[test]
+    fn passthrough_extracts_unclosed_fenced_block() {
+        let text = "```python\nx = 1\ny = 2";
+        assert_eq!(
+            extract_passthrough_body_from_text(text),
+            Some("x = 1\ny = 2".to_string())
+        );
+    }
+
+    #[test]
+    fn passthrough_falls_back_to_full_text_without_fences() {
+        let text = "  x = 1\ny = x + 1  ";
+        assert_eq!(
+            extract_passthrough_body_from_text(text),
+            Some("x = 1\ny = x + 1".to_string())
+        );
+    }
 }
 
 fn value_for_path_relaxed<'a>(

--- a/crates/dspy-rs/src/adapter/chat.rs
+++ b/crates/dspy-rs/src/adapter/chat.rs
@@ -20,7 +20,16 @@ use crate::{
     Signature, TypeIR,
 };
 
-/// Builds prompts and parses responses using the `[[ ## field ## ]]` delimiter protocol.
+/// Output formatting/parsing dialect for [`ChatAdapter`].
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
+pub enum Dialect {
+    #[default]
+    Chat,
+    Passthrough,
+    Xml,
+}
+
+/// Builds prompts and parses responses using signature-aware adapter dialects.
 ///
 /// The adapter is stateless — all state comes from the [`SignatureSchema`](crate::SignatureSchema)
 /// passed to each method. Two usage patterns:
@@ -32,8 +41,10 @@ use crate::{
 ///
 /// The building blocks exist so module authors can compose custom prompt flows (e.g.
 /// ReAct's action/extract loop) without reimplementing the delimiter protocol.
-#[derive(Default, Clone)]
-pub struct ChatAdapter;
+#[derive(Debug, Clone, Default)]
+pub struct ChatAdapter {
+    dialect: Dialect,
+}
 
 static FIELD_HEADER_PATTERN: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^\[\[ ## ([^#]+?) ## \]\]").unwrap());
@@ -300,6 +311,32 @@ fn format_schema_for_prompt(schema: &str) -> String {
 }
 
 impl ChatAdapter {
+    pub fn new() -> Self {
+        Self {
+            dialect: Dialect::Chat,
+        }
+    }
+
+    pub fn passthrough() -> Self {
+        Self {
+            dialect: Dialect::Passthrough,
+        }
+    }
+
+    pub fn xml() -> Self {
+        Self {
+            dialect: Dialect::Xml,
+        }
+    }
+
+    pub fn dialect(&self) -> Dialect {
+        self.dialect
+    }
+
+    fn is_structured_output(&self) -> bool {
+        !matches!(self.dialect, Dialect::Passthrough)
+    }
+
     fn format_task_description_schema(
         &self,
         schema: &crate::SignatureSchema,
@@ -331,7 +368,11 @@ impl ChatAdapter {
             indented.push_str(line);
         }
 
-        format!("In adhering to this structure, your objective is: {indented}")
+        if self.is_structured_output() {
+            format!("In adhering to this structure, your objective is: {indented}")
+        } else {
+            format!("Your objective is: {indented}")
+        }
     }
 
     fn format_response_instructions_schema(&self, schema: &crate::SignatureSchema) -> String {
@@ -396,12 +437,19 @@ impl ChatAdapter {
         schema: &crate::SignatureSchema,
         instruction_override: Option<&str>,
     ) -> Result<String> {
-        let parts = [
-            self.format_field_descriptions_schema(schema),
-            self.format_field_structure_schema(schema)?,
-            self.format_response_instructions_schema(schema),
-            self.format_task_description_schema(schema, instruction_override),
-        ];
+        let parts = if self.is_structured_output() {
+            vec![
+                self.format_field_descriptions_schema(schema),
+                self.format_field_structure_schema(schema)?,
+                self.format_response_instructions_schema(schema),
+                self.format_task_description_schema(schema, instruction_override),
+            ]
+        } else {
+            vec![
+                self.format_field_descriptions_schema(schema),
+                self.format_task_description_schema(schema, instruction_override),
+            ]
+        };
 
         let system = parts.join("\n\n");
         trace!(system_len = system.len(), "formatted schema system prompt");
@@ -488,8 +536,10 @@ impl ChatAdapter {
     /// Navigates the `BamlValue` using each field's [`FieldPath`](crate::FieldPath) to
     /// handle flattened structs correctly. A field with path `["inner", "question"]` is
     /// extracted from the nested structure but rendered as a flat `[[ ## question ## ]]`
-    /// section in the prompt. Appends response instructions so the LM sees
-    /// output-field ordering guidance in the latest user turn.
+    /// section in the prompt.
+    ///
+    /// Structured dialects append explicit output-field ordering guidance in the
+    /// user turn. Passthrough dialect omits output protocol instructions entirely.
     pub fn format_input<I>(&self, schema: &crate::SignatureSchema, input: &I) -> String
     where
         I: BamlType + for<'a> facet::Facet<'a>,
@@ -514,7 +564,9 @@ impl ChatAdapter {
             }
         }
 
-        result.push_str(&self.format_response_instructions_schema(schema));
+        if self.is_structured_output() {
+            result.push_str(&self.format_response_instructions_schema(schema));
+        }
         result
     }
 
@@ -618,6 +670,23 @@ impl ChatAdapter {
     ///
     /// Same as [`parse_response_typed`](ChatAdapter::parse_response_typed).
     pub fn parse_output_with_meta<O>(
+        &self,
+        schema: &crate::SignatureSchema,
+        response: &Message,
+    ) -> std::result::Result<(O, IndexMap<String, FieldMeta>), ParseError>
+    where
+        O: BamlType + for<'a> facet::Facet<'a>,
+    {
+        match self.dialect {
+            Dialect::Chat | Dialect::Xml => {
+                self.parse_structured_output_with_meta::<O>(schema, response)
+            }
+            Dialect::Passthrough => self.parse_passthrough_output_with_meta::<O>(schema, response),
+        }
+    }
+
+    #[allow(clippy::result_large_err)]
+    fn parse_structured_output_with_meta<O>(
         &self,
         schema: &crate::SignatureSchema,
         response: &Message,
@@ -787,6 +856,64 @@ impl ChatAdapter {
     }
 
     #[allow(clippy::result_large_err)]
+    fn parse_passthrough_output_with_meta<O>(
+        &self,
+        schema: &crate::SignatureSchema,
+        response: &Message,
+    ) -> std::result::Result<(O, IndexMap<String, FieldMeta>), ParseError>
+    where
+        O: BamlType + for<'a> facet::Facet<'a>,
+    {
+        let output_fields = schema.output_fields();
+        if output_fields.len() != 1 {
+            return Err(ParseError::ExtractionFailed {
+                field: "<all>".to_string(),
+                raw_response: response.content(),
+                reason: format!(
+                    "passthrough adapter requires exactly one output field, got {}",
+                    output_fields.len()
+                ),
+            });
+        }
+
+        let raw_response = response.content();
+        let code =
+            extract_passthrough_body(response).ok_or_else(|| ParseError::ExtractionFailed {
+                field: output_fields[0].rust_name.clone(),
+                raw_response: raw_response.clone(),
+                reason: "empty passthrough response".to_string(),
+            })?;
+
+        let mut output_map = bamltype::baml_types::BamlMap::new();
+        output_map.insert(
+            output_fields[0].rust_name.clone(),
+            BamlValue::String(code.clone()),
+        );
+
+        let typed_output = <O as BamlType>::try_from_baml_value(BamlValue::Class(
+            <O as BamlType>::baml_internal_name().to_string(),
+            output_map,
+        ))
+        .map_err(|err| ParseError::ExtractionFailed {
+            field: output_fields[0].rust_name.clone(),
+            raw_response: raw_response.clone(),
+            reason: err.to_string(),
+        })?;
+
+        let mut metas = IndexMap::new();
+        metas.insert(
+            output_fields[0].rust_name.clone(),
+            FieldMeta {
+                raw_text: code,
+                flags: Vec::new(),
+                checks: Vec::new(),
+            },
+        );
+
+        Ok((typed_output, metas))
+    }
+
+    #[allow(clippy::result_large_err)]
     /// Parses an LM response into a typed output, discarding field metadata.
     ///
     /// Convenience wrapper around [`parse_output_with_meta`](ChatAdapter::parse_output_with_meta).
@@ -829,12 +956,14 @@ impl ChatAdapter {
         response: Message,
     ) -> std::result::Result<Predicted<S::Output>, PredictError> {
         let raw_response = response.content();
+        let parse_chat = Chat::new(vec![response.clone()]);
         let (output, field_meta) = self
             .parse_response_typed::<S>(&response)
             .map_err(|source| PredictError::Parse {
                 source,
                 raw_response: raw_response.clone(),
                 lm_usage: crate::LmUsage::default(),
+                chat: parse_chat,
             })?;
         let metadata = CallMetadata::new(
             raw_response,
@@ -882,6 +1011,32 @@ fn parse_sections(content: &str) -> IndexMap<String, String> {
     }
 
     parsed
+}
+
+fn extract_passthrough_body(response: &Message) -> Option<String> {
+    let text = response.text_content();
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    if trimmed.starts_with("```") {
+        let mut lines = trimmed.lines();
+        let _opening = lines.next();
+        let mut fence_body = Vec::new();
+        for line in lines {
+            if line.trim_start().starts_with("```") {
+                break;
+            }
+            fence_body.push(line);
+        }
+        let body = fence_body.join("\n").trim().to_string();
+        if !body.is_empty() {
+            return Some(body);
+        }
+    }
+
+    Some(trimmed.to_string())
 }
 
 fn value_for_path_relaxed<'a>(

--- a/crates/dspy-rs/src/adapter/chat.rs
+++ b/crates/dspy-rs/src/adapter/chat.rs
@@ -177,42 +177,16 @@ fn resolve_rendered_type_token(token: &str, output_format: Option<&OutputFormatC
         }
     }
 
-    token.rsplit("::").next().unwrap_or(token).to_string()
-}
-
-fn simplify_type_name(raw: &str, output_format: Option<&OutputFormatContent>) -> String {
-    let mut result = String::with_capacity(raw.len());
-    let mut chars = raw.chars();
-    while let Some(ch) = chars.next() {
-        if ch == '`' {
-            let mut token = String::new();
-            for next in chars.by_ref() {
-                if next == '`' {
-                    break;
-                }
-                token.push(next);
-            }
-            let rendered = resolve_rendered_type_token(&token, output_format);
-            result.push_str(&rendered);
-        } else {
-            result.push(ch);
-        }
-    }
-    result
+    crate::core::simplify_type_token(token)
 }
 
 fn render_type_name_for_prompt(
     type_ir: &TypeIR,
     output_format: Option<&OutputFormatContent>,
 ) -> String {
-    let raw = type_ir.diagnostic_repr().to_string();
-    let simplified = simplify_type_name(&raw, output_format);
-    simplified
-        .replace("class ", "")
-        .replace("enum ", "")
-        .replace(" | ", " or ")
-        .trim()
-        .to_string()
+    crate::core::render_type_name_for_prompt_with(type_ir, |token| {
+        resolve_rendered_type_token(token, output_format)
+    })
 }
 
 fn split_schema_definitions(schema: &str) -> Option<(String, String)> {

--- a/crates/dspy-rs/src/adapter/chat.rs
+++ b/crates/dspy-rs/src/adapter/chat.rs
@@ -26,7 +26,6 @@ pub enum Dialect {
     #[default]
     Chat,
     Passthrough,
-    Xml,
 }
 
 /// Builds prompts and parses responses using signature-aware adapter dialects.
@@ -320,12 +319,6 @@ impl ChatAdapter {
     pub fn passthrough() -> Self {
         Self {
             dialect: Dialect::Passthrough,
-        }
-    }
-
-    pub fn xml() -> Self {
-        Self {
-            dialect: Dialect::Xml,
         }
     }
 
@@ -691,9 +684,7 @@ impl ChatAdapter {
         O: BamlType + for<'a> facet::Facet<'a>,
     {
         match self.dialect {
-            Dialect::Chat | Dialect::Xml => {
-                self.parse_structured_output_with_meta::<O>(schema, response)
-            }
+            Dialect::Chat => self.parse_structured_output_with_meta::<O>(schema, response),
             Dialect::Passthrough => self.parse_passthrough_output_with_meta::<O>(schema, response),
         }
     }

--- a/crates/dspy-rs/src/adapter/chat.rs
+++ b/crates/dspy-rs/src/adapter/chat.rs
@@ -552,15 +552,28 @@ impl ChatAdapter {
         let mut result = String::new();
         for field_spec in schema.input_fields() {
             if let Some(value) = value_for_path_relaxed(&baml_value, field_spec.path()) {
-                result.push_str(&format!("[[ ## {} ## ]]\n", field_spec.lm_name));
-                result.push_str(&render_input_field(
-                    field_spec,
-                    value,
-                    &input_json,
-                    input_output_format,
-                    &vars,
-                ));
-                result.push_str("\n\n");
+                if self.is_structured_output() {
+                    result.push_str(&format!("[[ ## {} ## ]]\n", field_spec.lm_name));
+                    result.push_str(&render_input_field(
+                        field_spec,
+                        value,
+                        &input_json,
+                        input_output_format,
+                        &vars,
+                    ));
+                    result.push_str("\n\n");
+                } else {
+                    result.push_str(field_spec.lm_name);
+                    result.push_str(":\n");
+                    result.push_str(&render_input_field(
+                        field_spec,
+                        value,
+                        &input_json,
+                        input_output_format,
+                        &vars,
+                    ));
+                    result.push_str("\n\n");
+                }
             }
         }
 

--- a/crates/dspy-rs/src/adapter/chat.rs
+++ b/crates/dspy-rs/src/adapter/chat.rs
@@ -527,6 +527,9 @@ impl ChatAdapter {
         let vars = Value::Object(serde_json::Map::new());
 
         let mut result = String::new();
+        let raw_perception_mode = !self.is_structured_output()
+            && schema.input_fields().len() == 1
+            && schema.input_fields()[0].lm_name == "perception";
         for field_spec in schema.input_fields() {
             if let Some(value) = value_for_path_relaxed(&baml_value, field_spec.path()) {
                 if self.is_structured_output() {
@@ -540,16 +543,22 @@ impl ChatAdapter {
                     ));
                     result.push_str("\n\n");
                 } else {
-                    result.push_str(field_spec.lm_name);
-                    result.push_str(":\n");
-                    result.push_str(&render_input_field(
+                    let rendered = render_input_field(
                         field_spec,
                         value,
                         &input_json,
                         input_output_format,
                         &vars,
-                    ));
-                    result.push_str("\n\n");
+                    );
+                    if raw_perception_mode {
+                        result.push_str(&rendered);
+                        result.push_str("\n");
+                    } else {
+                        result.push_str(field_spec.lm_name);
+                        result.push_str(":\n");
+                        result.push_str(&rendered);
+                        result.push_str("\n\n");
+                    }
                 }
             }
         }

--- a/crates/dspy-rs/src/adapter/chat.rs
+++ b/crates/dspy-rs/src/adapter/chat.rs
@@ -404,6 +404,16 @@ impl ChatAdapter {
         schema: &crate::SignatureSchema,
         instruction_override: Option<&str>,
     ) -> Result<String> {
+        if !self.is_structured_output()
+            && let Some(instruction_override) = instruction_override
+        {
+            trace!(
+                system_len = instruction_override.len(),
+                "formatted schema system prompt"
+            );
+            return Ok(instruction_override.to_string());
+        }
+
         let parts = if self.is_structured_output() {
             vec![
                 self.format_field_descriptions_schema(schema),

--- a/crates/dspy-rs/src/core/errors.rs
+++ b/crates/dspy-rs/src/core/errors.rs
@@ -1,6 +1,6 @@
 use std::{error::Error as StdError, time::Duration};
 
-use crate::{BamlConvertError, BamlValue, LmUsage};
+use crate::{BamlConvertError, BamlValue, Chat, LmUsage};
 
 /// Error from the jsonish coercion layer when LM output can't be parsed as a typed value.
 #[derive(Debug)]
@@ -56,6 +56,8 @@ pub enum ErrorClass {
 /// 3. **[`Conversion`](PredictError::Conversion)** — we parsed a valid `BamlValue`
 ///    from the response, but it doesn't fit the Rust output type. Code bug or schema
 ///    mismatch. **Not retryable** — the same parsed value will fail the same way.
+/// 4. **[`Module`](PredictError::Module)** — module-internal execution error outside
+///    of direct LM parsing/provider failure.
 ///
 /// Use [`is_retryable`](PredictError::is_retryable) for retry logic.
 /// Use [`class`](PredictError::class) for coarse [`ErrorClass`] bucketing.
@@ -78,6 +80,11 @@ pub enum PredictError {
         source: ParseError,
         raw_response: String,
         lm_usage: LmUsage,
+        /// Conversation history including the failed assistant turn.
+        ///
+        /// This enables callers (for example, multi-turn modules like RLM) to continue
+        /// the conversation after a recoverable parse failure.
+        chat: Chat,
     },
 
     /// The response parsed into a `BamlValue` but doesn't match the typed output struct.
@@ -91,6 +98,14 @@ pub enum PredictError {
         /// The successfully parsed `BamlValue` that failed type conversion.
         parsed: BamlValue,
     },
+
+    /// Module-level execution error not represented by LM/provider/parse conversion.
+    #[error("{module} module failed")]
+    Module {
+        module: &'static str,
+        #[source]
+        source: Box<dyn StdError + Send + Sync>,
+    },
 }
 
 impl PredictError {
@@ -99,6 +114,7 @@ impl PredictError {
             Self::Lm { source } => source.class(),
             Self::Parse { .. } => ErrorClass::BadResponse,
             Self::Conversion { .. } => ErrorClass::Internal,
+            Self::Module { .. } => ErrorClass::Internal,
         }
     }
 
@@ -107,6 +123,7 @@ impl PredictError {
             Self::Lm { source } => source.is_retryable(),
             Self::Parse { .. } => true,
             Self::Conversion { .. } => false,
+            Self::Module { .. } => false,
         }
     }
 }

--- a/crates/dspy-rs/src/core/lm/chat.rs
+++ b/crates/dspy-rs/src/core/lm/chat.rs
@@ -76,18 +76,8 @@ pub struct Message {
 }
 
 impl Message {
-    /// Creates a text-only message from a role string.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `role` is not one of `"system"`, `"user"`, or `"assistant"`.
-    pub fn new(role: &str, content: &str) -> Self {
-        let role = match role {
-            "system" => Role::System,
-            "user" => Role::User,
-            "assistant" => Role::Assistant,
-            _ => panic!("Invalid role: {role}"),
-        };
+    /// Creates a text-only message for a typed role.
+    pub fn new(role: Role, content: impl Into<String>) -> Self {
         Self {
             role,
             content: vec![ContentBlock::text(content)],
@@ -240,7 +230,7 @@ impl Message {
     /// Converts this message to a rig message for provider API calls.
     ///
     /// Returns `None` for system messages (rig handles them as preamble).
-    pub fn to_rig_message(&self) -> Option<RigMessage> {
+    pub(crate) fn to_rig_message(&self) -> Option<RigMessage> {
         match self.role {
             Role::System => None,
             Role::User => {
@@ -341,40 +331,13 @@ impl Message {
 
         let id = message.get("id").and_then(Value::as_str).map(String::from);
 
-        let content_val = message.get("content");
-
-        // Support both formats:
-        //   New: "content": [{ "type": "text", "text": "..." }, ...]
-        //   Legacy: "content": "plain string"
-        let content = match content_val {
-            Some(Value::Array(arr)) => arr
-                .iter()
-                .map(parse_content_block)
-                .collect::<Result<Vec<_>>>()?,
-            Some(Value::String(s)) => vec![ContentBlock::text(s.clone())],
-            _ => {
-                // Legacy type-tagged format: { "type": "tool_call", "tool_call": {...} }
-                match message.get("type").and_then(Value::as_str) {
-                    Some("tool_call") => {
-                        let tc: ToolCall = serde_json::from_value(message["tool_call"].clone())?;
-                        vec![ContentBlock::tool_call(tc)]
-                    }
-                    Some("tool_result") => {
-                        let tr: ToolResult =
-                            serde_json::from_value(message["tool_result"].clone())?;
-                        vec![ContentBlock::tool_result(tr)]
-                    }
-                    Some("reasoning") => {
-                        let r: Reasoning = serde_json::from_value(message["reasoning"].clone())?;
-                        vec![ContentBlock::reasoning(r)]
-                    }
-                    Some(other) => {
-                        return Err(anyhow::anyhow!("unsupported chat message type: {other}"));
-                    }
-                    None => return Err(anyhow::anyhow!("chat message missing content field")),
-                }
-            }
-        };
+        let content = message
+            .get("content")
+            .and_then(Value::as_array)
+            .ok_or_else(|| anyhow::anyhow!("chat message content must be an array"))?
+            .iter()
+            .map(parse_content_block)
+            .collect::<Result<Vec<_>>>()?;
 
         Ok(Self { role, content, id })
     }
@@ -411,7 +374,7 @@ fn parse_content_block(value: &Value) -> Result<ContentBlock> {
 }
 
 // ---------------------------------------------------------------------------
-// From<RigMessage> — lossless conversion, one rig message → one DSRs message
+// From<RigMessage> — grouped conversion, one rig message → one DSRs message
 // ---------------------------------------------------------------------------
 
 impl From<RigMessage> for Message {
@@ -485,7 +448,7 @@ impl Chat {
         self.messages.is_empty()
     }
 
-    pub fn push(&mut self, role: &str, content: &str) {
+    pub fn push(&mut self, role: Role, content: impl Into<String>) {
         self.messages.push(Message::new(role, content));
     }
 
@@ -524,7 +487,7 @@ impl Chat {
     // -- Rig interop ---------------------------------------------------------
 
     /// Extracts the system prompt text from the first system message.
-    pub fn system_prompt(&self) -> String {
+    pub(crate) fn system_prompt(&self) -> String {
         self.messages
             .iter()
             .find_map(|message| {
@@ -538,10 +501,113 @@ impl Chat {
     }
 
     /// Converts all non-system messages to rig messages for provider API calls.
-    pub fn to_rig_chat_history(&self) -> Vec<RigMessage> {
+    pub(crate) fn to_rig_chat_history(&self) -> Vec<RigMessage> {
         self.messages
             .iter()
             .filter_map(Message::to_rig_message)
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rig::OneOrMany;
+    use rig::message::{ToolFunction, ToolResultContent};
+    use serde_json::json;
+
+    #[test]
+    fn rig_conversion_preserves_assistant_reasoning_and_tool_calls() {
+        let original = Message::with_content(
+            Role::Assistant,
+            vec![
+                ContentBlock::reasoning(Reasoning::new("step 1")),
+                ContentBlock::reasoning(Reasoning::new("step 2")),
+                ContentBlock::tool_call(ToolCall::new(
+                    "tc-1".to_string(),
+                    ToolFunction {
+                        name: "search".to_string(),
+                        arguments: json!({"q": "rust ownership"}),
+                    },
+                )),
+            ],
+        );
+
+        let rig_msg = original
+            .to_rig_message()
+            .expect("assistant message should convert to rig");
+        let roundtripped = Message::from(rig_msg);
+
+        assert_eq!(roundtripped.role, Role::Assistant);
+        assert_eq!(roundtripped.content.len(), 3);
+        assert!(matches!(
+            &roundtripped.content[0],
+            ContentBlock::Reasoning { .. }
+        ));
+        assert!(matches!(
+            &roundtripped.content[1],
+            ContentBlock::Reasoning { .. }
+        ));
+        assert!(
+            matches!(&roundtripped.content[2], ContentBlock::ToolCall { tool_call } if tool_call.function.name == "search")
+        );
+    }
+
+    #[test]
+    fn rig_conversion_preserves_user_text_and_tool_result() {
+        let original = Message::with_content(
+            Role::User,
+            vec![
+                ContentBlock::text("Here is context"),
+                ContentBlock::tool_result(ToolResult {
+                    id: "tr-1".to_string(),
+                    call_id: Some("tc-1".to_string()),
+                    content: OneOrMany::one(ToolResultContent::text("search result")),
+                }),
+            ],
+        );
+
+        let rig_msg = original
+            .to_rig_message()
+            .expect("user should convert to rig");
+        let roundtripped = Message::from(rig_msg);
+
+        assert_eq!(roundtripped.role, Role::User);
+        assert_eq!(roundtripped.content.len(), 2);
+        assert!(
+            matches!(&roundtripped.content[0], ContentBlock::Text { text } if text == "Here is context")
+        );
+        assert!(roundtripped.has_tool_results());
+    }
+
+    #[test]
+    fn rig_chat_history_excludes_system_message() {
+        let chat = Chat::new(vec![
+            Message::system("You are a helpful assistant."),
+            Message::user("What is the capital of France?"),
+            Message::assistant("Paris."),
+        ]);
+
+        let rig_history = chat.to_rig_chat_history();
+        assert_eq!(rig_history.len(), 2);
+    }
+
+    #[test]
+    fn system_messages_are_not_converted_to_rig_messages() {
+        let msg = Message::system("You are helpful");
+        assert!(msg.to_rig_message().is_none());
+    }
+
+    #[test]
+    fn assistant_message_id_survives_rig_roundtrip() {
+        let mut msg = Message::assistant("some text");
+        msg.id = Some("msg_abc123".to_string());
+
+        let rig_msg = msg
+            .to_rig_message()
+            .expect("assistant should convert to rig");
+        let roundtripped = Message::from(rig_msg);
+
+        assert_eq!(roundtripped.id, Some("msg_abc123".to_string()));
     }
 }

--- a/crates/dspy-rs/src/core/lm/client_registry.rs
+++ b/crates/dspy-rs/src/core/lm/client_registry.rs
@@ -77,6 +77,7 @@ impl CompletionProvider for TestCompletionModel {
 #[derive(Clone)]
 pub enum LMClient {
     OpenAI(openai::completion::CompletionModel),
+    OpenAIResponses(openai::responses_api::ResponsesCompletionModel),
     Gemini(gemini::completion::CompletionModel),
     Anthropic(anthropic::completion::CompletionModel),
     Groq(groq::CompletionModel<reqwest::Client>),
@@ -99,6 +100,16 @@ impl CompletionProvider for openai::completion::CompletionModel {
     ) -> Result<CompletionResponse<()>, CompletionError> {
         let response = rig::completion::CompletionModel::completion(self, request).await?;
         // Convert the typed response to unit type
+        Ok(to_unit_completion_response(response))
+    }
+}
+
+impl CompletionProvider for openai::responses_api::ResponsesCompletionModel {
+    async fn completion(
+        &self,
+        request: CompletionRequest,
+    ) -> Result<CompletionResponse<()>, CompletionError> {
+        let response = rig::completion::CompletionModel::completion(self, request).await?;
         Ok(to_unit_completion_response(response))
     }
 }
@@ -213,6 +224,20 @@ impl CompletionProvider for deepseek::CompletionModel<reqwest::Client> {
 }
 
 impl LMClient {
+    fn parse_openai_model(model: &str) -> (&str, bool) {
+        if let Some(rest) = model
+            .strip_prefix("openai-responses:")
+            .or_else(|| model.strip_prefix("openai_responses:"))
+            .or_else(|| model.strip_prefix("openai.responses:"))
+        {
+            return (rest, true);
+        }
+        if let Some(rest) = model.strip_prefix("openai:") {
+            return (rest, false);
+        }
+        (model, false)
+    }
+
     #[tracing::instrument(
         name = "dsrs.lm.client.get_api_key",
         level = "trace",
@@ -236,15 +261,27 @@ impl LMClient {
         fields(model, base_url_present = true, api_key_present = true)
     )]
     pub fn from_openai_compatible(base_url: &str, api_key: &str, model: &str) -> Result<Self> {
-        trace!(base_url, "creating openai-compatible client");
-        let client = openai::CompletionsClient::builder()
-            .api_key(api_key)
-            .base_url(base_url)
-            .build()?;
-        debug!("openai-compatible client ready");
-        Ok(LMClient::OpenAI(openai::completion::CompletionModel::new(
-            client, model,
-        )))
+        let (model, use_responses) = Self::parse_openai_model(model);
+        trace!(base_url, use_responses, "creating openai-compatible client");
+        if use_responses {
+            let client = openai::Client::builder()
+                .api_key(api_key)
+                .base_url(base_url)
+                .build()?;
+            debug!("openai-compatible responses client ready");
+            Ok(LMClient::OpenAIResponses(
+                openai::responses_api::ResponsesCompletionModel::new(client, model),
+            ))
+        } else {
+            let client = openai::CompletionsClient::builder()
+                .api_key(api_key)
+                .base_url(base_url)
+                .build()?;
+            debug!("openai-compatible client ready");
+            Ok(LMClient::OpenAI(openai::completion::CompletionModel::new(
+                client, model,
+            )))
+        }
     }
 
     /// Build case 2: Local OpenAI-compatible model from base_url (vLLM, etc.)
@@ -256,15 +293,30 @@ impl LMClient {
         fields(model, base_url_present = true)
     )]
     pub fn from_local(base_url: &str, model: &str) -> Result<Self> {
-        trace!(base_url, "creating local openai-compatible client");
-        let client = openai::CompletionsClient::builder()
-            .api_key("dummy-key-for-local-server")
-            .base_url(base_url)
-            .build()?;
-        debug!("local openai-compatible client ready");
-        Ok(LMClient::OpenAI(openai::completion::CompletionModel::new(
-            client, model,
-        )))
+        let (model, use_responses) = Self::parse_openai_model(model);
+        trace!(
+            base_url,
+            use_responses, "creating local openai-compatible client"
+        );
+        if use_responses {
+            let client = openai::Client::builder()
+                .api_key("dummy-key-for-local-server")
+                .base_url(base_url)
+                .build()?;
+            debug!("local openai-compatible responses client ready");
+            Ok(LMClient::OpenAIResponses(
+                openai::responses_api::ResponsesCompletionModel::new(client, model),
+            ))
+        } else {
+            let client = openai::CompletionsClient::builder()
+                .api_key("dummy-key-for-local-server")
+                .base_url(base_url)
+                .build()?;
+            debug!("local openai-compatible client ready");
+            Ok(LMClient::OpenAI(openai::completion::CompletionModel::new(
+                client, model,
+            )))
+        }
     }
 
     /// Build case 3: From provider via model name (provider:model format)
@@ -286,6 +338,14 @@ impl LMClient {
         tracing::Span::current().record("model_id", tracing::field::display(model_id));
 
         match provider {
+            "openai-responses" | "openai_responses" | "openai.responses" => {
+                debug!("selecting openai responses provider");
+                let key = Self::get_api_key(api_key, "OPENAI_API_KEY")?;
+                let client = openai::Client::builder().api_key(key.as_ref()).build()?;
+                Ok(LMClient::OpenAIResponses(
+                    openai::responses_api::ResponsesCompletionModel::new(client, model_id),
+                ))
+            }
             "openai" => {
                 debug!("selecting openai provider");
                 let key = Self::get_api_key(api_key, "OPENAI_API_KEY")?;
@@ -340,7 +400,7 @@ impl LMClient {
             _ => {
                 warn!(provider, "unsupported provider");
                 anyhow::bail!(
-                    "Unsupported provider: {}. Supported providers are: openai, anthropic, gemini, groq, openrouter, ollama",
+                    "Unsupported provider: {}. Supported providers are: openai, openai-responses, anthropic, gemini, groq, openrouter, ollama",
                     provider
                 );
             }

--- a/crates/dspy-rs/src/core/lm/client_registry.rs
+++ b/crates/dspy-rs/src/core/lm/client_registry.rs
@@ -14,6 +14,11 @@ use std::{
 };
 use tracing::{debug, trace, warn};
 
+#[derive(Clone, Debug, Default)]
+pub struct ProviderOptions {
+    pub anthropic_prompt_caching: bool,
+}
+
 #[enum_dispatch]
 #[allow(async_fn_in_trait)]
 pub trait CompletionProvider {
@@ -331,6 +336,25 @@ impl LMClient {
         )
     )]
     pub fn from_model_string(model_str: &str, api_key: Option<&str>) -> Result<Self> {
+        Self::from_model_string_with_options(model_str, api_key, &ProviderOptions::default())
+    }
+
+    #[tracing::instrument(
+        name = "dsrs.lm.client.from_model_string_with_options",
+        level = "debug",
+        skip(model_str, api_key, options),
+        fields(
+            provider = tracing::field::Empty,
+            model_id = tracing::field::Empty,
+            api_key_present = api_key.is_some(),
+            anthropic_prompt_caching = options.anthropic_prompt_caching
+        )
+    )]
+    pub fn from_model_string_with_options(
+        model_str: &str,
+        api_key: Option<&str>,
+        options: &ProviderOptions,
+    ) -> Result<Self> {
         let (provider, model_id) = model_str.split_once(':').ok_or(anyhow::anyhow!(
             "Model string must be in format 'provider:model_name'"
         ))?;
@@ -360,9 +384,11 @@ impl LMClient {
                 debug!("selecting anthropic provider");
                 let key = Self::get_api_key(api_key, "ANTHROPIC_API_KEY")?;
                 let client = anthropic::Client::builder().api_key(key.as_ref()).build()?;
-                Ok(LMClient::Anthropic(
-                    anthropic::completion::CompletionModel::new(client, model_id),
-                ))
+                let mut model = anthropic::completion::CompletionModel::new(client, model_id);
+                if options.anthropic_prompt_caching {
+                    model = model.with_prompt_caching();
+                }
+                Ok(LMClient::Anthropic(model))
             }
             "gemini" => {
                 debug!("selecting gemini provider");
@@ -414,5 +440,42 @@ impl LMClient {
     /// each variant type, so you can use this with any concrete completion model.
     pub fn from_custom<T: Into<LMClient>>(client: T) -> Self {
         client.into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn anthropic_prompt_caching_option_enables_model_flag() {
+        let client = LMClient::from_model_string_with_options(
+            "anthropic:claude-opus-4-0",
+            Some("test-key"),
+            &ProviderOptions {
+                anthropic_prompt_caching: true,
+            },
+        )
+        .expect("anthropic client should build");
+
+        match client {
+            LMClient::Anthropic(model) => assert!(model.prompt_caching),
+            _ => panic!("expected anthropic client"),
+        }
+    }
+
+    #[test]
+    fn anthropic_prompt_caching_defaults_to_disabled() {
+        let client = LMClient::from_model_string_with_options(
+            "anthropic:claude-opus-4-0",
+            Some("test-key"),
+            &ProviderOptions::default(),
+        )
+        .expect("anthropic client should build");
+
+        match client {
+            LMClient::Anthropic(model) => assert!(!model.prompt_caching),
+            _ => panic!("expected anthropic client"),
+        }
     }
 }

--- a/crates/dspy-rs/src/core/lm/mod.rs
+++ b/crates/dspy-rs/src/core/lm/mod.rs
@@ -8,6 +8,7 @@ pub use usage::*;
 
 use anyhow::Result;
 use rig::{completion::AssistantContent, message::ToolCall, message::ToolChoice, tool::ToolDyn};
+use serde_json::Value;
 
 use bon::Builder;
 use std::{collections::HashMap, sync::Arc};
@@ -50,6 +51,11 @@ pub struct LM {
     pub max_tokens: u32,
     #[builder(default = 10)]
     pub max_tool_iterations: u32,
+    /// Provider-specific request parameters forwarded to rig `CompletionRequest.additional_params`.
+    pub additional_params: Option<Value>,
+    /// Enables Anthropic prompt caching when using `anthropic:model` model strings.
+    #[builder(default = false)]
+    pub anthropic_prompt_caching: bool,
     #[builder(default = false)]
     pub cache: bool,
     pub cache_handler: Option<Arc<Mutex<ResponseCache>>>,
@@ -72,6 +78,8 @@ impl Clone for LM {
             temperature: self.temperature,
             max_tokens: self.max_tokens,
             max_tool_iterations: self.max_tool_iterations,
+            additional_params: self.additional_params.clone(),
+            anthropic_prompt_caching: self.anthropic_prompt_caching,
             cache: self.cache,
             cache_handler: self.cache_handler.clone(),
             client: self.client.clone(),
@@ -127,7 +135,13 @@ impl LM {
             // Uses provider-specific clients
             (None, api_key, model) if model.contains(':') => {
                 debug!(build_case = 3, "using provider:model client");
-                Arc::new(LMClient::from_model_string(model, api_key.as_deref())?)
+                Arc::new(LMClient::from_model_string_with_options(
+                    model,
+                    api_key.as_deref(),
+                    &ProviderOptions {
+                        anthropic_prompt_caching: self.anthropic_prompt_caching,
+                    },
+                )?)
             }
             // Default case: assume OpenAI provider if no colon in model name
             (None, api_key, model) => {
@@ -137,7 +151,13 @@ impl LM {
                 } else {
                     format!("openai:{}", model)
                 };
-                Arc::new(LMClient::from_model_string(&model_str, api_key.as_deref())?)
+                Arc::new(LMClient::from_model_string_with_options(
+                    &model_str,
+                    api_key.as_deref(),
+                    &ProviderOptions {
+                        anthropic_prompt_caching: self.anthropic_prompt_caching,
+                    },
+                )?)
             }
         };
 
@@ -425,7 +445,7 @@ impl LM {
                 temperature: Some(self.temperature as f64),
                 max_tokens: Some(self.max_tokens as u64),
                 tool_choice: Some(ToolChoice::Auto),
-                additional_params: None,
+                additional_params: self.additional_params.clone(),
                 output_schema: None,
             };
 
@@ -534,7 +554,7 @@ impl LM {
             } else {
                 None
             },
-            additional_params: None,
+            additional_params: self.additional_params.clone(),
             output_schema: None,
         };
 
@@ -1018,9 +1038,18 @@ mod tests {
             temperature: 0.0,
             max_tokens: 128,
             max_tool_iterations: 4,
+            additional_params: None,
+            anthropic_prompt_caching: false,
             cache: false,
             cache_handler: None,
             client: Some(Arc::new(LMClient::Test(model))),
+        }
+    }
+
+    fn test_lm_with_model_and_params(model: TestCompletionModel, additional_params: Value) -> LM {
+        LM {
+            additional_params: Some(additional_params),
+            ..test_lm_with_model(model)
         }
     }
 
@@ -1047,6 +1076,29 @@ mod tests {
         assert!(response.output.content().contains("counter"));
         assert_eq!(response.chat.len(), 2);
         assert!(response.chat.messages[1].has_tool_calls());
+    }
+
+    #[tokio::test]
+    async fn call_forwards_additional_params_to_completion_request() {
+        let model = TestCompletionModel::new([make_text("ok")]);
+        let lm = test_lm_with_model_and_params(
+            model.clone(),
+            serde_json::json!({
+                "reasoning": { "effort": "high" }
+            }),
+        );
+
+        let chat = Chat::new(vec![Message::user("hello")]);
+        let _ = lm
+            .call(chat, Vec::new(), ToolLoopMode::CallerManaged)
+            .await
+            .expect("call should succeed");
+
+        let request = model.last_request().expect("request should be captured");
+        assert_eq!(
+            request.additional_params,
+            Some(serde_json::json!({ "reasoning": { "effort": "high" } }))
+        );
     }
 
     #[tokio::test]

--- a/crates/dspy-rs/src/core/mod.rs
+++ b/crates/dspy-rs/src/core/mod.rs
@@ -7,7 +7,8 @@
 //! input, returns a predicted output) so that strategies are interchangeable.
 //!
 //! [`Predicted`] wraps a typed output with [`CallMetadata`] (raw response text, token
-//! usage, per-field parse results). The error hierarchy — [`PredictError`], [`ParseError`],
+//! usage, per-field parse results) and [`Chat`] (the conversation history from the LM
+//! call). The error hierarchy — [`PredictError`], [`ParseError`],
 //! [`LmError`] — distinguishes LM failures from parse failures so callers can handle
 //! retries differently. [`LM`] is the language model client itself.
 //!

--- a/crates/dspy-rs/src/core/mod.rs
+++ b/crates/dspy-rs/src/core/mod.rs
@@ -31,6 +31,7 @@ mod schema;
 pub mod settings;
 pub mod signature;
 pub mod specials;
+mod type_name;
 
 pub(crate) use dyn_predictor::*;
 pub use errors::{ConversionError, ErrorClass, JsonishError, LmError, ParseError, PredictError};
@@ -42,3 +43,4 @@ pub use schema::{FieldMetadataSpec, FieldPath, FieldSchema, InputRenderSpec, Sig
 pub use settings::*;
 pub use signature::*;
 pub use specials::*;
+pub(crate) use type_name::{render_type_name_for_prompt_with, simplify_type_token};

--- a/crates/dspy-rs/src/core/module.rs
+++ b/crates/dspy-rs/src/core/module.rs
@@ -17,13 +17,15 @@ type IndexedForwardResult<T> = (usize, Result<Predicted<T>, PredictError>);
 /// implementors. `call` currently just delegates to `forward` — the split exists so we
 /// can add hooks or tracing around `call` without breaking module implementations.
 ///
-/// # Two kinds of output data
+/// # Three kinds of output data
 ///
 /// Every call returns [`Predicted<Output>`](crate::Predicted), which carries:
 /// - **`Output`** — what the LM was asked to produce. Shaped by your signature and any
 ///   augmentations. Accessible directly via `Deref`: `result.answer`, `result.reasoning`.
 /// - **[`CallMetadata`](crate::CallMetadata)** — what the runtime observed. Token counts,
 ///   raw response, constraint results. Never enters a prompt. Via `result.metadata()`.
+/// - **[`Chat`](crate::Chat)** — conversation history for the call, including the assistant
+///   response turn, so callers can continue multi-turn interactions via `result.chat()`.
 ///
 /// This drives the type system: [`ChainOfThought`](crate::ChainOfThought) changes `Output`
 /// because it modifies the prompt (adds a `reasoning` field). A wrapper like `BestOfN` keeps

--- a/crates/dspy-rs/src/core/module_ext.rs
+++ b/crates/dspy-rs/src/core/module_ext.rs
@@ -77,8 +77,8 @@ where
 
     async fn forward(&self, input: Self::Input) -> Result<Predicted<Self::Output>, PredictError> {
         let predicted = self.inner.call(input).await?;
-        let (output, metadata) = predicted.into_parts();
-        Ok(Predicted::new((self.map)(output), metadata))
+        let (output, metadata, chat) = predicted.into_parts();
+        Ok(Predicted::new((self.map)(output), metadata, chat))
     }
 }
 
@@ -107,8 +107,8 @@ where
 
     async fn forward(&self, input: Self::Input) -> Result<Predicted<Self::Output>, PredictError> {
         let predicted = self.inner.call(input).await?;
-        let (output, metadata) = predicted.into_parts();
+        let (output, metadata, chat) = predicted.into_parts();
         let transformed = (self.and_then)(output)?;
-        Ok(Predicted::new(transformed, metadata))
+        Ok(Predicted::new(transformed, metadata, chat))
     }
 }

--- a/crates/dspy-rs/src/core/type_name.rs
+++ b/crates/dspy-rs/src/core/type_name.rs
@@ -1,0 +1,52 @@
+use crate::TypeIR;
+
+pub(crate) fn simplify_type_token(token: &str) -> String {
+    token.rsplit("::").next().unwrap_or(token).to_string()
+}
+
+pub(crate) fn simplify_type_name_with(
+    raw: &str,
+    mut render_token: impl FnMut(&str) -> String,
+) -> String {
+    let mut result = String::with_capacity(raw.len());
+    let mut chars = raw.chars();
+    while let Some(ch) = chars.next() {
+        if ch == '`' {
+            let mut token = String::new();
+            for next in chars.by_ref() {
+                if next == '`' {
+                    break;
+                }
+                token.push(next);
+            }
+            result.push_str(&render_token(&token));
+        } else {
+            result.push(ch);
+        }
+    }
+    result
+}
+
+pub(crate) fn render_type_name_for_prompt_with(
+    type_ir: &TypeIR,
+    render_token: impl FnMut(&str) -> String,
+) -> String {
+    simplify_type_name_with(&type_ir.diagnostic_repr().to_string(), render_token)
+        .replace("class ", "")
+        .replace("enum ", "")
+        .replace(" | ", " or ")
+        .trim()
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn simplify_type_name_with_rewrites_backtick_tokens() {
+        let raw = "class `my::pkg::Thing` | `other::Foo`";
+        let rendered = simplify_type_name_with(raw, simplify_type_token);
+        assert_eq!(rendered, "class Thing | Foo");
+    }
+}

--- a/crates/dspy-rs/src/lib.rs
+++ b/crates/dspy-rs/src/lib.rs
@@ -131,6 +131,8 @@ pub use bamltype::internal_baml_jinja::types::{OutputFormatContent, RenderOption
 pub use bamltype::jsonish::deserializer::deserialize_flags::Flag;
 pub use dsrs_macros::*;
 pub use facet::Facet;
+#[cfg(feature = "rlm")]
+pub use modules::rlm::RlmInputFields;
 
 /// Pre-built signature for use in doc examples. Not part of the public API.
 #[doc(hidden)]
@@ -153,6 +155,8 @@ pub mod __macro_support {
     pub use schemars;
     pub use serde;
     pub use serde_json;
+    #[cfg(feature = "rlm")]
+    pub use pyo3;
 }
 
 #[macro_export]

--- a/crates/dspy-rs/src/lib.rs
+++ b/crates/dspy-rs/src/lib.rs
@@ -41,7 +41,7 @@
 //!     .build()
 //!     .await
 //!     .unwrap();
-//! dspy_rs::configure(lm, ChatAdapter);
+//! dspy_rs::configure(lm, ChatAdapter::new());
 //!
 //! // 2. Pick a strategy
 //! let cot = ChainOfThought::<QA>::new();

--- a/crates/dspy-rs/src/lib.rs
+++ b/crates/dspy-rs/src/lib.rs
@@ -133,6 +133,8 @@ pub use dsrs_macros::*;
 pub use facet::Facet;
 #[cfg(feature = "rlm")]
 pub use modules::rlm::RlmInputFields;
+#[cfg(feature = "rlm")]
+pub use rlm_derive::{RlmType, rlm_type};
 
 /// Pre-built signature for use in doc examples. Not part of the public API.
 #[doc(hidden)]
@@ -152,11 +154,11 @@ pub mod __macro_support {
     pub use anyhow;
     pub use bamltype;
     pub use indexmap;
+    #[cfg(feature = "rlm")]
+    pub use pyo3;
     pub use schemars;
     pub use serde;
     pub use serde_json;
-    #[cfg(feature = "rlm")]
-    pub use pyo3;
 }
 
 #[macro_export]

--- a/crates/dspy-rs/src/modules/mod.rs
+++ b/crates/dspy-rs/src/modules/mod.rs
@@ -1,5 +1,9 @@
 pub mod chain_of_thought;
 pub mod react;
+#[cfg(feature = "rlm")]
+pub mod rlm;
 
 pub use chain_of_thought::{ChainOfThought, ChainOfThoughtOutput, Reasoning, WithReasoning};
 pub use react::ReAct;
+#[cfg(feature = "rlm")]
+pub use rlm::Rlm;

--- a/crates/dspy-rs/src/modules/react.rs
+++ b/crates/dspy-rs/src/modules/react.rs
@@ -158,7 +158,7 @@ where
                 ReActActionStepInput::new(serialized_input.clone(), trajectory_text.clone());
 
             let action_predicted = self.action.call(action_input).await?;
-            let (action_output, mut action_metadata) = action_predicted.into_parts();
+            let (action_output, mut action_metadata, _action_chat) = action_predicted.into_parts();
             tool_calls.append(&mut action_metadata.tool_calls);
             tool_executions.append(&mut action_metadata.tool_executions);
 
@@ -220,12 +220,16 @@ where
         let extract_input = ReActExtractStepInput::new(serialized_input, trajectory_text);
 
         let extract_predicted = self.extract.call(extract_input).await?;
-        let (extract_output, mut extract_metadata) = extract_predicted.into_parts();
+        let (extract_output, mut extract_metadata, extract_chat) = extract_predicted.into_parts();
         extract_metadata.tool_calls.extend(tool_calls);
         extract_metadata.tool_executions.extend(tool_executions);
 
         let output: ReActExtractStepOutput<S::Output> = extract_output;
-        Ok(Predicted::new(output.output, extract_metadata))
+        Ok(Predicted::new(
+            output.output,
+            extract_metadata,
+            extract_chat,
+        ))
     }
 }
 

--- a/crates/dspy-rs/src/modules/rlm/exec.rs
+++ b/crates/dspy-rs/src/modules/rlm/exec.rs
@@ -1,3 +1,4 @@
+use pyo3::exceptions::PyRuntimeError;
 use pyo3::ffi::c_str;
 use pyo3::types::{PyAnyMethods, PyDict, PyModule};
 use pyo3::{Py, PyResult, Python};
@@ -82,17 +83,19 @@ fn run_exec(
     suppress_output: bool,
     max_output_chars: usize,
 ) -> PyResult<String> {
-    let module = PyModule::from_code(
-        py,
+    let helper_globals = PyDict::new(py);
+    py.run(
         EXEC_HELPER_CODE,
-        c_str!("<dsrs_exec>"),
-        c_str!("dsrs_exec"),
+        Some(&helper_globals),
+        Some(&helper_globals),
     )?;
-    let exec_fn = module.getattr("dsrs_exec")?;
+    let exec_fn = helper_globals
+        .get_item("dsrs_exec")
+        .map_err(|_| PyRuntimeError::new_err("dsrs_exec helper function missing"))?;
     let globals = globals.bind(py);
     match exec_fn.call1((code, globals, suppress_output)) {
         Ok(result) => {
-            let (stdout, repr): (String, Option<String>) = result.extract()?;
+            let (stdout, repr) = result.extract::<(String, Option<String>)>()?;
             Ok(format_output(stdout, repr, max_output_chars))
         }
         Err(err) if is_submit_terminated(&err, py) => {
@@ -291,10 +294,16 @@ mod tests {
 
             assert!(err.contains("Traceback"));
             assert!(
-                err.contains("ModuleNotFoundError") || err.contains("ImportError"),
-                "expected import failure class in traceback: {err}"
+                err.contains("ModuleNotFoundError")
+                    || err.contains("ImportError")
+                    || err.contains("AttributeError"),
+                "expected import-related failure class in traceback: {err}"
             );
-            assert!(err.contains("definitely_missing_module_xyz"));
+            assert!(
+                err.contains("definitely_missing_module_xyz")
+                    || err.contains("partially initialized module"),
+                "expected import target or fallback import error context: {err}"
+            );
         });
     }
 

--- a/crates/dspy-rs/src/modules/rlm/exec.rs
+++ b/crates/dspy-rs/src/modules/rlm/exec.rs
@@ -73,6 +73,18 @@ pub fn execute_repl_code(
     ) {
         Ok(output) => Ok(output),
         Err(err) => {
+            if let Some(repaired_code) = maybe_repair_submit_code(py, &prepared_code, &err) {
+                match run_exec(
+                    py,
+                    globals,
+                    &repaired_code,
+                    suppress_output,
+                    max_output_chars,
+                ) {
+                    Ok(output) => return Ok(output),
+                    Err(_repaired_err) => {}
+                }
+            }
             let stdout = extract_submit_stdout(py, &err).unwrap_or_default();
             let traceback = extract_traceback(py, &err)
                 .or_else(|| format_python_traceback(py, &err).ok())
@@ -81,6 +93,50 @@ pub fn execute_repl_code(
             Err(truncate_capture_output(&combined, max_output_chars))
         }
     }
+}
+
+fn maybe_repair_submit_code(py: Python<'_>, code: &str, err: &pyo3::PyErr) -> Option<String> {
+    if !code.contains("SUBMIT(") {
+        return None;
+    }
+
+    let traceback = extract_traceback(py, err).or_else(|| format_python_traceback(py, err).ok())?;
+    if !traceback.contains("SyntaxError")
+        || (!traceback.contains("unterminated triple-quoted string literal")
+            && !traceback.contains("unterminated string literal"))
+    {
+        return None;
+    }
+
+    repair_submit_code(code)
+}
+
+fn repair_submit_code(code: &str) -> Option<String> {
+    if !code.contains("SUBMIT(") {
+        return None;
+    }
+
+    let mut repaired = code.trim_end().to_string();
+    let mut changed = false;
+
+    for quote in ["\"\"\"", "'''"] {
+        if repaired.matches(quote).count() % 2 != 0 {
+            repaired.push_str(quote);
+            changed = true;
+        }
+    }
+
+    if let Some(submit_start) = repaired.rfind("SUBMIT(") {
+        let tail = &repaired[submit_start..];
+        let open_parens = tail.chars().filter(|&c| c == '(').count();
+        let close_parens = tail.chars().filter(|&c| c == ')').count();
+        if open_parens > close_parens {
+            repaired.push_str(&")".repeat(open_parens - close_parens));
+            changed = true;
+        }
+    }
+
+    if changed { Some(repaired) } else { None }
 }
 
 fn preprocess_repl_code(code: &str) -> String {
@@ -416,6 +472,34 @@ mod tests {
             let raw = "Let me start by exploring the data to understand the structure and then systematically find recurring corrections.\n\n```python\n# First, explore the data structure\nprint('ok')\n```";
             let output = execute_repl_code(py, &globals, raw, 500).expect("exec");
             assert_eq!(output, "ok\n");
+        });
+    }
+
+    #[test]
+    fn repair_submit_code_closes_unterminated_triple_quote_and_paren() {
+        let repaired = repair_submit_code("SUBMIT(direct_answer=\"\"\"hello")
+            .expect("repair should produce code");
+        assert_eq!(repaired, "SUBMIT(direct_answer=\"\"\"hello\"\"\")");
+    }
+
+    #[test]
+    fn execute_repl_code_repairs_unterminated_submit_payload() {
+        Python::attach(|py| {
+            let globals = PyDict::new(py);
+            globals
+                .set_item("SubmitTerminated", py.get_type::<SubmitTerminated>())
+                .expect("set type");
+            py.run(
+                c_str!("def SUBMIT(**kwargs):\n    raise SubmitTerminated('done')\n"),
+                Some(&globals),
+                Some(&globals),
+            )
+            .expect("submit helper");
+            let globals = globals.unbind();
+
+            let output = execute_repl_code(py, &globals, "SUBMIT(direct_answer=\"\"\"hello", 500)
+                .expect("submit should recover");
+            assert_eq!(output, NO_OUTPUT_MESSAGE);
         });
     }
 }

--- a/crates/dspy-rs/src/modules/rlm/exec.rs
+++ b/crates/dspy-rs/src/modules/rlm/exec.rs
@@ -7,6 +7,7 @@ use super::submit::{SUBMIT_STDOUT_ATTR, is_submit_terminated};
 
 const NO_OUTPUT_MESSAGE: &str = "(no output - did you forget to print?)";
 const TRACEBACK_ATTR: &str = "__dsrs_traceback__";
+const LLM_BUDGET_EXHAUSTED_PREFIX: &str = "LLM call budget exhausted: requested ";
 
 static EXEC_HELPER_CODE: &std::ffi::CStr = c_str!(
     r#"
@@ -89,6 +90,10 @@ pub fn execute_repl_code(
             let traceback = extract_traceback(py, &err)
                 .or_else(|| format_python_traceback(py, &err).ok())
                 .unwrap_or_else(|| err.to_string());
+            if let Some(resource_message) = format_resource_budget_message(&traceback) {
+                let combined = combine_stdout_and_message(stdout, resource_message);
+                return Err(truncate_capture_output(&combined, max_output_chars));
+            }
             let combined = combine_stdout_and_traceback(stdout, traceback);
             Err(truncate_capture_output(&combined, max_output_chars))
         }
@@ -255,6 +260,38 @@ fn combine_stdout_and_traceback(stdout: String, traceback: String) -> String {
     } else {
         format!("{stdout}\n{traceback}")
     }
+}
+
+fn combine_stdout_and_message(stdout: String, message: String) -> String {
+    if stdout.is_empty() {
+        return message;
+    }
+    if stdout.ends_with('\n') {
+        format!("{stdout}{message}")
+    } else {
+        format!("{stdout}\n{message}")
+    }
+}
+
+fn format_resource_budget_message(traceback: &str) -> Option<String> {
+    let after_prefix = traceback.split_once(LLM_BUDGET_EXHAUSTED_PREFIX)?.1;
+    let (requested_raw, after_requested) = after_prefix.split_once(", remaining ")?;
+    let (remaining_raw, after_remaining) = after_requested.split_once(", max ")?;
+    let max_raw: String = after_remaining
+        .chars()
+        .take_while(|ch| ch.is_ascii_digit())
+        .collect();
+    if max_raw.is_empty() {
+        return None;
+    }
+
+    let requested = requested_raw.trim().parse::<usize>().ok()?;
+    let remaining = remaining_raw.trim().parse::<usize>().ok()?;
+    let max = max_raw.parse::<usize>().ok()?;
+
+    Some(format!(
+        "⛔ RESOURCE: llm_query({requested}) refused — {remaining} of {max} calls remain.\ncode was valid. namespace unchanged."
+    ))
 }
 
 fn format_output(stdout: String, repr: Option<String>, max_chars: usize) -> String {
@@ -519,6 +556,28 @@ mod tests {
             let output = execute_repl_code(py, &globals, "SUBMIT(direct_answer=\"\"\"hello", 500)
                 .expect("submit should recover");
             assert_eq!(output, NO_OUTPUT_MESSAGE);
+        });
+    }
+
+    #[test]
+    fn budget_exhaustion_errors_are_rendered_as_resource_messages_without_traceback() {
+        Python::attach(|py| {
+            let globals = PyDict::new(py);
+            py.run(
+                c_str!(
+                    "def llm_query(prompt):\n    raise RuntimeError(\"[Error] RuntimeError: LLM call budget exhausted: requested 1, remaining 0, max 20. This is retryable after reducing llm_query usage.\")\n"
+                ),
+                Some(&globals),
+                Some(&globals),
+            )
+            .expect("define llm_query");
+            let globals = globals.unbind();
+
+            let err = execute_repl_code(py, &globals, "llm_query('hello')", 500)
+                .expect_err("budget exhaustion should fail");
+            assert!(err.contains("⛔ RESOURCE: llm_query(1) refused — 0 of 20 calls remain."));
+            assert!(err.contains("code was valid. namespace unchanged."));
+            assert!(!err.contains("Traceback"));
         });
     }
 }

--- a/crates/dspy-rs/src/modules/rlm/exec.rs
+++ b/crates/dspy-rs/src/modules/rlm/exec.rs
@@ -1,0 +1,282 @@
+use pyo3::ffi::c_str;
+use pyo3::types::{PyAnyMethods, PyDict, PyModule};
+use pyo3::{Py, PyResult, Python};
+
+use super::submit::{SUBMIT_STDOUT_ATTR, is_submit_terminated};
+
+const NO_OUTPUT_MESSAGE: &str = "(no output - did you forget to print?)";
+
+static EXEC_HELPER_CODE: &std::ffi::CStr = c_str!(
+    r#"
+import ast
+import contextlib
+import io
+
+
+def dsrs_exec(code, globals_dict, suppress_output):
+    buffer = io.StringIO()
+    result = None
+    with contextlib.redirect_stdout(buffer):
+        try:
+            parsed = ast.parse(code, mode="exec")
+            if suppress_output or not parsed.body:
+                exec(compile(parsed, "<repl>", "exec"), globals_dict, globals_dict)
+            else:
+                last = parsed.body[-1]
+                if isinstance(last, ast.Expr):
+                    body = parsed.body[:-1]
+                    if body:
+                        exec(
+                            compile(ast.Module(body=body, type_ignores=[]), "<repl>", "exec"),
+                            globals_dict,
+                            globals_dict,
+                        )
+                    result = eval(
+                        compile(ast.Expression(last.value), "<repl>", "eval"),
+                        globals_dict,
+                        globals_dict,
+                    )
+                else:
+                    exec(compile(parsed, "<repl>", "exec"), globals_dict, globals_dict)
+        except BaseException as exc:
+            try:
+                setattr(exc, "__dsrs_stdout__", buffer.getvalue())
+            except Exception:
+                pass
+            raise
+    return buffer.getvalue(), (None if result is None else repr(result))
+"#
+);
+
+pub fn execute_repl_code(
+    py: Python<'_>,
+    globals: &Py<PyDict>,
+    code: &str,
+    max_output_chars: usize,
+) -> Result<String, String> {
+    let suppress_output = code.trim_end().ends_with(';');
+
+    match run_exec(py, globals, code, suppress_output, max_output_chars) {
+        Ok(output) => Ok(output),
+        Err(err) => {
+            let stdout = extract_submit_stdout(py, &err).unwrap_or_default();
+            let traceback = format_python_traceback(py, &err).unwrap_or_else(|_| err.to_string());
+            let combined = combine_stdout_and_traceback(stdout, traceback);
+            Err(truncate_capture_output(&combined, max_output_chars))
+        }
+    }
+}
+
+fn run_exec(
+    py: Python<'_>,
+    globals: &Py<PyDict>,
+    code: &str,
+    suppress_output: bool,
+    max_output_chars: usize,
+) -> PyResult<String> {
+    let module = PyModule::from_code(
+        py,
+        EXEC_HELPER_CODE,
+        c_str!("<dsrs_exec>"),
+        c_str!("dsrs_exec"),
+    )?;
+    let exec_fn = module.getattr("dsrs_exec")?;
+    let globals = globals.bind(py);
+    match exec_fn.call1((code, globals, suppress_output)) {
+        Ok(result) => {
+            let (stdout, repr): (String, Option<String>) = result.extract()?;
+            Ok(format_output(stdout, repr, max_output_chars))
+        }
+        Err(err) if is_submit_terminated(&err, py) => {
+            let stdout = extract_submit_stdout(py, &err).unwrap_or_default();
+            Ok(format_output(stdout, None, max_output_chars))
+        }
+        Err(err) => Err(err),
+    }
+}
+
+fn extract_submit_stdout(py: Python<'_>, err: &pyo3::PyErr) -> Option<String> {
+    err.value(py)
+        .getattr(SUBMIT_STDOUT_ATTR)
+        .ok()
+        .and_then(|value| value.extract::<String>().ok())
+}
+
+fn format_python_traceback(py: Python<'_>, err: &pyo3::PyErr) -> PyResult<String> {
+    let traceback = PyModule::import(py, "traceback")?;
+    let formatted = traceback.getattr("format_exception")?.call1((
+        err.get_type(py),
+        err.value(py),
+        err.traceback(py),
+    ))?;
+    let parts: Vec<String> = formatted.extract()?;
+    Ok(parts.join(""))
+}
+
+fn combine_stdout_and_traceback(stdout: String, traceback: String) -> String {
+    if stdout.is_empty() {
+        return traceback;
+    }
+    if stdout.ends_with('\n') {
+        format!("{stdout}{traceback}")
+    } else {
+        format!("{stdout}\n{traceback}")
+    }
+}
+
+fn format_output(stdout: String, repr: Option<String>, max_chars: usize) -> String {
+    let mut output = stdout;
+    if let Some(repr) = repr {
+        if !output.is_empty() && !output.ends_with('\n') {
+            output.push('\n');
+        }
+        output.push_str(&repr);
+    }
+
+    if output.is_empty() {
+        output = NO_OUTPUT_MESSAGE.to_string();
+    }
+
+    truncate_capture_output(&output, max_chars)
+}
+
+fn truncate_capture_output(text: &str, max_chars: usize) -> String {
+    if max_chars == 0 {
+        return String::new();
+    }
+    let total = text.chars().count();
+    if total <= max_chars {
+        return text.to_string();
+    }
+
+    let head_len = max_chars / 2;
+    let tail_len = max_chars.saturating_sub(head_len);
+
+    let head: String = text.chars().take(head_len).collect();
+    let tail: String = text.chars().skip(total.saturating_sub(tail_len)).collect();
+
+    format!("{head}\n... (truncated)\n{tail}")
+}
+
+#[cfg(test)]
+mod tests {
+    use pyo3::types::{PyDict, PyDictMethods};
+
+    use super::*;
+    use crate::modules::rlm::submit::SubmitTerminated;
+
+    #[test]
+    fn executes_expression_and_returns_repr() {
+        Python::attach(|py| {
+            let globals = PyDict::new(py).unbind();
+            let output = execute_repl_code(py, &globals, "1 + 2", 100).expect("exec");
+            assert_eq!(output, "3");
+        });
+    }
+
+    #[test]
+    fn combines_stdout_and_repr() {
+        Python::attach(|py| {
+            let globals = PyDict::new(py).unbind();
+            let output = execute_repl_code(py, &globals, "print('hi')\n2 + 3", 100).expect("exec");
+            assert_eq!(output, "hi\n5");
+        });
+    }
+
+    #[test]
+    fn suppresses_output_on_trailing_semicolon() {
+        Python::attach(|py| {
+            let globals = PyDict::new(py).unbind();
+            let output = execute_repl_code(py, &globals, "2 + 3;", 100).expect("exec");
+            assert_eq!(output, NO_OUTPUT_MESSAGE);
+        });
+    }
+
+    #[test]
+    fn returns_no_output_message_when_no_stdout_or_repr() {
+        Python::attach(|py| {
+            let globals = PyDict::new(py).unbind();
+            let output = execute_repl_code(py, &globals, "x = 10", 100).expect("exec");
+            assert_eq!(output, NO_OUTPUT_MESSAGE);
+        });
+    }
+
+    #[test]
+    fn truncates_with_head_and_tail() {
+        Python::attach(|py| {
+            let globals = PyDict::new(py).unbind();
+            let output = execute_repl_code(py, &globals, "print('abcdefghijklmnopqrstuvwxyz')", 10)
+                .expect("exec");
+            assert!(output.contains("... (truncated)"));
+            assert!(output.starts_with("abcde"));
+            assert!(output.ends_with("wxyz\n"));
+        });
+    }
+
+    #[test]
+    fn submit_terminated_is_treated_as_success_path() {
+        Python::attach(|py| {
+            let globals = PyDict::new(py);
+            globals
+                .set_item("SubmitTerminated", py.get_type::<SubmitTerminated>())
+                .expect("set type");
+            let globals = globals.unbind();
+
+            let output = execute_repl_code(
+                py,
+                &globals,
+                "print('before submit')\nraise SubmitTerminated('done')",
+                200,
+            )
+            .expect("exec");
+
+            assert_eq!(output, "before submit\n");
+        });
+    }
+
+    #[test]
+    fn syntax_errors_return_err_string() {
+        Python::attach(|py| {
+            let globals = PyDict::new(py).unbind();
+            let err = execute_repl_code(py, &globals, "if True print('x')", 100)
+                .expect_err("should fail");
+            assert!(err.contains("SyntaxError"));
+            assert!(err.contains("Traceback"));
+        });
+    }
+
+    #[test]
+    fn includes_stdout_and_traceback_on_python_errors() {
+        Python::attach(|py| {
+            let globals = PyDict::new(py).unbind();
+            let err = execute_repl_code(
+                py,
+                &globals,
+                "print('before failure')\nraise ValueError('boom')",
+                500,
+            )
+            .expect_err("should fail");
+
+            assert!(err.contains("before failure"));
+            assert!(err.contains("Traceback"));
+            assert!(err.contains("ValueError: boom"));
+        });
+    }
+
+    #[test]
+    fn truncates_error_output_with_budget() {
+        Python::attach(|py| {
+            let globals = PyDict::new(py).unbind();
+            let err = execute_repl_code(
+                py,
+                &globals,
+                "print('abcdefghijklmnopqrstuvwxyz')\nraise RuntimeError('abcdefghijklmnopqrstuvwxyz')",
+                20,
+            )
+            .expect_err("should fail");
+
+            assert!(err.contains("... (truncated)"));
+            assert!(err.chars().count() > 20);
+        });
+    }
+}

--- a/crates/dspy-rs/src/modules/rlm/exec.rs
+++ b/crates/dspy-rs/src/modules/rlm/exec.rs
@@ -155,7 +155,9 @@ fn truncate_capture_output(text: &str, max_chars: usize) -> String {
     let head: String = text.chars().take(head_len).collect();
     let tail: String = text.chars().skip(total.saturating_sub(tail_len)).collect();
 
-    format!("{head}\n... (truncated)\n{tail}")
+    format!(
+        "{head}\n[output truncated at {max_chars} chars - full content in variable. pass to llm_query() to analyze]\n{tail}"
+    )
 }
 
 #[cfg(test)]
@@ -207,7 +209,9 @@ mod tests {
             let globals = PyDict::new(py).unbind();
             let output = execute_repl_code(py, &globals, "print('abcdefghijklmnopqrstuvwxyz')", 10)
                 .expect("exec");
-            assert!(output.contains("... (truncated)"));
+            assert!(output.contains(
+                "[output truncated at 10 chars - full content in variable. pass to llm_query() to analyze]"
+            ));
             assert!(output.starts_with("abcde"));
             assert!(output.ends_with("wxyz\n"));
         });
@@ -275,7 +279,9 @@ mod tests {
             )
             .expect_err("should fail");
 
-            assert!(err.contains("... (truncated)"));
+            assert!(err.contains(
+                "[output truncated at 20 chars - full content in variable. pass to llm_query() to analyze]"
+            ));
             assert!(err.chars().count() > 20);
         });
     }

--- a/crates/dspy-rs/src/modules/rlm/exec.rs
+++ b/crates/dspy-rs/src/modules/rlm/exec.rs
@@ -287,9 +287,25 @@ fn truncate_capture_output(text: &str, max_chars: usize) -> String {
 
     let head: String = text.chars().take(head_len).collect();
     let tail: String = text.chars().skip(total.saturating_sub(tail_len)).collect();
-    let truncation_notice = format!("... [STDOUT TRUNCATED: Exceeded {max_chars} char threshold]");
+    let truncation_notice = format!(
+        "[STDOUT TRUNCATED at {} chars ({} total)]",
+        format_count(max_chars),
+        format_count(total)
+    );
 
     format!("{head}\n{tail}\n{truncation_notice}")
+}
+
+fn format_count(value: usize) -> String {
+    let raw = value.to_string();
+    let mut out = String::with_capacity(raw.len() + raw.len() / 3);
+    for (index, ch) in raw.chars().rev().enumerate() {
+        if index > 0 && index % 3 == 0 {
+            out.push(',');
+        }
+        out.push(ch);
+    }
+    out.chars().rev().collect()
 }
 
 #[cfg(test)]
@@ -341,10 +357,10 @@ mod tests {
             let globals = PyDict::new(py).unbind();
             let output = execute_repl_code(py, &globals, "print('abcdefghijklmnopqrstuvwxyz')", 10)
                 .expect("exec");
-            assert!(output.contains("... [STDOUT TRUNCATED: Exceeded 10 char threshold]"));
+            assert!(output.contains("[STDOUT TRUNCATED at 10 chars (27 total)]"));
             assert!(output.starts_with("abcde"));
             assert!(output.contains("wxyz\n"));
-            assert!(output.ends_with("... [STDOUT TRUNCATED: Exceeded 10 char threshold]"));
+            assert!(output.ends_with("[STDOUT TRUNCATED at 10 chars (27 total)]"));
         });
     }
 
@@ -432,7 +448,7 @@ mod tests {
             )
             .expect_err("should fail");
 
-            assert!(err.contains("... [STDOUT TRUNCATED: Exceeded 20 char threshold]"));
+            assert!(err.contains("[STDOUT TRUNCATED at 20 chars ("));
             assert!(err.chars().count() > 20);
         });
     }
@@ -442,9 +458,16 @@ mod tests {
         let text = "😀".repeat(40);
         let truncated = truncate_capture_output(&text, 9);
 
-        assert!(truncated.contains("... [STDOUT TRUNCATED: Exceeded 9 char threshold]"));
+        assert!(truncated.contains("[STDOUT TRUNCATED at 9 chars (40 total)]"));
         assert!(truncated.is_char_boundary(truncated.len()));
         assert!(truncated.contains('😀'));
+    }
+
+    #[test]
+    fn format_count_uses_thousands_separators() {
+        assert_eq!(format_count(0), "0");
+        assert_eq!(format_count(10_000), "10,000");
+        assert_eq!(format_count(2_345_678), "2,345,678");
     }
 
     #[test]

--- a/crates/dspy-rs/src/modules/rlm/exec.rs
+++ b/crates/dspy-rs/src/modules/rlm/exec.rs
@@ -61,9 +61,16 @@ pub fn execute_repl_code(
     code: &str,
     max_output_chars: usize,
 ) -> Result<String, String> {
-    let suppress_output = code.trim_end().ends_with(';');
+    let prepared_code = preprocess_repl_code(code);
+    let suppress_output = prepared_code.trim_end().ends_with(';');
 
-    match run_exec(py, globals, code, suppress_output, max_output_chars) {
+    match run_exec(
+        py,
+        globals,
+        &prepared_code,
+        suppress_output,
+        max_output_chars,
+    ) {
         Ok(output) => Ok(output),
         Err(err) => {
             let stdout = extract_submit_stdout(py, &err).unwrap_or_default();
@@ -74,6 +81,58 @@ pub fn execute_repl_code(
             Err(truncate_capture_output(&combined, max_output_chars))
         }
     }
+}
+
+fn preprocess_repl_code(code: &str) -> String {
+    let without_fences = strip_markdown_fence_lines(code);
+    strip_leading_non_python_lines(&without_fences)
+}
+
+fn strip_markdown_fence_lines(text: &str) -> String {
+    text.lines()
+        .filter(|line| !line.trim_start().starts_with("```"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn strip_leading_non_python_lines(text: &str) -> String {
+    let lines = text.lines().collect::<Vec<_>>();
+    let first_code_index = lines.iter().position(|line| {
+        let trimmed = line.trim();
+        !trimmed.is_empty() && looks_like_python_line(trimmed)
+    });
+
+    let selected = match first_code_index {
+        Some(index) => lines[index..].join("\n"),
+        None => text.to_string(),
+    };
+    selected.trim_end().to_string()
+}
+
+fn looks_like_python_line(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    if trimmed.is_empty() {
+        return false;
+    }
+    if trimmed.starts_with('#')
+        || trimmed.starts_with('[')
+        || trimmed.starts_with('{')
+        || trimmed.contains('=')
+        || trimmed.contains('(')
+    {
+        return true;
+    }
+
+    let lower = trimmed.to_ascii_lowercase();
+    for prefix in [
+        "import ", "from ", "print", "def ", "for ", "if ", "while ", "try:", "with ", "class ",
+    ] {
+        if lower.starts_with(prefix) {
+            return true;
+        }
+    }
+
+    false
 }
 
 fn run_exec(
@@ -334,5 +393,29 @@ mod tests {
         assert!(truncated.contains("[output truncated at 9 chars"));
         assert!(truncated.is_char_boundary(truncated.len()));
         assert!(truncated.contains('😀'));
+    }
+
+    #[test]
+    fn preprocess_strips_markdown_fences() {
+        let raw = "```python\nprint('a')\n```\n```py\nprint('b')\n```\n```\nprint('c')\n```";
+        let prepared = preprocess_repl_code(raw);
+        assert_eq!(prepared, "print('a')\nprint('b')\nprint('c')");
+    }
+
+    #[test]
+    fn preprocess_strips_leading_prose_until_python() {
+        let raw = "Let me start by exploring the data first.\n\n```python\n# First, inspect\na = 1\nprint(a)\n```";
+        let prepared = preprocess_repl_code(raw);
+        assert_eq!(prepared, "# First, inspect\na = 1\nprint(a)");
+    }
+
+    #[test]
+    fn execute_repl_code_handles_failed_turn_one_pattern() {
+        Python::attach(|py| {
+            let globals = PyDict::new(py).unbind();
+            let raw = "Let me start by exploring the data to understand the structure and then systematically find recurring corrections.\n\n```python\n# First, explore the data structure\nprint('ok')\n```";
+            let output = execute_repl_code(py, &globals, raw, 500).expect("exec");
+            assert_eq!(output, "ok\n");
+        });
     }
 }

--- a/crates/dspy-rs/src/modules/rlm/exec.rs
+++ b/crates/dspy-rs/src/modules/rlm/exec.rs
@@ -287,10 +287,9 @@ fn truncate_capture_output(text: &str, max_chars: usize) -> String {
 
     let head: String = text.chars().take(head_len).collect();
     let tail: String = text.chars().skip(total.saturating_sub(tail_len)).collect();
+    let truncation_notice = format!("... [STDOUT TRUNCATED: Exceeded {max_chars} char threshold]");
 
-    format!(
-        "{head}\n[output truncated at {max_chars} chars - full content in variable. pass to llm_query() to analyze]\n{tail}"
-    )
+    format!("{head}\n{tail}\n{truncation_notice}")
 }
 
 #[cfg(test)]
@@ -342,11 +341,10 @@ mod tests {
             let globals = PyDict::new(py).unbind();
             let output = execute_repl_code(py, &globals, "print('abcdefghijklmnopqrstuvwxyz')", 10)
                 .expect("exec");
-            assert!(output.contains(
-                "[output truncated at 10 chars - full content in variable. pass to llm_query() to analyze]"
-            ));
+            assert!(output.contains("... [STDOUT TRUNCATED: Exceeded 10 char threshold]"));
             assert!(output.starts_with("abcde"));
-            assert!(output.ends_with("wxyz\n"));
+            assert!(output.contains("wxyz\n"));
+            assert!(output.ends_with("... [STDOUT TRUNCATED: Exceeded 10 char threshold]"));
         });
     }
 
@@ -434,9 +432,7 @@ mod tests {
             )
             .expect_err("should fail");
 
-            assert!(err.contains(
-                "[output truncated at 20 chars - full content in variable. pass to llm_query() to analyze]"
-            ));
+            assert!(err.contains("... [STDOUT TRUNCATED: Exceeded 20 char threshold]"));
             assert!(err.chars().count() > 20);
         });
     }
@@ -446,7 +442,7 @@ mod tests {
         let text = "😀".repeat(40);
         let truncated = truncate_capture_output(&text, 9);
 
-        assert!(truncated.contains("[output truncated at 9 chars"));
+        assert!(truncated.contains("... [STDOUT TRUNCATED: Exceeded 9 char threshold]"));
         assert!(truncated.is_char_boundary(truncated.len()));
         assert!(truncated.contains('😀'));
     }

--- a/crates/dspy-rs/src/modules/rlm/exec.rs
+++ b/crates/dspy-rs/src/modules/rlm/exec.rs
@@ -5,12 +5,14 @@ use pyo3::{Py, PyResult, Python};
 use super::submit::{SUBMIT_STDOUT_ATTR, is_submit_terminated};
 
 const NO_OUTPUT_MESSAGE: &str = "(no output - did you forget to print?)";
+const TRACEBACK_ATTR: &str = "__dsrs_traceback__";
 
 static EXEC_HELPER_CODE: &std::ffi::CStr = c_str!(
     r#"
 import ast
 import contextlib
 import io
+import traceback
 
 
 def dsrs_exec(code, globals_dict, suppress_output):
@@ -43,6 +45,10 @@ def dsrs_exec(code, globals_dict, suppress_output):
                 setattr(exc, "__dsrs_stdout__", buffer.getvalue())
             except Exception:
                 pass
+            try:
+                setattr(exc, "__dsrs_traceback__", traceback.format_exc())
+            except Exception:
+                pass
             raise
     return buffer.getvalue(), (None if result is None else repr(result))
 "#
@@ -60,7 +66,9 @@ pub fn execute_repl_code(
         Ok(output) => Ok(output),
         Err(err) => {
             let stdout = extract_submit_stdout(py, &err).unwrap_or_default();
-            let traceback = format_python_traceback(py, &err).unwrap_or_else(|_| err.to_string());
+            let traceback = extract_traceback(py, &err)
+                .or_else(|| format_python_traceback(py, &err).ok())
+                .unwrap_or_else(|| err.to_string());
             let combined = combine_stdout_and_traceback(stdout, traceback);
             Err(truncate_capture_output(&combined, max_output_chars))
         }
@@ -98,6 +106,13 @@ fn run_exec(
 fn extract_submit_stdout(py: Python<'_>, err: &pyo3::PyErr) -> Option<String> {
     err.value(py)
         .getattr(SUBMIT_STDOUT_ATTR)
+        .ok()
+        .and_then(|value| value.extract::<String>().ok())
+}
+
+fn extract_traceback(py: Python<'_>, err: &pyo3::PyErr) -> Option<String> {
+    err.value(py)
+        .getattr(TRACEBACK_ATTR)
         .ok()
         .and_then(|value| value.extract::<String>().ok())
 }
@@ -268,6 +283,22 @@ mod tests {
     }
 
     #[test]
+    fn import_errors_include_traceback_and_exception_type() {
+        Python::attach(|py| {
+            let globals = PyDict::new(py).unbind();
+            let err = execute_repl_code(py, &globals, "import definitely_missing_module_xyz", 500)
+                .expect_err("should fail");
+
+            assert!(err.contains("Traceback"));
+            assert!(
+                err.contains("ModuleNotFoundError") || err.contains("ImportError"),
+                "expected import failure class in traceback: {err}"
+            );
+            assert!(err.contains("definitely_missing_module_xyz"));
+        });
+    }
+
+    #[test]
     fn truncates_error_output_with_budget() {
         Python::attach(|py| {
             let globals = PyDict::new(py).unbind();
@@ -284,5 +315,15 @@ mod tests {
             ));
             assert!(err.chars().count() > 20);
         });
+    }
+
+    #[test]
+    fn truncation_is_unicode_safe_for_multibyte_characters() {
+        let text = "😀".repeat(40);
+        let truncated = truncate_capture_output(&text, 9);
+
+        assert!(truncated.contains("[output truncated at 9 chars"));
+        assert!(truncated.is_char_boundary(truncated.len()));
+        assert!(truncated.contains('😀'));
     }
 }

--- a/crates/dspy-rs/src/modules/rlm/mod.rs
+++ b/crates/dspy-rs/src/modules/rlm/mod.rs
@@ -1,8 +1,13 @@
+use std::collections::BTreeSet;
 use std::marker::PhantomData;
 use std::sync::{Arc, Mutex};
 
 use indexmap::IndexMap;
-use pyo3::Python;
+use pyo3::types::{
+    PyAnyMethods, PyBool, PyDict, PyDictMethods, PyFloat, PyInt, PyList, PyListMethods, PyModule,
+    PySet, PyString, PyStringMethods, PyTuple, PyTypeMethods,
+};
+use pyo3::{Bound, Py, Python};
 use rig::message::ToolCall;
 use tracing::{debug, info, info_span};
 
@@ -44,13 +49,7 @@ Output:
 #[derive(Signature, Clone, Debug)]
 struct RlmActionSig {
     #[input]
-    variables_info: Option<String>,
-
-    #[input]
-    execution_feedback: Option<String>,
-
-    #[input]
-    budget_remaining: u32,
+    perception: String,
 
     #[output]
     code: String,
@@ -226,6 +225,12 @@ enum TurnDecision {
     Fallback,
 }
 
+#[derive(Debug, Clone, Default)]
+struct PerceptionFeedback {
+    stdout: Option<String>,
+    stderr: Option<String>,
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum RlmError {
     #[error("configuration error: {message}")]
@@ -274,11 +279,12 @@ where
     S::Input: BamlType + for<'a> Facet<'a> + Clone + Send + Sync + RlmInputFields,
     S::Output: BamlType + for<'a> Facet<'a> + Clone + Send + Sync,
 {
-    generate_action: Predict<RlmActionSig>,
     extract: Predict<RlmExtractSig<S>>,
 
     #[facet(skip)]
     config: RlmConfig,
+    #[facet(skip)]
+    instruction_override: Option<String>,
     #[facet(skip, opaque)]
     sub_lm: Option<Arc<crate::LM>>,
     #[facet(skip, opaque)]
@@ -394,8 +400,31 @@ where
         let preview_len = previews.chars().count();
         preview_span.record("preview_len", preview_len);
         info!(preview_len, "rlm preview generated");
+
+        let action_instruction = render_action_instruction::<S>(
+            &self.config,
+            self.instruction_override.as_deref(),
+            &previews,
+        );
+        // TODO(dsrs-rlm): This local Predict is a runtime-workaround so instruction
+        // composition can include runtime-collected method metadata and rendered
+        // input schemas. Structural fix options:
+        // 1) public post-build instruction override on Predict, or
+        // 2) build-time instruction composition using compile-time method metadata.
+        let generate_action = Predict::<RlmActionSig>::builder()
+            .instruction(action_instruction)
+            .adapter(ChatAdapter::passthrough())
+            .build();
+        let task_hint = task_hint_from_input::<S>(input).unwrap_or_else(|| {
+            if let Some(instruction) = self.instruction_override.as_deref() {
+                instruction.trim().to_string()
+            } else {
+                S::instruction().trim().to_string()
+            }
+        });
+
         let mut history: Option<Chat> = None;
-        let mut feedback: Option<String> = None;
+        let mut feedback: Option<PerceptionFeedback> = None;
         let mut turn_index = 1usize;
         let mut acc = MetadataAcc::default();
         let mut repl_history = REPLHistory {
@@ -429,12 +458,21 @@ where
                 .max_iterations
                 .saturating_sub(turn_index)
                 .saturating_add(1);
-            let action_input = self.build_action_input(
-                turn_index,
-                Some(previews.as_str()),
-                feedback.as_deref(),
-                budget_remaining,
-            );
+            let sub_lm_remaining = self.runtime.sub_lm_budget_remaining(llm_tools.as_ref());
+            let perception = Python::attach(|py| {
+                build_perception_message::<S>(
+                    py,
+                    &globals,
+                    input,
+                    &task_hint,
+                    feedback.as_ref(),
+                    budget_remaining,
+                    sub_lm_remaining,
+                    is_first_turn,
+                )
+            })
+            .map_err(|message| RlmError::Configuration { message })?;
+            let action_input = RlmActionSigInput::new(perception);
 
             info!(
                 iteration = turn_index,
@@ -443,7 +481,10 @@ where
                 "running action predict call"
             );
             let turn_history = history.take();
-            match self.run_action_turn(action_input, turn_history).await? {
+            match self
+                .run_action_turn(&generate_action, action_input, turn_history)
+                .await?
+            {
                 ActionTurn::RecoverableParse {
                     raw_response,
                     lm_usage,
@@ -458,19 +499,10 @@ where
                     );
                     acc.absorb_parse_metadata(raw_response, lm_usage);
                     history = Some(chat);
-                    let sub_lm_remaining = self.runtime.sub_lm_budget_remaining(llm_tools.as_ref());
-                    let next_turn_index = turn_index.saturating_add(1);
-                    let finalization_directive = (next_turn_index == self.config.max_iterations)
-                        .then(|| self.finalization_directive());
-                    let parsed_feedback = format_feedback(
-                        next_turn_index,
-                        self.config.max_iterations.saturating_sub(turn_index),
-                        sub_lm_remaining,
-                        self.config.max_llm_calls,
-                        &ExecOutcome::RecoverableParse { message: reason },
-                        finalization_directive.as_deref(),
-                    );
-                    feedback = Some(parsed_feedback);
+                    feedback = Some(PerceptionFeedback {
+                        stdout: None,
+                        stderr: Some(reason),
+                    });
                     turn_index += 1;
                 }
                 ActionTurn::Parsed(predicted) => {
@@ -523,21 +555,7 @@ where
                                 outcome = exec_outcome_kind(&other),
                                 "predict response received"
                             );
-                            let sub_lm_remaining =
-                                self.runtime.sub_lm_budget_remaining(llm_tools.as_ref());
-                            let next_turn_index = turn_index.saturating_add(1);
-                            let finalization_directive = (next_turn_index
-                                == self.config.max_iterations)
-                                .then(|| self.finalization_directive());
-                            let rendered_feedback = format_feedback(
-                                next_turn_index,
-                                self.config.max_iterations.saturating_sub(turn_index),
-                                sub_lm_remaining,
-                                self.config.max_llm_calls,
-                                &other,
-                                finalization_directive.as_deref(),
-                            );
-                            feedback = Some(rendered_feedback);
+                            feedback = Some(perception_feedback_from_outcome(&other));
                             repl_history.entries.push(REPLEntry {
                                 turn: turn_index.min(u32::MAX as usize) as u32,
                                 code,
@@ -551,32 +569,13 @@ where
         }
     }
 
-    fn build_action_input(
-        &self,
-        turn_index: usize,
-        previews: Option<&str>,
-        execution_feedback: Option<&str>,
-        budget_remaining: usize,
-    ) -> RlmActionSigInput {
-        let (variables_info, execution_feedback) = if turn_index == 1 {
-            (previews.map(ToOwned::to_owned), None)
-        } else {
-            (None, execution_feedback.map(ToOwned::to_owned))
-        };
-
-        RlmActionSigInput::new(
-            variables_info,
-            execution_feedback,
-            budget_remaining.min(u32::MAX as usize) as u32,
-        )
-    }
-
     async fn run_action_turn(
         &self,
+        generate_action: &Predict<RlmActionSig>,
         action_input: RlmActionSigInput,
         history: Option<Chat>,
     ) -> Result<ActionTurn, RlmError> {
-        match self.generate_action.forward(action_input, history).await {
+        match generate_action.forward(action_input, history).await {
             Ok(predicted) => Ok(ActionTurn::Parsed(predicted)),
             Err(error) => match error {
                 PredictError::Parse {
@@ -627,16 +626,6 @@ where
         acc.absorb_call_metadata(metadata);
         let metadata = std::mem::take(acc).into_call_metadata();
         Ok(Predicted::new(output, metadata, chat))
-    }
-
-    fn finalization_directive(&self) -> String {
-        let output_fields = S::schema()
-            .output_fields()
-            .iter()
-            .map(|field| format!("{}=...", field.lm_name))
-            .collect::<Vec<_>>()
-            .join(", ");
-        format!("This is your final turn. Call SUBMIT({output_fields}) now with your best answer.")
     }
 }
 
@@ -719,14 +708,8 @@ where
     }
 
     pub fn build(self) -> Rlm<S> {
-        let action_instruction =
-            render_action_instruction::<S>(&self.config, self.instruction_override.as_deref());
         let extract_instruction =
             render_extract_instruction::<S>(self.instruction_override.as_deref());
-        let generate_action = Predict::<RlmActionSig>::builder()
-            .instruction(action_instruction)
-            .adapter(ChatAdapter::passthrough())
-            .build();
         let extract = Predict::<RlmExtractSig<S>>::builder()
             .instruction(extract_instruction)
             .adapter(ChatAdapter::new())
@@ -737,9 +720,9 @@ where
             .unwrap_or_else(|| default_runtime::<S>(self.config.max_llm_calls));
 
         Rlm {
-            generate_action,
             extract,
             config: self.config,
+            instruction_override: self.instruction_override,
             sub_lm: self.sub_lm,
             runtime,
         }
@@ -770,28 +753,304 @@ where
     }
 }
 
-fn format_feedback(
-    turn_index: usize,
+fn task_hint_from_input<S>(input: &S::Input) -> Option<String>
+where
+    S: Signature,
+    S::Input: BamlType,
+{
+    let value = input.to_baml_value();
+    let question = match &value {
+        BamlValue::Class(_, fields) | BamlValue::Map(fields) => fields.get("question"),
+        _ => None,
+    }?;
+    if let BamlValue::String(text) = question {
+        let trimmed = text.trim();
+        if !trimmed.is_empty() {
+            return Some(trimmed.to_string());
+        }
+    }
+    None
+}
+
+fn build_perception_message<S>(
+    py: Python<'_>,
+    globals: &Py<PyDict>,
+    input: &S::Input,
+    task_hint: &str,
+    feedback: Option<&PerceptionFeedback>,
     budget_remaining: usize,
     sub_lm_remaining: usize,
-    max_llm_calls: usize,
-    outcome: &ExecOutcome,
-    finalization_directive: Option<&str>,
-) -> String {
-    let header = format!(
-        "[Turn {turn_index} | {budget_remaining} turns, {sub_lm_remaining}/{max_llm_calls} sub-model calls remaining]"
-    );
-    let body = outcome_to_raw_output(outcome);
-    let mut rendered = if body.is_empty() {
-        header
+    first_turn: bool,
+) -> Result<String, String>
+where
+    S: Signature,
+    S::Input: BamlType + RlmInputFields,
+{
+    let mut lines = Vec::new();
+    let turns_label = if budget_remaining == 1 {
+        "1 turn".to_string()
     } else {
-        format!("{header}\n\n{body}")
+        format!("{budget_remaining} turns")
     };
-    if let Some(directive) = finalization_directive {
-        rendered.push_str("\n\n");
-        rendered.push_str(directive);
+    lines.push(format!(
+        "[env] {turns_label} | {sub_lm_remaining} sub-LLM calls"
+    ));
+
+    if first_turn {
+        lines.push(format!("[query] {}", truncate_chars(task_hint, 180)));
     }
-    rendered
+
+    if let Some(feedback) = feedback {
+        if let Some(stdout) = feedback.stdout.as_deref()
+            && !stdout.trim().is_empty()
+        {
+            lines.push(String::new());
+            lines.push("[stdout]".to_string());
+            lines.push(stdout.to_string());
+        }
+        if let Some(stderr) = feedback.stderr.as_deref()
+            && !stderr.trim().is_empty()
+        {
+            lines.push(String::new());
+            lines.push("[stderr]".to_string());
+            lines.push(stderr.to_string());
+        }
+    }
+
+    if budget_remaining == 1 {
+        lines.push(String::new());
+        lines.push("⚠ LAST TURN — you MUST call SUBMIT() now with your best answer.".to_string());
+    }
+
+    let namespace = collect_namespace_snapshot(py, globals, input.rlm_field_names())?;
+    lines.push(String::new());
+    if first_turn {
+        lines.push("--- namespace ---".to_string());
+    } else {
+        lines.push(format!("--- namespace ({} names) ---", namespace.len()));
+    }
+    for (name, repr_value) in namespace {
+        lines.push(format!("{name} = {repr_value}"));
+    }
+    lines.push(String::new());
+    lines.push(">>>".to_string());
+
+    Ok(lines.join("\n"))
+}
+
+fn collect_namespace_snapshot(
+    py: Python<'_>,
+    globals: &Py<PyDict>,
+    injected_roots: &[&str],
+) -> Result<Vec<(String, String)>, String> {
+    let dict = globals.bind(py);
+    let roots = injected_roots
+        .iter()
+        .map(|name| (*name).to_string())
+        .collect::<BTreeSet<_>>();
+
+    let mut out = Vec::new();
+    for root in injected_roots {
+        if let Some(value) = dict
+            .get_item(*root)
+            .map_err(|err| format!("failed to fetch root `{root}` from globals: {err}"))?
+        {
+            out.push(((*root).to_string(), safe_namespace_repr(&value, true)?));
+        }
+    }
+
+    let mut extras = Vec::new();
+    for (name, value) in dict.iter() {
+        let Ok(name) = name.extract::<String>() else {
+            continue;
+        };
+        if roots.contains(name.as_str()) {
+            continue;
+        }
+        if !include_in_namespace(name.as_str(), &value, &roots) {
+            continue;
+        }
+        extras.push((name, safe_namespace_repr(&value, false)?));
+    }
+    extras.sort_by(|a, b| a.0.cmp(&b.0));
+    out.extend(extras);
+
+    Ok(out)
+}
+
+fn include_in_namespace(
+    name: &str,
+    value: &Bound<'_, pyo3::PyAny>,
+    roots: &BTreeSet<String>,
+) -> bool {
+    if roots.contains(name) {
+        return true;
+    }
+    if name.starts_with('_') {
+        return false;
+    }
+    if name.chars().count() <= 1 {
+        return false;
+    }
+    if value.is_instance_of::<PyModule>() {
+        return false;
+    }
+    if value.is_callable() {
+        return false;
+    }
+    true
+}
+
+fn safe_namespace_repr(value: &Bound<'_, pyo3::PyAny>, is_root: bool) -> Result<String, String> {
+    if is_root {
+        if value.is_instance_of::<PyList>() {
+            let len = value.len().unwrap_or_default();
+            if len > 5 {
+                if let Ok(list) = value.cast::<PyList>() {
+                    let mut preview = Vec::new();
+                    for item in list.iter().take(2) {
+                        let rendered = sanitize_python_surface(&repr_value(&item)?);
+                        preview.push(truncate_chars(&rendered, 100));
+                    }
+                    if !preview.is_empty() {
+                        return Ok(format!("[{}, ... ({} total)]", preview.join(", "), len));
+                    }
+                }
+                return Ok(format!("list({len} items)"));
+            }
+        }
+        return Ok(truncate_chars(&repr_value(value)?, 200));
+    }
+
+    if value.is_instance_of::<PyString>() {
+        let text = value
+            .extract::<String>()
+            .map_err(|err| format!("string extract failed: {err}"))?;
+        return Ok(format!("{:?}", truncate_chars(&text, 50)));
+    }
+    if value.is_instance_of::<PyBool>()
+        || value.is_instance_of::<PyInt>()
+        || value.is_instance_of::<PyFloat>()
+    {
+        return repr_value(value);
+    }
+
+    if value.is_instance_of::<PyList>() {
+        let len = value.len().unwrap_or_default();
+        if len <= 5 {
+            return Ok(truncate_chars(
+                &sanitize_python_surface(&repr_value(value)?),
+                120,
+            ));
+        }
+        return Ok(format!("<list of {len} items>"));
+    }
+    if value.is_instance_of::<PyTuple>() {
+        let len = value.len().unwrap_or_default();
+        if len <= 5 {
+            return Ok(truncate_chars(
+                &sanitize_python_surface(&repr_value(value)?),
+                120,
+            ));
+        }
+        return Ok(format!("<tuple of {len} items>"));
+    }
+    if value.is_instance_of::<PySet>() {
+        let len = value.len().unwrap_or_default();
+        if len <= 5 {
+            return Ok(truncate_chars(
+                &sanitize_python_surface(&repr_value(value)?),
+                120,
+            ));
+        }
+        return Ok(format!("<set of {len} items>"));
+    }
+    if value.is_instance_of::<PyDict>() {
+        let len = value.len().unwrap_or_default();
+        if len <= 5 {
+            return Ok(truncate_chars(
+                &sanitize_python_surface(&repr_value(value)?),
+                120,
+            ));
+        }
+        return Ok(format!("<dict of {len} items>"));
+    }
+
+    let class_name = value
+        .get_type()
+        .name()
+        .map(|name| name.to_string_lossy().to_string())
+        .unwrap_or_else(|_| "Object".to_string());
+
+    if let Ok(len) = value.len() {
+        return Ok(format!("<{class_name}: {len} items>"));
+    }
+
+    Ok(format!("<{class_name}>"))
+}
+
+fn repr_value(value: &Bound<'_, pyo3::PyAny>) -> Result<String, String> {
+    let repr = value
+        .repr()
+        .map_err(|err| format!("repr() failed: {err}"))?;
+    Ok(repr.to_string_lossy().to_string())
+}
+
+fn sanitize_python_surface(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut token = String::new();
+
+    let flush = |out: &mut String, token: &mut String| {
+        if token.is_empty() {
+            return;
+        }
+        if let Some(last) = token.rsplit("::").next() {
+            out.push_str(last);
+        } else {
+            out.push_str(token);
+        }
+        token.clear();
+    };
+
+    for ch in text.chars() {
+        if ch.is_ascii_alphanumeric() || ch == '_' || ch == ':' {
+            token.push(ch);
+        } else {
+            flush(&mut out, &mut token);
+            out.push(ch);
+        }
+    }
+    flush(&mut out, &mut token);
+    out
+}
+
+fn perception_feedback_from_outcome(outcome: &ExecOutcome) -> PerceptionFeedback {
+    match outcome {
+        ExecOutcome::Continue { output } => PerceptionFeedback {
+            stdout: (!output.trim().is_empty()).then(|| output.clone()),
+            stderr: None,
+        },
+        ExecOutcome::SubmitAccepted { .. } => PerceptionFeedback::default(),
+        ExecOutcome::SubmitValidationError { .. }
+        | ExecOutcome::SubmitAssertionFailed { .. }
+        | ExecOutcome::PythonException { .. }
+        | ExecOutcome::RecoverableParse { .. } => PerceptionFeedback {
+            stdout: None,
+            stderr: Some(outcome_to_raw_output(outcome)),
+        },
+    }
+}
+
+fn truncate_chars(text: &str, max_chars: usize) -> String {
+    if text.chars().count() <= max_chars {
+        return text.to_string();
+    }
+    let mut out = String::new();
+    for ch in text.chars().take(max_chars) {
+        out.push(ch);
+    }
+    out.push_str("...");
+    out
 }
 
 #[cfg(test)]
@@ -921,6 +1180,8 @@ fn outcome_to_raw_output(outcome: &ExecOutcome) -> String {
 mod tests {
     use super::*;
     use crate::{ParseError, Signature};
+    use pyo3::Python;
+    use pyo3::types::{PyDict, PyDictMethods, PyModule};
     use std::sync::Arc;
     use temp_env::with_var;
 
@@ -964,18 +1225,157 @@ mod tests {
     }
 
     #[test]
-    fn action_input_is_asymmetric_between_first_and_later_turns() {
-        let module = Rlm::<RuntimePolicySig>::builder().build();
+    fn perception_message_uses_env_task_namespace_and_prompt_markers() {
+        Python::attach(|py| {
+            let globals = PyDict::new(py);
+            globals
+                .set_item("prompt", "Where did signal drop?")
+                .expect("set prompt");
+            globals
+                .set_item("result_count", 7)
+                .expect("set result_count");
+            globals.set_item("_tmp", 99).expect("set tmp");
 
-        let turn1 = module.build_action_input(1, Some("preview block"), Some("feedback"), 20);
-        assert_eq!(turn1.variables_info.as_deref(), Some("preview block"));
-        assert!(turn1.execution_feedback.is_none());
-        assert_eq!(turn1.budget_remaining, 20);
+            let input = RuntimePolicySigInput {
+                prompt: "Where did signal drop?".to_string(),
+            };
+            let message = build_perception_message::<RuntimePolicySig>(
+                py,
+                &globals.unbind(),
+                &input,
+                "Inspect trajectories",
+                None,
+                3,
+                11,
+                true,
+            )
+            .expect("message");
 
-        let turn2 = module.build_action_input(2, Some("preview block"), Some("feedback"), 19);
-        assert!(turn2.variables_info.is_none());
-        assert_eq!(turn2.execution_feedback.as_deref(), Some("feedback"));
-        assert_eq!(turn2.budget_remaining, 19);
+            assert!(message.contains("[env] 3 turns | 11 sub-LLM calls"));
+            assert!(message.contains("[query] Inspect trajectories"));
+            assert!(message.contains("--- namespace ---"));
+            assert!(message.contains("prompt ="));
+            assert!(message.contains("result_count = 7"));
+            assert!(!message.contains("_tmp ="));
+            assert!(message.ends_with(">>>"));
+        });
+    }
+
+    #[test]
+    fn perception_message_turn_two_includes_stdout_and_last_turn_warning() {
+        Python::attach(|py| {
+            let globals = PyDict::new(py);
+            globals.set_item("prompt", "x").expect("set prompt");
+            let input = RuntimePolicySigInput {
+                prompt: "x".to_string(),
+            };
+            let feedback = PerceptionFeedback {
+                stdout: Some("computed summary".to_string()),
+                stderr: None,
+            };
+
+            let message = build_perception_message::<RuntimePolicySig>(
+                py,
+                &globals.unbind(),
+                &input,
+                "Inspect trajectories",
+                Some(&feedback),
+                1,
+                3,
+                false,
+            )
+            .expect("message");
+
+            assert!(message.contains("[env] 1 turn | 3 sub-LLM calls"));
+            assert!(message.contains("[stdout]"));
+            assert!(message.contains("computed summary"));
+            assert!(
+                message.contains("⚠ LAST TURN — you MUST call SUBMIT() now with your best answer.")
+            );
+            assert!(!message.contains("[query]"));
+        });
+    }
+
+    #[test]
+    fn namespace_filtering_excludes_noise_and_keeps_roots() {
+        Python::attach(|py| {
+            let globals = PyDict::new(py);
+            globals
+                .set_item("prompt", "Where did signal drop?")
+                .expect("set prompt root");
+            globals.set_item("i", 1).expect("set single char");
+            globals
+                .set_item("_scratch", "temp")
+                .expect("set private name");
+
+            let json_mod = PyModule::import(py, "json").expect("import json");
+            globals
+                .set_item("json", json_mod)
+                .expect("set module variable");
+
+            let builtins = PyModule::import(py, "builtins").expect("import builtins");
+            let len_fn = builtins.getattr("len").expect("load len");
+            globals
+                .set_item("callable_fn", len_fn)
+                .expect("set callable variable");
+
+            globals
+                .set_item("kept_value", 42)
+                .expect("set regular value");
+
+            let input = RuntimePolicySigInput {
+                prompt: "Where did signal drop?".to_string(),
+            };
+            let message = build_perception_message::<RuntimePolicySig>(
+                py,
+                &globals.unbind(),
+                &input,
+                "Inspect trajectories",
+                None,
+                3,
+                9,
+                true,
+            )
+            .expect("message");
+
+            assert!(message.contains("prompt ="));
+            assert!(message.contains("kept_value = 42"));
+            assert!(!message.contains("\ni = "));
+            assert!(!message.contains("_scratch = "));
+            assert!(!message.contains("json = "));
+            assert!(!message.contains("callable_fn = "));
+        });
+    }
+
+    #[test]
+    fn sanitize_python_surface_strips_module_paths() {
+        let rendered = sanitize_python_surface(
+            "Sessions(items=[tanha::types::Session(id='abc')], kind=tanha::types::Kind::Fast)",
+        );
+        assert!(!rendered.contains("tanha::types::"));
+        assert!(rendered.contains("Session(id='abc')"));
+        assert!(rendered.contains("kind=Fast"));
+    }
+
+    #[test]
+    fn root_namespace_repr_uses_object_repr_without_custom_heuristics() {
+        Python::attach(|py| {
+            let globals = PyDict::new(py);
+            py.run(
+                pyo3::ffi::c_str!(
+                    "class Sessions:\n  def __repr__(self):\n    return 'Sessions(CUSTOM_REPR)'\nsessions = Sessions()\n"
+                ),
+                Some(&globals),
+                Some(&globals),
+            )
+            .expect("python setup");
+            let sessions = globals
+                .get_item("sessions")
+                .expect("sessions lookup should succeed")
+                .expect("sessions should exist");
+            let rendered = safe_namespace_repr(&sessions, true).expect("repr");
+            assert_eq!(rendered, "Sessions(CUSTOM_REPR)");
+        });
     }
 
     #[test]
@@ -1015,21 +1415,18 @@ mod tests {
     }
 
     #[test]
-    fn feedback_uses_next_turn_framing_and_supports_finalization_directive() {
-        let feedback = format_feedback(
-            2,
-            19,
-            50,
-            50,
-            &ExecOutcome::Continue {
-                output: "ok".to_string(),
-            },
-            Some("This is your final turn. Call SUBMIT(answer=...) now with your best answer."),
-        );
+    fn perception_feedback_maps_stdout_and_stderr_honestly() {
+        let continue_feedback = perception_feedback_from_outcome(&ExecOutcome::Continue {
+            output: "ok".to_string(),
+        });
+        assert_eq!(continue_feedback.stdout.as_deref(), Some("ok"));
+        assert!(continue_feedback.stderr.is_none());
 
-        assert!(feedback.contains("[Turn 2 | 19 turns, 50/50 sub-model calls remaining]"));
-        assert!(feedback.contains("\n\nok"));
-        assert!(feedback.contains("This is your final turn. Call SUBMIT(answer=...) now"));
+        let error_feedback = perception_feedback_from_outcome(&ExecOutcome::PythonException {
+            message: "Traceback...".to_string(),
+        });
+        assert_eq!(error_feedback.stderr.as_deref(), Some("Traceback..."));
+        assert!(error_feedback.stdout.is_none());
     }
 
     #[test]

--- a/crates/dspy-rs/src/modules/rlm/mod.rs
+++ b/crates/dspy-rs/src/modules/rlm/mod.rs
@@ -8,14 +8,18 @@ use rig::message::ToolCall;
 
 use crate::{
     BamlType, BamlValue, CallMetadata, Chat, ChatAdapter, Facet, FieldMeta, LmUsage, Module,
-    Predict, PredictError, Predicted, Signature, SignatureSchema,
+    Predict, PredictError, Predicted, Signature,
 };
 
 mod exec;
+mod previews;
+mod prompt;
 mod py_bridge;
 pub mod runtime;
 mod submit;
 mod tools;
+use previews::render_previews;
+use prompt::render_action_instruction;
 pub use runtime::{
     DynRuntime, LlmTools, PyO3Runtime, RlmRuntime, StubRuntime, SubmitError, SubmitHandler,
     SubmitResultDyn, SubmitSlot, clear_submit_slot, take_submit_result,
@@ -26,11 +30,6 @@ const DEFAULT_MAX_ITERATIONS: usize = 20;
 const DEFAULT_MAX_LLM_CALLS: usize = 50;
 const DEFAULT_MAX_OUTPUT_CHARS: usize = 100_000;
 const DEFAULT_ENABLE_EXTRACTION_FALLBACK: bool = true;
-
-const ACTION_INSTRUCTION: &str = "You are operating inside a persistent Python REPL.\n\
-Write executable Python code that advances the task.\n\
-Use SUBMIT(field=value, ...) once you can return the final typed answer.\n\
-Do not add prose or markdown fences unless needed by the task.";
 
 const EXTRACT_INSTRUCTION: &str = "Extract the final typed answer from the REPL history.\n\
 Use the expected output schema exactly.";
@@ -322,27 +321,30 @@ where
 
         let submit_slot: SubmitSlot = Arc::new(Mutex::new(None));
         let submit_handler = SubmitHandler::new::<S>(Arc::clone(&submit_slot));
-        let sub_lm = self
-            .sub_lm
-            .clone()
-            .or_else(|| {
-                let guard = crate::GLOBAL_SETTINGS.read().ok()?;
-                guard.as_ref().map(|settings| Arc::clone(&settings.lm))
-            })
-            .ok_or_else(|| RlmError::Configuration {
-                message: "Rlm requires a configured LM (global configure() or builder.sub_lm(...))"
+        let sub_lm = self.sub_lm.clone().or_else(|| {
+            let guard = crate::GLOBAL_SETTINGS.read().ok()?;
+            guard.as_ref().map(|settings| Arc::clone(&settings.lm))
+        });
+        if self.runtime.requires_sub_lm_tools() && sub_lm.is_none() {
+            return Err(RlmError::Configuration {
+                message: "Rlm runtime requires a configured sub-LM (global configure() or builder.sub_lm(...))"
                     .to_string(),
-            })?;
-        let llm_tools = LlmTools::with_budget(
-            sub_lm,
-            self.config.max_llm_calls,
-            tokio::runtime::Handle::try_current().map_err(|err| RlmError::Configuration {
-                message: format!("Rlm requires an active Tokio runtime handle: {err}"),
-            })?,
-        );
+            });
+        }
+        let llm_tools = if self.runtime.requires_sub_lm_tools() {
+            Some(LlmTools::with_budget(
+                sub_lm.expect("sub_lm present when required by runtime"),
+                self.config.max_llm_calls,
+                tokio::runtime::Handle::try_current().map_err(|err| RlmError::Configuration {
+                    message: format!("Rlm requires an active Tokio runtime handle: {err}"),
+                })?,
+            ))
+        } else {
+            None
+        };
         let globals: Py<PyDict> = Python::attach(|py| {
             self.runtime
-                .setup_interpreter_globals(py, input, &submit_handler, &llm_tools)
+                .setup_interpreter_globals(py, input, &submit_handler, llm_tools.as_ref())
         })
         .map_err(|err| RlmError::Configuration {
             message: err.to_string(),
@@ -372,18 +374,6 @@ where
                 TurnDecision::Continue | TurnDecision::Finalization => {}
             }
 
-            let mut execution_feedback = feedback.clone();
-            if matches!(
-                self.decide_turn_policy(turn_index, self.config.max_iterations),
-                TurnDecision::Finalization
-            ) {
-                let directive = self.finalization_directive();
-                execution_feedback = Some(match execution_feedback {
-                    Some(existing) if !existing.is_empty() => format!("{existing}\n\n{directive}"),
-                    _ => directive,
-                });
-            }
-
             let budget_remaining = self
                 .config
                 .max_iterations
@@ -392,7 +382,7 @@ where
             let action_input = self.build_action_input(
                 turn_index,
                 Some(previews.as_str()),
-                execution_feedback.as_deref(),
+                feedback.as_deref(),
                 budget_remaining,
             );
 
@@ -408,13 +398,17 @@ where
                 } => {
                     acc.absorb_parse_metadata(raw_response, lm_usage);
                     history = Some(chat);
-                    let sub_lm_remaining = self.runtime.sub_lm_budget_remaining(&llm_tools);
+                    let sub_lm_remaining = self.runtime.sub_lm_budget_remaining(llm_tools.as_ref());
+                    let next_turn_index = turn_index.saturating_add(1);
+                    let finalization_directive = (next_turn_index == self.config.max_iterations)
+                        .then(|| self.finalization_directive());
                     let parsed_feedback = format_feedback(
-                        turn_index,
+                        next_turn_index,
                         self.config.max_iterations.saturating_sub(turn_index),
                         sub_lm_remaining,
                         self.config.max_llm_calls,
                         &ExecOutcome::RecoverableParse { message: reason },
+                        finalization_directive.as_deref(),
                     );
                     feedback = Some(parsed_feedback);
                     turn_index += 1;
@@ -458,13 +452,19 @@ where
                             ));
                         }
                         other => {
-                            let sub_lm_remaining = self.runtime.sub_lm_budget_remaining(&llm_tools);
+                            let sub_lm_remaining =
+                                self.runtime.sub_lm_budget_remaining(llm_tools.as_ref());
+                            let next_turn_index = turn_index.saturating_add(1);
+                            let finalization_directive = (next_turn_index
+                                == self.config.max_iterations)
+                                .then(|| self.finalization_directive());
                             let rendered_feedback = format_feedback(
-                                turn_index,
+                                next_turn_index,
                                 self.config.max_iterations.saturating_sub(turn_index),
                                 sub_lm_remaining,
                                 self.config.max_llm_calls,
                                 &other,
+                                finalization_directive.as_deref(),
                             );
                             feedback = Some(rendered_feedback);
                             repl_history.entries.push(REPLEntry {
@@ -589,6 +589,7 @@ where
     S::Output: BamlType + for<'a> Facet<'a> + Clone + Send + Sync,
 {
     config: RlmConfig,
+    instruction_override: Option<String>,
     sub_lm: Option<Arc<crate::LM>>,
     runtime: Option<Arc<dyn RlmRuntime<S>>>,
     _marker: PhantomData<S>,
@@ -603,6 +604,7 @@ where
     fn new() -> Self {
         Self {
             config: RlmConfig::default(),
+            instruction_override: None,
             sub_lm: None,
             runtime: None,
             _marker: PhantomData,
@@ -629,6 +631,11 @@ where
         self
     }
 
+    pub fn instruction(mut self, instruction: impl Into<String>) -> Self {
+        self.instruction_override = Some(instruction.into());
+        self
+    }
+
     pub fn sub_lm(mut self, sub_lm: Arc<crate::LM>) -> Self {
         self.sub_lm = Some(sub_lm);
         self
@@ -640,8 +647,10 @@ where
     }
 
     pub fn build(self) -> Rlm<S> {
+        let action_instruction =
+            render_action_instruction::<S>(&self.config, self.instruction_override.as_deref());
         let generate_action = Predict::<RlmActionSig>::builder()
-            .instruction(ACTION_INSTRUCTION)
+            .instruction(action_instruction)
             .adapter(ChatAdapter::passthrough())
             .build();
         let extract = Predict::<RlmExtractSig<S>>::builder()
@@ -650,7 +659,7 @@ where
 
         let runtime = self
             .runtime
-            .unwrap_or_else(|| Arc::new(StubRuntime::new(self.config.max_llm_calls)));
+            .unwrap_or_else(|| default_runtime::<S>(self.config.max_llm_calls));
 
         Rlm {
             generate_action,
@@ -662,22 +671,52 @@ where
     }
 }
 
+fn default_runtime<S: Signature>(max_llm_calls: usize) -> Arc<dyn RlmRuntime<S>>
+where
+    S::Input: BamlType + for<'a> Facet<'a> + Clone + Send + Sync,
+    S::Output: BamlType + for<'a> Facet<'a> + Clone + Send + Sync,
+{
+    if let Ok(runtime_override) = std::env::var("DSPY_RS_RLM_RUNTIME") {
+        match runtime_override.trim().to_ascii_lowercase().as_str() {
+            "stub" => return Arc::new(StubRuntime::new(max_llm_calls)),
+            "pyo3" => return Arc::new(PyO3Runtime),
+            _ => {}
+        }
+    }
+
+    #[cfg(test)]
+    {
+        Arc::new(StubRuntime::new(max_llm_calls))
+    }
+    #[cfg(not(test))]
+    {
+        let _ = max_llm_calls;
+        Arc::new(PyO3Runtime)
+    }
+}
+
 pub fn format_feedback(
     turn_index: usize,
     budget_remaining: usize,
     sub_lm_remaining: usize,
     max_llm_calls: usize,
     outcome: &ExecOutcome,
+    finalization_directive: Option<&str>,
 ) -> String {
     let header = format!(
-        "[Turn {turn_index} | {budget_remaining} turns remaining, {sub_lm_remaining}/{max_llm_calls} sub-model calls remaining]"
+        "[Turn {turn_index} | {budget_remaining} turns, {sub_lm_remaining}/{max_llm_calls} sub-model calls remaining]"
     );
     let body = outcome_to_raw_output(outcome);
-    if body.is_empty() {
+    let mut rendered = if body.is_empty() {
         header
     } else {
-        format!("{header}\n{body}")
+        format!("{header}\n\n{body}")
+    };
+    if let Some(directive) = finalization_directive {
+        rendered.push_str("\n\n");
+        rendered.push_str(directive);
     }
+    rendered
 }
 
 pub fn recoverable_outcome_from_parse_error(error: &PredictError) -> Option<(String, Chat)> {
@@ -693,37 +732,6 @@ pub fn recoverable_outcome_from_parse_error(error: &PredictError) -> Option<(Str
         )),
         _ => None,
     }
-}
-
-pub fn render_previews<S: Signature>(input: &S::Input) -> String
-where
-    S::Input: BamlType + for<'a> Facet<'a>,
-{
-    let schema = SignatureSchema::of::<S>();
-    let value = input.to_baml_value();
-
-    let mut lines = vec!["## Variables".to_string(), String::new()];
-    for field in schema.input_fields() {
-        let rendered_type = field.type_ir.diagnostic_repr().to_string();
-        lines.push(format!("{}: {}", field.lm_name, rendered_type));
-        if let Some(field_value) = schema.navigate_field(field.path(), &value) {
-            lines.push(format!("  {}", render_value_preview(field_value, 0)));
-        } else {
-            lines.push("  <missing>".to_string());
-        }
-    }
-
-    lines.push(String::new());
-    lines.push("## Expected Output".to_string());
-    for field in schema.output_fields() {
-        lines.push(format!(
-            "{}: {}",
-            field.lm_name,
-            field.type_ir.diagnostic_repr()
-        ));
-    }
-
-    lines.join("\n")
 }
 
 fn classify_exec_outcome(
@@ -795,93 +803,106 @@ fn outcome_to_raw_output(outcome: &ExecOutcome) -> String {
     }
 }
 
-fn render_value_preview(value: &BamlValue, depth: usize) -> String {
-    const MAX_DEPTH: usize = 2;
-    if depth >= MAX_DEPTH {
-        return summarize_value_shape(value);
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Signature;
+    use std::sync::Arc;
+    use temp_env::with_var;
+
+    #[derive(Signature, Clone, Debug)]
+    struct RuntimePolicySig {
+        #[input]
+        prompt: String,
+        #[output]
+        answer: String,
     }
 
-    match value {
-        BamlValue::String(s) => {
-            let len = s.chars().count();
-            if len <= 200 {
-                format!("String ({len} chars): {:?}", s)
-            } else {
-                let head: String = s.chars().take(100).collect();
-                let tail: String = s
-                    .chars()
-                    .rev()
-                    .take(100)
-                    .collect::<String>()
-                    .chars()
-                    .rev()
-                    .collect();
-                format!(
-                    "String ({len} chars): {:?} ... ({} chars omitted) ... {:?}",
-                    head,
-                    len.saturating_sub(200),
-                    tail
-                )
-            }
-        }
-        BamlValue::Int(n) => format!("Int: {n}"),
-        BamlValue::Float(f) => format!("Float: {f}"),
-        BamlValue::Bool(b) => format!("Bool: {b}"),
-        BamlValue::Null => "Null".to_string(),
-        BamlValue::Enum(name, variant) => format!("Enum {name}::{variant}"),
-        BamlValue::Media(_) => "Media (preview omitted)".to_string(),
-        BamlValue::List(items) => {
-            if items.is_empty() {
-                return "List (0 items)".to_string();
-            }
-            let mut sample_indices = vec![0usize];
-            let mid = items.len() / 2;
-            if mid != 0 && mid != items.len() - 1 {
-                sample_indices.push(mid);
-            }
-            if items.len() > 1 {
-                sample_indices.push(items.len() - 1);
-            }
-            sample_indices.sort_unstable();
-            sample_indices.dedup();
-
-            let samples = sample_indices
-                .into_iter()
-                .map(|idx| {
-                    format!(
-                        "sample[{idx}] = {}",
-                        render_value_preview(&items[idx], depth + 1)
-                    )
-                })
-                .collect::<Vec<_>>()
-                .join("; ");
-            format!("List ({} items): {samples}", items.len())
-        }
-        BamlValue::Map(map) | BamlValue::Class(_, map) => {
-            let mut fields = map
-                .iter()
-                .take(4)
-                .map(|(k, v)| format!("{k}: {}", summarize_value_shape(v)))
-                .collect::<Vec<_>>();
-            if map.len() > 4 {
-                fields.push(format!("... ({} more)", map.len() - 4));
-            }
-            format!("Object {{{}}}", fields.join(", "))
-        }
+    #[test]
+    fn default_runtime_in_tests_uses_stub_policy() {
+        let runtime = default_runtime::<RuntimePolicySig>(3);
+        assert!(
+            !runtime.requires_sub_lm_tools(),
+            "test default runtime should be StubRuntime without required sub-LM tools"
+        );
     }
-}
 
-fn summarize_value_shape(value: &BamlValue) -> String {
-    match value {
-        BamlValue::String(s) => format!("String({} chars)", s.chars().count()),
-        BamlValue::Int(_) => "Int".to_string(),
-        BamlValue::Float(_) => "Float".to_string(),
-        BamlValue::Bool(_) => "Bool".to_string(),
-        BamlValue::Null => "Null".to_string(),
-        BamlValue::Enum(name, variant) => format!("Enum {name}::{variant}"),
-        BamlValue::Media(_) => "Media".to_string(),
-        BamlValue::List(items) => format!("List({} items)", items.len()),
-        BamlValue::Map(map) => format!("Map({} keys)", map.len()),
-        BamlValue::Class(name, map) => format!("Class {name}({} fields)", map.len()),
+    #[test]
+    fn default_runtime_override_to_pyo3_is_explicit() {
+        with_var("DSPY_RS_RLM_RUNTIME", Some("pyo3"), || {
+            let runtime = default_runtime::<RuntimePolicySig>(3);
+            assert!(
+                runtime.requires_sub_lm_tools(),
+                "explicit pyo3 override should require sub-LM tools"
+            );
+        });
+    }
+
+    #[test]
+    fn default_runtime_override_to_stub_is_explicit() {
+        with_var("DSPY_RS_RLM_RUNTIME", Some("stub"), || {
+            let runtime = default_runtime::<RuntimePolicySig>(3);
+            assert!(
+                !runtime.requires_sub_lm_tools(),
+                "explicit stub override should not require sub-LM tools"
+            );
+        });
+    }
+
+    #[test]
+    fn action_input_is_asymmetric_between_first_and_later_turns() {
+        let module = Rlm::<RuntimePolicySig>::builder().build();
+
+        let turn1 = module.build_action_input(1, Some("preview block"), Some("feedback"), 20);
+        assert_eq!(turn1.variables_info.as_deref(), Some("preview block"));
+        assert!(turn1.execution_feedback.is_none());
+        assert_eq!(turn1.budget_remaining, 20);
+
+        let turn2 = module.build_action_input(2, Some("preview block"), Some("feedback"), 19);
+        assert!(turn2.variables_info.is_none());
+        assert_eq!(turn2.execution_feedback.as_deref(), Some("feedback"));
+        assert_eq!(turn2.budget_remaining, 19);
+    }
+
+    #[test]
+    fn feedback_uses_next_turn_framing_and_supports_finalization_directive() {
+        let feedback = format_feedback(
+            2,
+            19,
+            50,
+            50,
+            &ExecOutcome::Continue {
+                code: "print('ok')".to_string(),
+                output: "ok".to_string(),
+            },
+            Some("This is your final turn. Call SUBMIT(answer=...) now with your best answer."),
+        );
+
+        assert!(feedback.contains("[Turn 2 | 19 turns, 50/50 sub-model calls remaining]"));
+        assert!(feedback.contains("\n\nok"));
+        assert!(feedback.contains("This is your final turn. Call SUBMIT(answer=...) now"));
+    }
+
+    #[tokio::test]
+    async fn pyo3_runtime_requires_sub_lm_when_not_configured() {
+        let module = Rlm::<RuntimePolicySig>::builder()
+            .runtime(Arc::new(PyO3Runtime))
+            .build();
+
+        let err = module
+            .call(RuntimePolicySigInput {
+                prompt: "ping".to_string(),
+            })
+            .await
+            .expect_err("missing sub-LM should fail before first action turn");
+        match err {
+            PredictError::Module { source, .. } => {
+                assert!(
+                    source.to_string().contains("configured sub-LM"),
+                    "expected sub-LM config error, got: {source}"
+                );
+            }
+            other => panic!("expected module error, got: {other}"),
+        }
     }
 }

--- a/crates/dspy-rs/src/modules/rlm/mod.rs
+++ b/crates/dspy-rs/src/modules/rlm/mod.rs
@@ -959,7 +959,11 @@ where
     render_namespace_section(&mut lines, "Recent", &namespace_sections.recent);
     render_namespace_section(&mut lines, "Stable", &namespace_sections.stable);
     lines.push(String::new());
-    lines.push(">>>".to_string());
+    lines.push(render_repl_prompt(
+        turn_index,
+        budget_remaining,
+        sub_lm_remaining,
+    ));
 
     Ok(PerceptionMessage {
         text: lines.join("\n"),
@@ -992,7 +996,7 @@ fn build_synthetic_turn_zero_user_message(
         "[Stable]".to_string(),
         "(none)".to_string(),
         String::new(),
-        ">>>".to_string(),
+        render_repl_prompt(0, budget_remaining, sub_lm_remaining),
     ]
     .join("\n")
 }
@@ -1106,6 +1110,17 @@ fn turns_label(turns: usize) -> String {
     } else {
         format!("{turns} turns")
     }
+}
+
+fn render_repl_prompt(
+    turn_index: usize,
+    turns_remaining: usize,
+    sub_lm_remaining: usize,
+) -> String {
+    format!(
+        "[T{turn_index} | {} | {sub_lm_remaining} llm] >>>",
+        turns_label(turns_remaining)
+    )
 }
 
 fn plural_suffix(count: usize) -> &'static str {
@@ -1545,7 +1560,7 @@ mod tests {
             assert!(message.contains("prompt ="));
             assert!(message.contains("result_count = 7"));
             assert!(!message.contains("_tmp ="));
-            assert!(message.ends_with(">>>"));
+            assert!(message.ends_with("[T1 | 3 turns | 11 llm] >>>"));
         });
     }
 
@@ -1596,7 +1611,7 @@ mod tests {
         assert!(message.contains("=== Execution Receipt (Turn 0) ==="));
         assert!(message.contains("Budget: 12 turns remaining | 20 sub-LLM calls remaining"));
         assert!(message.contains("=== Namespace ==="));
-        assert!(message.ends_with(">>>"));
+        assert!(message.ends_with("[T0 | 12 turns | 20 llm] >>>"));
         assert!(!message.contains("[query]"));
     }
 

--- a/crates/dspy-rs/src/modules/rlm/mod.rs
+++ b/crates/dspy-rs/src/modules/rlm/mod.rs
@@ -11,11 +11,16 @@ use crate::{
     Predict, PredictError, Predicted, Signature, SignatureSchema,
 };
 
+mod exec;
+mod py_bridge;
 pub mod runtime;
+mod submit;
+mod tools;
 pub use runtime::{
-    DynRuntime, LlmTools, RlmRuntime, StubRuntime, SubmitError, SubmitHandler, SubmitResultDyn,
-    SubmitSlot, clear_submit_slot, take_submit_result,
+    DynRuntime, LlmTools, PyO3Runtime, RlmRuntime, StubRuntime, SubmitError, SubmitHandler,
+    SubmitResultDyn, SubmitSlot, clear_submit_slot, take_submit_result,
 };
+pub use tools::LlmQuery;
 
 const DEFAULT_MAX_ITERATIONS: usize = 20;
 const DEFAULT_MAX_LLM_CALLS: usize = 50;
@@ -316,10 +321,25 @@ where
         }
 
         let submit_slot: SubmitSlot = Arc::new(Mutex::new(None));
-        let submit_handler = SubmitHandler;
-        let llm_tools = LlmTools {
-            max_llm_calls: self.config.max_llm_calls,
-        };
+        let submit_handler = SubmitHandler::new::<S>(Arc::clone(&submit_slot));
+        let sub_lm = self
+            .sub_lm
+            .clone()
+            .or_else(|| {
+                let guard = crate::GLOBAL_SETTINGS.read().ok()?;
+                guard.as_ref().map(|settings| Arc::clone(&settings.lm))
+            })
+            .ok_or_else(|| RlmError::Configuration {
+                message: "Rlm requires a configured LM (global configure() or builder.sub_lm(...))"
+                    .to_string(),
+            })?;
+        let llm_tools = LlmTools::with_budget(
+            sub_lm,
+            self.config.max_llm_calls,
+            tokio::runtime::Handle::try_current().map_err(|err| RlmError::Configuration {
+                message: format!("Rlm requires an active Tokio runtime handle: {err}"),
+            })?,
+        );
         let globals: Py<PyDict> = Python::attach(|py| {
             self.runtime
                 .setup_interpreter_globals(py, input, &submit_handler, &llm_tools)

--- a/crates/dspy-rs/src/modules/rlm/mod.rs
+++ b/crates/dspy-rs/src/modules/rlm/mod.rs
@@ -963,6 +963,7 @@ where
         turn_index,
         budget_remaining,
         sub_lm_remaining,
+        namespace_sections.namespace_snapshot.len(),
     ));
 
     Ok(PerceptionMessage {
@@ -996,7 +997,7 @@ fn build_synthetic_turn_zero_user_message(
         "[Stable]".to_string(),
         "(none)".to_string(),
         String::new(),
-        render_repl_prompt(0, budget_remaining, sub_lm_remaining),
+        render_repl_prompt(0, budget_remaining, sub_lm_remaining, 0),
     ]
     .join("\n")
 }
@@ -1116,10 +1117,11 @@ fn render_repl_prompt(
     turn_index: usize,
     turns_remaining: usize,
     sub_lm_remaining: usize,
+    namespace_var_count: usize,
 ) -> String {
     format!(
-        "[T{turn_index} | {} | {sub_lm_remaining} llm] >>>",
-        turns_label(turns_remaining)
+        "[T{turn_index} | {} | {sub_lm_remaining} llm | {namespace_var_count} vars] >>>",
+        turns_label(turns_remaining),
     )
 }
 
@@ -1560,7 +1562,7 @@ mod tests {
             assert!(message.contains("prompt ="));
             assert!(message.contains("result_count = 7"));
             assert!(!message.contains("_tmp ="));
-            assert!(message.ends_with("[T1 | 3 turns | 11 llm] >>>"));
+            assert!(message.ends_with("[T1 | 3 turns | 11 llm | 2 vars] >>>"));
         });
     }
 
@@ -1611,7 +1613,7 @@ mod tests {
         assert!(message.contains("=== Execution Receipt (Turn 0) ==="));
         assert!(message.contains("Budget: 12 turns remaining | 20 sub-LLM calls remaining"));
         assert!(message.contains("=== Namespace ==="));
-        assert!(message.ends_with("[T0 | 12 turns | 20 llm] >>>"));
+        assert!(message.ends_with("[T0 | 12 turns | 20 llm | 0 vars] >>>"));
         assert!(!message.contains("[query]"));
     }
 

--- a/crates/dspy-rs/src/modules/rlm/mod.rs
+++ b/crates/dspy-rs/src/modules/rlm/mod.rs
@@ -34,9 +34,10 @@ pub use tools::LlmQuery;
 
 const DEFAULT_MAX_ITERATIONS: usize = 20;
 const DEFAULT_MAX_LLM_CALLS: usize = 50;
-const DEFAULT_MAX_OUTPUT_CHARS: usize = 100_000;
+const DEFAULT_MAX_OUTPUT_CHARS: usize = 10_000;
 const DEFAULT_ENABLE_EXTRACTION_FALLBACK: bool = true;
 const MAX_RECOVERABLE_PARSE_SNIPPET_CHARS: usize = 80;
+const STDOUT_TRUNCATION_NOTICE_PREFIX: &str = "[STDOUT TRUNCATED at ";
 const SYNTHETIC_TURN_ZERO_ASSISTANT_CODE: &str =
     "# sanity check: does this thing work?\nprint('hello world')";
 
@@ -924,7 +925,11 @@ where
         {
             lines.push(String::new());
             lines.push("--- stdout ---".to_string());
-            lines.push(stdout.to_string());
+            append_stdout_lines_with_truncation_hint(
+                &mut lines,
+                stdout,
+                &namespace_sections.updated_names,
+            );
             lines.push("--------------".to_string());
         }
         if let Some(stderr) = feedback.stderr.as_deref()
@@ -1058,8 +1063,31 @@ fn render_updated_names(sections: &NamespaceSections) -> String {
     if sections.updated_names.is_empty() {
         return "none".to_string();
     }
-    sections
-        .updated_names
+    render_updated_var_names_inline(&sections.updated_names)
+}
+
+fn append_stdout_lines_with_truncation_hint(
+    lines: &mut Vec<String>,
+    stdout: &str,
+    updated_names: &[String],
+) {
+    for line in stdout.lines() {
+        lines.push(line.to_string());
+        if line
+            .trim_start()
+            .starts_with(STDOUT_TRUNCATION_NOTICE_PREFIX)
+            && !updated_names.is_empty()
+        {
+            lines.push(format!(
+                "hint: updated vars this turn: {} — query directly",
+                render_updated_var_names_inline(updated_names)
+            ));
+        }
+    }
+}
+
+fn render_updated_var_names_inline(updated_names: &[String]) -> String {
+    updated_names
         .iter()
         .map(|name| format!("`{name}`"))
         .collect::<Vec<_>>()
@@ -1603,6 +1631,98 @@ mod tests {
             let stdout_idx = message.find("--- stdout ---").expect("stdout marker");
             let query_idx = message.find("[query]").expect("query marker");
             assert!(stdout_idx < query_idx, "stdout should appear before query");
+        });
+    }
+
+    #[test]
+    fn perception_message_adds_truncation_hint_when_vars_updated() {
+        Python::attach(|py| {
+            let baseline = PyDict::new(py);
+            baseline.set_item("prompt", "x").expect("set prompt");
+            let baseline = baseline.unbind();
+            let previous_snapshot = collect_namespace_snapshot(py, &baseline, &["prompt"])
+                .map(|snapshot| namespace_snapshot_map(&snapshot))
+                .expect("previous snapshot");
+
+            let globals = PyDict::new(py);
+            globals.set_item("prompt", "x").expect("set prompt");
+            globals
+                .set_item("retro_corrections", vec!["a", "b"])
+                .expect("set updated var");
+
+            let input = RuntimePolicySigInput {
+                prompt: "x".to_string(),
+            };
+            let feedback = PerceptionFeedback {
+                stdout: Some(
+                    "partial output\n[STDOUT TRUNCATED at 10,000 chars (24,847 total)]".to_string(),
+                ),
+                stderr: None,
+                execution_time: Some(Duration::from_millis(220)),
+            };
+
+            let message = build_perception_message::<RuntimePolicySig>(
+                py,
+                &globals.unbind(),
+                &input,
+                "Inspect trajectories",
+                Some(&feedback),
+                7,
+                0,
+                false,
+                6,
+                Some(20),
+                Some(&previous_snapshot),
+            )
+            .expect("message")
+            .text;
+
+            assert!(message.contains("[STDOUT TRUNCATED at 10,000 chars (24,847 total)]"));
+            assert!(
+                message
+                    .contains("hint: updated vars this turn: `retro_corrections` — query directly"),
+                "{message}"
+            );
+        });
+    }
+
+    #[test]
+    fn perception_message_skips_truncation_hint_when_no_vars_updated() {
+        Python::attach(|py| {
+            let globals = PyDict::new(py);
+            globals.set_item("prompt", "x").expect("set prompt");
+            globals.set_item("stable_value", 1).expect("set stable");
+            let globals = globals.unbind();
+            let previous_snapshot = collect_namespace_snapshot(py, &globals, &["prompt"])
+                .map(|snapshot| namespace_snapshot_map(&snapshot))
+                .expect("previous snapshot");
+
+            let input = RuntimePolicySigInput {
+                prompt: "x".to_string(),
+            };
+            let feedback = PerceptionFeedback {
+                stdout: Some("[STDOUT TRUNCATED at 10,000 chars (24,847 total)]".to_string()),
+                stderr: None,
+                execution_time: Some(Duration::from_millis(180)),
+            };
+
+            let message = build_perception_message::<RuntimePolicySig>(
+                py,
+                &globals,
+                &input,
+                "Inspect trajectories",
+                Some(&feedback),
+                7,
+                0,
+                false,
+                6,
+                Some(0),
+                Some(&previous_snapshot),
+            )
+            .expect("message")
+            .text;
+
+            assert!(!message.contains("hint: updated vars this turn:"));
         });
     }
 

--- a/crates/dspy-rs/src/modules/rlm/mod.rs
+++ b/crates/dspy-rs/src/modules/rlm/mod.rs
@@ -957,7 +957,7 @@ where
     lines.push("=== Namespace ===".to_string());
     render_namespace_section(&mut lines, "Injected", &namespace_sections.injected);
     render_namespace_section(&mut lines, "Recent", &namespace_sections.recent);
-    render_namespace_section(&mut lines, "Stable", &namespace_sections.stable);
+    render_stable_namespace_summary(&mut lines, namespace_sections.stable.len());
     lines.push(String::new());
     lines.push(render_repl_prompt(
         turn_index,
@@ -994,8 +994,7 @@ fn build_synthetic_turn_zero_user_message(
         "[Recent]".to_string(),
         "(none)".to_string(),
         String::new(),
-        "[Stable]".to_string(),
-        "(none)".to_string(),
+        "[Stable] 0 variables".to_string(),
         String::new(),
         render_repl_prompt(0, budget_remaining, sub_lm_remaining, 0),
     ]
@@ -1059,6 +1058,18 @@ fn render_namespace_section(lines: &mut Vec<String>, title: &str, entries: &[(St
     for (name, repr_value) in entries {
         lines.push(format!("{name} = {repr_value}"));
     }
+}
+
+fn render_stable_namespace_summary(lines: &mut Vec<String>, stable_count: usize) {
+    lines.push(String::new());
+    lines.push(format!(
+        "[Stable] {stable_count} {}",
+        if stable_count == 1 {
+            "variable"
+        } else {
+            "variables"
+        }
+    ));
 }
 
 fn render_updated_names(sections: &NamespaceSections) -> String {
@@ -1786,7 +1797,7 @@ mod tests {
 
             assert!(message.contains("Updated: `recent_value`"));
             assert!(message.contains("[Recent]\nrecent_value = 2"));
-            assert!(message.contains("[Stable]\nstable_value = 1"));
+            assert!(message.contains("[Stable] 1 variable"));
         });
     }
 

--- a/crates/dspy-rs/src/modules/rlm/mod.rs
+++ b/crates/dspy-rs/src/modules/rlm/mod.rs
@@ -4,6 +4,7 @@ use std::sync::{Arc, Mutex};
 use indexmap::IndexMap;
 use pyo3::Python;
 use rig::message::ToolCall;
+use tracing::{debug, info, info_span};
 
 use crate::{
     BamlType, BamlValue, CallMetadata, Chat, ChatAdapter, Facet, FieldMeta, LmUsage, Module,
@@ -323,6 +324,13 @@ where
                 message: "max_iterations must be >= 1".to_string(),
             });
         }
+        info!(
+            max_iterations = self.config.max_iterations,
+            max_llm_calls = self.config.max_llm_calls,
+            max_output_chars = self.config.max_output_chars,
+            extraction_fallback = self.config.enable_extraction_fallback,
+            "rlm run started"
+        );
 
         let submit_slot: SubmitSlot = Arc::new(Mutex::new(None));
         let submit_handler = SubmitHandler::new::<S>(Arc::clone(&submit_slot));
@@ -347,16 +355,45 @@ where
         } else {
             None
         };
-        let setup = Python::attach(|py| {
-            self.runtime
-                .setup_interpreter_globals(py, input, &submit_handler, llm_tools.as_ref())
-        })
+        let input_fields = input.rlm_field_names().len();
+        let setup = {
+            let _inject_span = info_span!(
+                "rlm.inject",
+                input_fields,
+                sub_lm_tools = llm_tools.is_some()
+            )
+            .entered();
+            Python::attach(|py| {
+                self.runtime.setup_interpreter_globals(
+                    py,
+                    input,
+                    &submit_handler,
+                    llm_tools.as_ref(),
+                )
+            })
+        }
         .map_err(|err| RlmError::Configuration {
             message: err.to_string(),
         })?;
+        debug!(
+            input_fields,
+            injected_objects = setup.methods_by_var.len(),
+            "interpreter globals injected"
+        );
         let globals = setup.globals;
 
-        let previews = render_previews::<S>(input, &setup.methods_by_var);
+        let preview_span = info_span!(
+            "rlm.preview",
+            input_fields,
+            preview_len = tracing::field::Empty
+        );
+        let previews = {
+            let _preview_span = preview_span.enter();
+            render_previews::<S>(input, &setup.methods_by_var)
+        };
+        let preview_len = previews.chars().count();
+        preview_span.record("preview_len", preview_len);
+        info!(preview_len, "rlm preview generated");
         let mut history: Option<Chat> = None;
         let mut feedback: Option<String> = None;
         let mut turn_index = 1usize;
@@ -366,6 +403,13 @@ where
         };
 
         loop {
+            let is_first_turn = turn_index == 1;
+            let _turn_span = info_span!(
+                "rlm.turn",
+                iteration = turn_index,
+                first_turn = is_first_turn
+            )
+            .entered();
             match self.decide_turn_policy(turn_index, self.config.max_iterations) {
                 TurnDecision::Fallback => {
                     if self.config.enable_extraction_fallback {
@@ -392,6 +436,12 @@ where
                 budget_remaining,
             );
 
+            info!(
+                iteration = turn_index,
+                first_turn = is_first_turn,
+                budget_remaining,
+                "running action predict call"
+            );
             let turn_history = history.take();
             match self.run_action_turn(action_input, turn_history).await? {
                 ActionTurn::RecoverableParse {
@@ -400,6 +450,12 @@ where
                     chat,
                     reason,
                 } => {
+                    debug!(
+                        iteration = turn_index,
+                        response_kind = "error",
+                        error_kind = "recoverable_parse",
+                        "predict response received"
+                    );
                     acc.absorb_parse_metadata(raw_response, lm_usage);
                     history = Some(chat);
                     let sub_lm_remaining = self.runtime.sub_lm_budget_remaining(llm_tools.as_ref());
@@ -438,6 +494,11 @@ where
 
                     match outcome {
                         ExecOutcome::SubmitAccepted { value, field_meta } => {
+                            info!(
+                                iteration = turn_index,
+                                response_kind = "submit",
+                                "predict response received"
+                            );
                             let typed_output =
                                 S::Output::try_from_baml_value(value).map_err(|err| {
                                     RlmError::Invariant {
@@ -456,6 +517,12 @@ where
                             ));
                         }
                         other => {
+                            debug!(
+                                iteration = turn_index,
+                                response_kind = predict_response_kind_from_outcome(&other),
+                                outcome = exec_outcome_kind(&other),
+                                "predict response received"
+                            );
                             let sub_lm_remaining =
                                 self.runtime.sub_lm_budget_remaining(llm_tools.as_ref());
                             let next_turn_index = turn_index.saturating_add(1);
@@ -792,6 +859,28 @@ fn classify_exec_outcome(
     match exec_result {
         Ok(output) => ExecOutcome::Continue { output },
         Err(message) => ExecOutcome::PythonException { message },
+    }
+}
+
+fn predict_response_kind_from_outcome(outcome: &ExecOutcome) -> &'static str {
+    match outcome {
+        ExecOutcome::SubmitAccepted { .. } => "submit",
+        ExecOutcome::Continue { .. } => "code",
+        ExecOutcome::SubmitValidationError { .. }
+        | ExecOutcome::SubmitAssertionFailed { .. }
+        | ExecOutcome::PythonException { .. }
+        | ExecOutcome::RecoverableParse { .. } => "error",
+    }
+}
+
+fn exec_outcome_kind(outcome: &ExecOutcome) -> &'static str {
+    match outcome {
+        ExecOutcome::Continue { .. } => "continue",
+        ExecOutcome::SubmitAccepted { .. } => "submit_accepted",
+        ExecOutcome::SubmitValidationError { .. } => "submit_validation_error",
+        ExecOutcome::SubmitAssertionFailed { .. } => "submit_assertion_failed",
+        ExecOutcome::PythonException { .. } => "python_exception",
+        ExecOutcome::RecoverableParse { .. } => "recoverable_parse",
     }
 }
 

--- a/crates/dspy-rs/src/modules/rlm/mod.rs
+++ b/crates/dspy-rs/src/modules/rlm/mod.rs
@@ -473,8 +473,14 @@ where
             match self.decide_turn_policy(turn_index, self.config.max_iterations) {
                 TurnDecision::Fallback => {
                     if self.config.enable_extraction_fallback {
+                        let action_history = history.take();
                         return self
-                            .run_extraction_fallback(&previews, repl_history, &mut acc)
+                            .run_extraction_fallback(
+                                &previews,
+                                repl_history,
+                                action_history,
+                                &mut acc,
+                            )
                             .await;
                     }
                     return Err(RlmError::MaxIterationsReached {
@@ -642,6 +648,7 @@ where
         &self,
         previews: &str,
         repl_history: REPLHistory,
+        action_history: Option<Chat>,
         acc: &mut MetadataAcc,
     ) -> Result<Predicted<S::Output>, RlmError> {
         let extract_input = RlmExtractInput {
@@ -653,10 +660,14 @@ where
             .forward(extract_input, None)
             .await
             .map_err(|source| RlmError::ExtractFallback { source })?;
-        let (output, metadata, chat) = predicted.into_parts();
+        let (output, metadata, extract_chat) = predicted.into_parts();
         acc.absorb_call_metadata(metadata);
         let metadata = std::mem::take(acc).into_call_metadata();
-        Ok(Predicted::new(output, metadata, chat))
+        // Preserve action-loop chat when fallback extraction runs so downstream
+        // transcripts still reflect the REPL interaction that produced the evidence.
+        // If no action history exists, fall back to the extractor chat.
+        let final_chat = action_history.unwrap_or(extract_chat);
+        Ok(Predicted::new(output, metadata, final_chat))
     }
 }
 

--- a/crates/dspy-rs/src/modules/rlm/mod.rs
+++ b/crates/dspy-rs/src/modules/rlm/mod.rs
@@ -1,0 +1,838 @@
+use std::marker::PhantomData;
+use std::sync::{Arc, Mutex};
+
+use indexmap::IndexMap;
+use pyo3::types::PyDict;
+use pyo3::{Py, Python};
+use rig::message::ToolCall;
+
+use crate::{
+    BamlType, BamlValue, CallMetadata, Chat, ChatAdapter, Facet, FieldMeta, LmUsage, Module,
+    Predict, PredictError, Predicted, Signature, SignatureSchema,
+};
+
+pub mod runtime;
+pub use runtime::{
+    DynRuntime, LlmTools, RlmRuntime, StubRuntime, SubmitError, SubmitHandler, SubmitResultDyn,
+    SubmitSlot, clear_submit_slot, take_submit_result,
+};
+
+const DEFAULT_MAX_ITERATIONS: usize = 20;
+const DEFAULT_MAX_LLM_CALLS: usize = 50;
+const DEFAULT_MAX_OUTPUT_CHARS: usize = 100_000;
+const DEFAULT_ENABLE_EXTRACTION_FALLBACK: bool = true;
+
+const ACTION_INSTRUCTION: &str = "You are operating inside a persistent Python REPL.\n\
+Write executable Python code that advances the task.\n\
+Use SUBMIT(field=value, ...) once you can return the final typed answer.\n\
+Do not add prose or markdown fences unless needed by the task.";
+
+const EXTRACT_INSTRUCTION: &str = "Extract the final typed answer from the REPL history.\n\
+Use the expected output schema exactly.";
+
+#[derive(Signature, Clone, Debug)]
+struct RlmActionSig {
+    #[input]
+    variables_info: Option<String>,
+
+    #[input]
+    execution_feedback: Option<String>,
+
+    #[input]
+    budget_remaining: u32,
+
+    #[output]
+    code: String,
+}
+
+#[derive(Clone, Debug)]
+#[BamlType]
+pub struct REPLHistory {
+    pub entries: Vec<REPLEntry>,
+}
+
+#[derive(Clone, Debug)]
+#[BamlType]
+pub struct REPLEntry {
+    pub turn: u32,
+    pub code: String,
+    pub output: String,
+}
+
+#[derive(Clone, Debug)]
+#[BamlType]
+pub struct RlmExtractInput {
+    pub variables_info: String,
+    pub repl_history: REPLHistory,
+}
+
+pub struct RlmExtractSig<S: Signature>(PhantomData<S>);
+
+impl<S> Signature for RlmExtractSig<S>
+where
+    S: Signature,
+    S::Input: BamlType + for<'a> Facet<'a> + Clone + Send + Sync,
+    S::Output: BamlType + for<'a> Facet<'a> + Clone + Send + Sync,
+{
+    type Input = RlmExtractInput;
+    type Output = S::Output;
+
+    fn instruction() -> &'static str {
+        EXTRACT_INSTRUCTION
+    }
+
+    fn input_shape() -> &'static facet::Shape {
+        facet::shape_of::<RlmExtractInput>()
+    }
+
+    fn output_shape() -> &'static facet::Shape {
+        facet::shape_of::<S::Output>()
+    }
+
+    fn input_field_metadata() -> &'static [crate::FieldMetadataSpec] {
+        const INPUT_META: [crate::FieldMetadataSpec; 2] = [
+            crate::FieldMetadataSpec {
+                rust_name: "variables_info",
+                alias: None,
+                constraints: &[],
+                input_render: crate::InputRenderSpec::Default,
+            },
+            crate::FieldMetadataSpec {
+                rust_name: "repl_history",
+                alias: None,
+                constraints: &[],
+                input_render: crate::InputRenderSpec::Default,
+            },
+        ];
+        &INPUT_META
+    }
+
+    fn output_field_metadata() -> &'static [crate::FieldMetadataSpec] {
+        S::output_field_metadata()
+    }
+}
+
+#[derive(Debug, Clone, facet::Facet)]
+#[facet(crate = facet)]
+pub struct RlmConfig {
+    pub max_iterations: usize,
+    pub max_llm_calls: usize,
+    pub max_output_chars: usize,
+    pub enable_extraction_fallback: bool,
+}
+
+impl Default for RlmConfig {
+    fn default() -> Self {
+        Self {
+            max_iterations: DEFAULT_MAX_ITERATIONS,
+            max_llm_calls: DEFAULT_MAX_LLM_CALLS,
+            max_output_chars: DEFAULT_MAX_OUTPUT_CHARS,
+            enable_extraction_fallback: DEFAULT_ENABLE_EXTRACTION_FALLBACK,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct MetadataAcc {
+    pub lm_usage: LmUsage,
+    pub tool_calls: Vec<ToolCall>,
+    pub tool_executions: Vec<String>,
+    pub raw_responses: Vec<String>,
+    pub field_meta: IndexMap<String, FieldMeta>,
+}
+
+impl MetadataAcc {
+    fn absorb_call_metadata(&mut self, metadata: CallMetadata) {
+        self.lm_usage = self.lm_usage.clone() + metadata.lm_usage;
+        self.tool_calls.extend(metadata.tool_calls);
+        self.tool_executions.extend(metadata.tool_executions);
+        self.raw_responses.push(metadata.raw_response);
+        self.field_meta.extend(metadata.field_meta);
+    }
+
+    fn absorb_parse_metadata(&mut self, raw_response: String, lm_usage: LmUsage) {
+        self.lm_usage = self.lm_usage.clone() + lm_usage;
+        self.raw_responses.push(raw_response);
+    }
+
+    fn to_call_metadata(&self) -> CallMetadata {
+        let raw_response = if self.raw_responses.is_empty() {
+            String::new()
+        } else {
+            self.raw_responses.join("\n\n")
+        };
+
+        CallMetadata::new(
+            raw_response,
+            self.lm_usage.clone(),
+            self.tool_calls.clone(),
+            self.tool_executions.clone(),
+            None,
+            self.field_meta.clone(),
+        )
+    }
+}
+
+pub enum ActionTurn {
+    Parsed(Predicted<RlmActionSigOutput>),
+    RecoverableParse {
+        raw_response: String,
+        lm_usage: LmUsage,
+        chat: Chat,
+        reason: String,
+    },
+}
+
+pub enum ExecOutcome {
+    Continue {
+        code: String,
+        output: String,
+    },
+    SubmitAccepted {
+        value: BamlValue,
+        field_meta: IndexMap<String, FieldMeta>,
+    },
+    SubmitValidationError {
+        message: String,
+        errors: Vec<String>,
+    },
+    SubmitAssertionFailed {
+        label: String,
+        expression: String,
+    },
+    PythonException {
+        message: String,
+    },
+    RecoverableParse {
+        message: String,
+    },
+}
+
+enum TurnDecision {
+    Continue,
+    Finalization,
+    Fallback,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum RlmError {
+    #[error("configuration error: {message}")]
+    Configuration { message: String },
+
+    #[error("action predict failed")]
+    ActionPredict {
+        #[source]
+        source: PredictError,
+    },
+
+    #[error("python execution failed: {message}")]
+    PythonExec { message: String },
+
+    #[error("extraction fallback failed")]
+    ExtractFallback {
+        #[source]
+        source: PredictError,
+    },
+
+    #[error("max iterations reached ({max})")]
+    MaxIterationsReached { max: usize },
+
+    #[error("internal invariant violated: {message}")]
+    Invariant { message: String },
+}
+
+impl From<RlmError> for PredictError {
+    fn from(value: RlmError) -> Self {
+        match value {
+            RlmError::ActionPredict { source } => source,
+            RlmError::ExtractFallback { source } => source,
+            other => PredictError::Module {
+                module: "Rlm",
+                source: Box::new(other),
+            },
+        }
+    }
+}
+
+#[derive(facet::Facet)]
+#[facet(crate = facet)]
+pub struct Rlm<S>
+where
+    S: Signature,
+    S::Input: BamlType + for<'a> Facet<'a> + Clone + Send + Sync,
+    S::Output: BamlType + for<'a> Facet<'a> + Clone + Send + Sync,
+{
+    generate_action: Predict<RlmActionSig>,
+    extract: Predict<RlmExtractSig<S>>,
+
+    #[facet(skip)]
+    config: RlmConfig,
+    #[facet(skip, opaque)]
+    sub_lm: Option<Arc<crate::LM>>,
+    #[facet(skip, opaque)]
+    runtime: Arc<dyn RlmRuntime<S>>,
+}
+
+impl<S> Default for Rlm<S>
+where
+    S: Signature,
+    S::Input: BamlType + for<'a> Facet<'a> + Clone + Send + Sync,
+    S::Output: BamlType + for<'a> Facet<'a> + Clone + Send + Sync,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<S> Rlm<S>
+where
+    S: Signature,
+    S::Input: BamlType + for<'a> Facet<'a> + Clone + Send + Sync,
+    S::Output: BamlType + for<'a> Facet<'a> + Clone + Send + Sync,
+{
+    pub fn new() -> Self {
+        Self::builder().build()
+    }
+
+    pub fn builder() -> RlmBuilder<S> {
+        RlmBuilder::new()
+    }
+
+    pub async fn call(&self, input: S::Input) -> Result<Predicted<S::Output>, PredictError> {
+        self.forward(input).await
+    }
+
+    pub async fn forward(&self, input: S::Input) -> Result<Predicted<S::Output>, PredictError> {
+        self.run_loop(&input).await.map_err(Into::into)
+    }
+
+    async fn run_loop(&self, input: &S::Input) -> Result<Predicted<S::Output>, RlmError> {
+        if self.config.max_iterations == 0 {
+            return Err(RlmError::Configuration {
+                message: "max_iterations must be >= 1".to_string(),
+            });
+        }
+
+        let submit_slot: SubmitSlot = Arc::new(Mutex::new(None));
+        let submit_handler = SubmitHandler;
+        let llm_tools = LlmTools {
+            max_llm_calls: self.config.max_llm_calls,
+        };
+        let globals: Py<PyDict> = Python::attach(|py| {
+            self.runtime
+                .setup_interpreter_globals(py, input, &submit_handler, &llm_tools)
+        })
+        .map_err(|err| RlmError::Configuration {
+            message: err.to_string(),
+        })?;
+
+        let previews = render_previews::<S>(input);
+        let mut history: Option<Chat> = None;
+        let mut feedback: Option<String> = None;
+        let mut turn_index = 1usize;
+        let mut acc = MetadataAcc::default();
+        let mut repl_history = REPLHistory {
+            entries: Vec::new(),
+        };
+
+        loop {
+            match self.decide_turn_policy(turn_index, self.config.max_iterations) {
+                TurnDecision::Fallback => {
+                    if self.config.enable_extraction_fallback {
+                        return self
+                            .run_extraction_fallback(&previews, repl_history, &mut acc)
+                            .await;
+                    }
+                    return Err(RlmError::MaxIterationsReached {
+                        max: self.config.max_iterations,
+                    });
+                }
+                TurnDecision::Continue | TurnDecision::Finalization => {}
+            }
+
+            let mut execution_feedback = feedback.clone();
+            if matches!(
+                self.decide_turn_policy(turn_index, self.config.max_iterations),
+                TurnDecision::Finalization
+            ) {
+                let directive = self.finalization_directive();
+                execution_feedback = Some(match execution_feedback {
+                    Some(existing) if !existing.is_empty() => format!("{existing}\n\n{directive}"),
+                    _ => directive,
+                });
+            }
+
+            let budget_remaining = self
+                .config
+                .max_iterations
+                .saturating_sub(turn_index)
+                .saturating_add(1);
+            let action_input = self.build_action_input(
+                turn_index,
+                Some(previews.as_str()),
+                execution_feedback.as_deref(),
+                budget_remaining,
+            );
+
+            match self
+                .run_action_turn(action_input, history.clone(), &mut acc)
+                .await?
+            {
+                ActionTurn::RecoverableParse {
+                    raw_response,
+                    lm_usage,
+                    chat,
+                    reason,
+                } => {
+                    acc.absorb_parse_metadata(raw_response, lm_usage);
+                    history = Some(chat);
+                    let sub_lm_remaining = self.runtime.sub_lm_budget_remaining(&llm_tools);
+                    let parsed_feedback = format_feedback(
+                        turn_index,
+                        self.config.max_iterations.saturating_sub(turn_index),
+                        sub_lm_remaining,
+                        self.config.max_llm_calls,
+                        &ExecOutcome::RecoverableParse { message: reason },
+                    );
+                    feedback = Some(parsed_feedback);
+                    turn_index += 1;
+                }
+                ActionTurn::Parsed(predicted) => {
+                    let (action_output, action_metadata, action_chat) = predicted.into_parts();
+                    acc.absorb_call_metadata(action_metadata);
+                    history = Some(action_chat);
+
+                    let code = action_output.code;
+                    clear_submit_slot(&submit_slot);
+
+                    let exec_result = Python::attach(|py| {
+                        self.runtime.execute_repl_code(
+                            py,
+                            &globals,
+                            &code,
+                            self.config.max_output_chars,
+                        )
+                    });
+                    let submit_result = take_submit_result(&submit_slot);
+                    let outcome = classify_exec_outcome(code.clone(), exec_result, submit_result);
+
+                    match outcome {
+                        ExecOutcome::SubmitAccepted { value, field_meta } => {
+                            let typed_output =
+                                S::Output::try_from_baml_value(value).map_err(|err| {
+                                    RlmError::Invariant {
+                                        message: format!(
+                                            "SUBMIT produced invalid output value: {err}"
+                                        ),
+                                    }
+                                })?;
+                            acc.field_meta.extend(field_meta);
+
+                            let final_chat = history.unwrap_or_else(|| Chat::new(vec![]));
+                            return Ok(Predicted::new(
+                                typed_output,
+                                acc.to_call_metadata(),
+                                final_chat,
+                            ));
+                        }
+                        other => {
+                            let sub_lm_remaining = self.runtime.sub_lm_budget_remaining(&llm_tools);
+                            let rendered_feedback = format_feedback(
+                                turn_index,
+                                self.config.max_iterations.saturating_sub(turn_index),
+                                sub_lm_remaining,
+                                self.config.max_llm_calls,
+                                &other,
+                            );
+                            feedback = Some(rendered_feedback);
+                            repl_history.entries.push(REPLEntry {
+                                turn: turn_index.min(u32::MAX as usize) as u32,
+                                code,
+                                output: outcome_to_raw_output(&other),
+                            });
+                            turn_index += 1;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn build_action_input(
+        &self,
+        turn_index: usize,
+        previews: Option<&str>,
+        execution_feedback: Option<&str>,
+        budget_remaining: usize,
+    ) -> RlmActionSigInput {
+        let (variables_info, execution_feedback) = if turn_index == 1 {
+            (previews.map(ToOwned::to_owned), None)
+        } else {
+            (None, execution_feedback.map(ToOwned::to_owned))
+        };
+
+        RlmActionSigInput::new(
+            variables_info,
+            execution_feedback,
+            budget_remaining.min(u32::MAX as usize) as u32,
+        )
+    }
+
+    async fn run_action_turn(
+        &self,
+        action_input: RlmActionSigInput,
+        history: Option<Chat>,
+        _acc: &mut MetadataAcc,
+    ) -> Result<ActionTurn, RlmError> {
+        match self.generate_action.forward(action_input, history).await {
+            Ok(predicted) => Ok(ActionTurn::Parsed(predicted)),
+            Err(error) => match error {
+                PredictError::Parse {
+                    source,
+                    raw_response,
+                    lm_usage,
+                    chat,
+                } if raw_response.trim().is_empty() => Ok(ActionTurn::RecoverableParse {
+                    raw_response,
+                    lm_usage,
+                    chat,
+                    reason: format!(
+                        "Empty response from model ({source}). Write executable Python code."
+                    ),
+                }),
+                other => Err(RlmError::ActionPredict { source: other }),
+            },
+        }
+    }
+
+    fn decide_turn_policy(&self, turn_index: usize, max_iterations: usize) -> TurnDecision {
+        if turn_index < max_iterations {
+            TurnDecision::Continue
+        } else if turn_index == max_iterations {
+            TurnDecision::Finalization
+        } else {
+            TurnDecision::Fallback
+        }
+    }
+
+    async fn run_extraction_fallback(
+        &self,
+        previews: &str,
+        repl_history: REPLHistory,
+        acc: &mut MetadataAcc,
+    ) -> Result<Predicted<S::Output>, RlmError> {
+        let extract_input = RlmExtractInput {
+            variables_info: previews.to_string(),
+            repl_history,
+        };
+        let predicted = self
+            .extract
+            .forward(extract_input, None)
+            .await
+            .map_err(|source| RlmError::ExtractFallback { source })?;
+        let (output, metadata, chat) = predicted.into_parts();
+        acc.absorb_call_metadata(metadata);
+        Ok(Predicted::new(output, acc.to_call_metadata(), chat))
+    }
+
+    fn finalization_directive(&self) -> String {
+        let output_fields = S::schema()
+            .output_fields()
+            .iter()
+            .map(|field| format!("{}=...", field.lm_name))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("This is your final turn. Call SUBMIT({output_fields}) now with your best answer.")
+    }
+}
+
+impl<S> Module for Rlm<S>
+where
+    S: Signature,
+    S::Input: BamlType + for<'a> Facet<'a> + Clone + Send + Sync,
+    S::Output: BamlType + for<'a> Facet<'a> + Clone + Send + Sync,
+{
+    type Input = S::Input;
+    type Output = S::Output;
+
+    async fn forward(&self, input: S::Input) -> Result<Predicted<S::Output>, PredictError> {
+        Rlm::forward(self, input).await
+    }
+}
+
+pub struct RlmBuilder<S>
+where
+    S: Signature,
+    S::Input: BamlType + for<'a> Facet<'a> + Clone + Send + Sync,
+    S::Output: BamlType + for<'a> Facet<'a> + Clone + Send + Sync,
+{
+    config: RlmConfig,
+    sub_lm: Option<Arc<crate::LM>>,
+    runtime: Option<Arc<dyn RlmRuntime<S>>>,
+    _marker: PhantomData<S>,
+}
+
+impl<S> RlmBuilder<S>
+where
+    S: Signature,
+    S::Input: BamlType + for<'a> Facet<'a> + Clone + Send + Sync,
+    S::Output: BamlType + for<'a> Facet<'a> + Clone + Send + Sync,
+{
+    fn new() -> Self {
+        Self {
+            config: RlmConfig::default(),
+            sub_lm: None,
+            runtime: None,
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn max_iterations(mut self, max_iterations: usize) -> Self {
+        self.config.max_iterations = max_iterations;
+        self
+    }
+
+    pub fn max_llm_calls(mut self, max_llm_calls: usize) -> Self {
+        self.config.max_llm_calls = max_llm_calls;
+        self
+    }
+
+    pub fn max_output_chars(mut self, max_output_chars: usize) -> Self {
+        self.config.max_output_chars = max_output_chars;
+        self
+    }
+
+    pub fn enable_extraction_fallback(mut self, enable_extraction_fallback: bool) -> Self {
+        self.config.enable_extraction_fallback = enable_extraction_fallback;
+        self
+    }
+
+    pub fn sub_lm(mut self, sub_lm: Arc<crate::LM>) -> Self {
+        self.sub_lm = Some(sub_lm);
+        self
+    }
+
+    pub fn runtime(mut self, runtime: Arc<dyn RlmRuntime<S>>) -> Self {
+        self.runtime = Some(runtime);
+        self
+    }
+
+    pub fn build(self) -> Rlm<S> {
+        let generate_action = Predict::<RlmActionSig>::builder()
+            .instruction(ACTION_INSTRUCTION)
+            .adapter(ChatAdapter::passthrough())
+            .build();
+        let extract = Predict::<RlmExtractSig<S>>::builder()
+            .instruction(EXTRACT_INSTRUCTION)
+            .build();
+
+        let runtime = self
+            .runtime
+            .unwrap_or_else(|| Arc::new(StubRuntime::new(self.config.max_llm_calls)));
+
+        Rlm {
+            generate_action,
+            extract,
+            config: self.config,
+            sub_lm: self.sub_lm,
+            runtime,
+        }
+    }
+}
+
+pub fn format_feedback(
+    turn_index: usize,
+    budget_remaining: usize,
+    sub_lm_remaining: usize,
+    max_llm_calls: usize,
+    outcome: &ExecOutcome,
+) -> String {
+    let header = format!(
+        "[Turn {turn_index} | {budget_remaining} turns remaining, {sub_lm_remaining}/{max_llm_calls} sub-model calls remaining]"
+    );
+    let body = outcome_to_raw_output(outcome);
+    if body.is_empty() {
+        header
+    } else {
+        format!("{header}\n{body}")
+    }
+}
+
+pub fn recoverable_outcome_from_parse_error(error: &PredictError) -> Option<(String, Chat)> {
+    match error {
+        PredictError::Parse {
+            raw_response,
+            chat,
+            source,
+            ..
+        } if raw_response.trim().is_empty() => Some((
+            format!("Empty response from model ({source}). Write executable Python code."),
+            chat.clone(),
+        )),
+        _ => None,
+    }
+}
+
+pub fn render_previews<S: Signature>(input: &S::Input) -> String
+where
+    S::Input: BamlType + for<'a> Facet<'a>,
+{
+    let schema = SignatureSchema::of::<S>();
+    let value = input.to_baml_value();
+
+    let mut lines = vec!["## Variables".to_string(), String::new()];
+    for field in schema.input_fields() {
+        let rendered_type = field.type_ir.diagnostic_repr().to_string();
+        lines.push(format!("{}: {}", field.lm_name, rendered_type));
+        if let Some(field_value) = schema.navigate_field(field.path(), &value) {
+            lines.push(format!("  {}", render_value_preview(field_value, 0)));
+        } else {
+            lines.push("  <missing>".to_string());
+        }
+    }
+
+    lines.push(String::new());
+    lines.push("## Expected Output".to_string());
+    for field in schema.output_fields() {
+        lines.push(format!(
+            "{}: {}",
+            field.lm_name,
+            field.type_ir.diagnostic_repr()
+        ));
+    }
+
+    lines.join("\n")
+}
+
+fn classify_exec_outcome(
+    code: String,
+    exec_result: Result<String, String>,
+    submit_result: Option<SubmitResultDyn>,
+) -> ExecOutcome {
+    if let Some(submit_result) = submit_result {
+        return match submit_result {
+            Ok((value, field_meta)) => ExecOutcome::SubmitAccepted { value, field_meta },
+            Err(SubmitError::ValidationError { message, errors }) => {
+                ExecOutcome::SubmitValidationError { message, errors }
+            }
+            Err(SubmitError::AssertionFailed { label, expression }) => {
+                ExecOutcome::SubmitAssertionFailed { label, expression }
+            }
+        };
+    }
+
+    match exec_result {
+        Ok(output) => ExecOutcome::Continue { code, output },
+        Err(message) => ExecOutcome::PythonException { message },
+    }
+}
+
+fn outcome_to_raw_output(outcome: &ExecOutcome) -> String {
+    match outcome {
+        ExecOutcome::Continue { output, .. } => output.clone(),
+        ExecOutcome::SubmitAccepted { .. } => String::new(),
+        ExecOutcome::SubmitValidationError { message, errors } => {
+            if errors.is_empty() {
+                message.clone()
+            } else {
+                format!("{message}\n{}", errors.join("\n"))
+            }
+        }
+        ExecOutcome::SubmitAssertionFailed { label, expression } => {
+            format!("Submit assertion failed: `{label}` ({expression})")
+        }
+        ExecOutcome::PythonException { message } => message.clone(),
+        ExecOutcome::RecoverableParse { message } => message.clone(),
+    }
+}
+
+fn render_value_preview(value: &BamlValue, depth: usize) -> String {
+    const MAX_DEPTH: usize = 2;
+    if depth >= MAX_DEPTH {
+        return summarize_value_shape(value);
+    }
+
+    match value {
+        BamlValue::String(s) => {
+            let len = s.chars().count();
+            if len <= 200 {
+                format!("String ({len} chars): {:?}", s)
+            } else {
+                let head: String = s.chars().take(100).collect();
+                let tail: String = s
+                    .chars()
+                    .rev()
+                    .take(100)
+                    .collect::<String>()
+                    .chars()
+                    .rev()
+                    .collect();
+                format!(
+                    "String ({len} chars): {:?} ... ({} chars omitted) ... {:?}",
+                    head,
+                    len.saturating_sub(200),
+                    tail
+                )
+            }
+        }
+        BamlValue::Int(n) => format!("Int: {n}"),
+        BamlValue::Float(f) => format!("Float: {f}"),
+        BamlValue::Bool(b) => format!("Bool: {b}"),
+        BamlValue::Null => "Null".to_string(),
+        BamlValue::Enum(name, variant) => format!("Enum {name}::{variant}"),
+        BamlValue::Media(_) => "Media (preview omitted)".to_string(),
+        BamlValue::List(items) => {
+            if items.is_empty() {
+                return "List (0 items)".to_string();
+            }
+            let mut sample_indices = vec![0usize];
+            let mid = items.len() / 2;
+            if mid != 0 && mid != items.len() - 1 {
+                sample_indices.push(mid);
+            }
+            if items.len() > 1 {
+                sample_indices.push(items.len() - 1);
+            }
+            sample_indices.sort_unstable();
+            sample_indices.dedup();
+
+            let samples = sample_indices
+                .into_iter()
+                .map(|idx| {
+                    format!(
+                        "sample[{idx}] = {}",
+                        render_value_preview(&items[idx], depth + 1)
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join("; ");
+            format!("List ({} items): {samples}", items.len())
+        }
+        BamlValue::Map(map) | BamlValue::Class(_, map) => {
+            let mut fields = map
+                .iter()
+                .take(4)
+                .map(|(k, v)| format!("{k}: {}", summarize_value_shape(v)))
+                .collect::<Vec<_>>();
+            if map.len() > 4 {
+                fields.push(format!("... ({} more)", map.len() - 4));
+            }
+            format!("Object {{{}}}", fields.join(", "))
+        }
+    }
+}
+
+fn summarize_value_shape(value: &BamlValue) -> String {
+    match value {
+        BamlValue::String(s) => format!("String({} chars)", s.chars().count()),
+        BamlValue::Int(_) => "Int".to_string(),
+        BamlValue::Float(_) => "Float".to_string(),
+        BamlValue::Bool(_) => "Bool".to_string(),
+        BamlValue::Null => "Null".to_string(),
+        BamlValue::Enum(name, variant) => format!("Enum {name}::{variant}"),
+        BamlValue::Media(_) => "Media".to_string(),
+        BamlValue::List(items) => format!("List({} items)", items.len()),
+        BamlValue::Map(map) => format!("Map({} keys)", map.len()),
+        BamlValue::Class(name, map) => format!("Class {name}({} fields)", map.len()),
+    }
+}

--- a/crates/dspy-rs/src/modules/rlm/mod.rs
+++ b/crates/dspy-rs/src/modules/rlm/mod.rs
@@ -2,8 +2,7 @@ use std::marker::PhantomData;
 use std::sync::{Arc, Mutex};
 
 use indexmap::IndexMap;
-use pyo3::types::PyDict;
-use pyo3::{Py, Python};
+use pyo3::Python;
 use rig::message::ToolCall;
 
 use crate::{

--- a/crates/dspy-rs/src/modules/rlm/mod.rs
+++ b/crates/dspy-rs/src/modules/rlm/mod.rs
@@ -30,6 +30,7 @@ const DEFAULT_MAX_ITERATIONS: usize = 20;
 const DEFAULT_MAX_LLM_CALLS: usize = 50;
 const DEFAULT_MAX_OUTPUT_CHARS: usize = 100_000;
 const DEFAULT_ENABLE_EXTRACTION_FALLBACK: bool = true;
+const MAX_RECOVERABLE_PARSE_SNIPPET_CHARS: usize = 80;
 
 const EXTRACT_INSTRUCTION: &str = "Extract the final typed answer from the REPL history.\n\
 Use the expected output schema exactly.";
@@ -514,14 +515,15 @@ where
                     raw_response,
                     lm_usage,
                     chat,
-                } if raw_response.trim().is_empty() => Ok(ActionTurn::RecoverableParse {
-                    raw_response,
-                    lm_usage,
-                    chat,
-                    reason: format!(
-                        "Empty response from model ({source}). Write executable Python code."
-                    ),
-                }),
+                } if raw_response.trim().is_empty() => {
+                    let reason = format_empty_response_recovery_reason(&raw_response, &source);
+                    Ok(ActionTurn::RecoverableParse {
+                        raw_response,
+                        lm_usage,
+                        chat,
+                        reason,
+                    })
+                }
                 other => Err(RlmError::ActionPredict { source: other }),
             },
         }
@@ -727,11 +729,29 @@ pub fn recoverable_outcome_from_parse_error(error: &PredictError) -> Option<(Str
             source,
             ..
         } if raw_response.trim().is_empty() => Some((
-            format!("Empty response from model ({source}). Write executable Python code."),
+            format_empty_response_recovery_reason(raw_response, source),
             chat.clone(),
         )),
         _ => None,
     }
+}
+
+fn format_empty_response_recovery_reason(
+    raw_response: &str,
+    source: &impl std::fmt::Display,
+) -> String {
+    let total_chars = raw_response.chars().count();
+    let mut snippet = raw_response
+        .chars()
+        .take(MAX_RECOVERABLE_PARSE_SNIPPET_CHARS)
+        .collect::<String>();
+    if total_chars > MAX_RECOVERABLE_PARSE_SNIPPET_CHARS {
+        snippet.push_str("...");
+    }
+
+    format!(
+        "Empty response from model ({source}). Write executable Python code. Raw response: len={total_chars}, snippet={snippet:?}."
+    )
 }
 
 fn classify_exec_outcome(
@@ -992,6 +1012,8 @@ mod tests {
         let recovered = recoverable_outcome_from_parse_error(&empty_err)
             .expect("empty response should be recoverable");
         assert!(recovered.0.contains("Empty response from model"));
+        assert!(recovered.0.contains("Raw response: len="));
+        assert!(recovered.0.contains("\\n\\t"));
 
         let non_empty_err = PredictError::Parse {
             source: ParseError::ExtractionFailed {

--- a/crates/dspy-rs/src/modules/rlm/mod.rs
+++ b/crates/dspy-rs/src/modules/rlm/mod.rs
@@ -1,6 +1,7 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::marker::PhantomData;
 use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 use indexmap::IndexMap;
 use pyo3::types::{
@@ -231,6 +232,23 @@ enum TurnDecision {
 struct PerceptionFeedback {
     stdout: Option<String>,
     stderr: Option<String>,
+    execution_time: Option<Duration>,
+}
+
+#[derive(Debug, Clone)]
+struct PerceptionMessage {
+    text: String,
+    namespace_snapshot: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct NamespaceSections {
+    injected: Vec<(String, String)>,
+    recent: Vec<(String, String)>,
+    stable: Vec<(String, String)>,
+    updated_names: Vec<String>,
+    namespace_snapshot: BTreeMap<String, String>,
+    initial_state: bool,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -425,37 +443,62 @@ where
             }
         });
 
-        let initial_sub_lm_remaining = self.runtime.sub_lm_budget_remaining(llm_tools.as_ref());
-        let synthetic_turn_zero_user = build_synthetic_turn_zero_user_message(
-            self.config.max_iterations,
-            initial_sub_lm_remaining,
-        );
-        let mut synthetic_history = Chat::new(vec![]);
-        synthetic_history.push(Role::System, &action_instruction);
-        synthetic_history.push(Role::User, &synthetic_turn_zero_user);
-        synthetic_history.push(Role::Assistant, SYNTHETIC_TURN_ZERO_ASSISTANT_CODE);
+        let enable_turn_zero_demo = true;
+        let mut previous_namespace_snapshot: Option<BTreeMap<String, String>> = None;
+        let mut previous_sub_lm_remaining: Option<usize> = None;
+        let (mut history, mut feedback): (Option<Chat>, Option<PerceptionFeedback>) =
+            if enable_turn_zero_demo {
+                let initial_sub_lm_remaining =
+                    self.runtime.sub_lm_budget_remaining(llm_tools.as_ref());
+                previous_sub_lm_remaining = Some(initial_sub_lm_remaining);
+                let synthetic_turn_zero_user = build_synthetic_turn_zero_user_message(
+                    self.config.max_iterations,
+                    initial_sub_lm_remaining,
+                );
+                let mut synthetic_history = Chat::new(vec![]);
+                synthetic_history.push(Role::System, &action_instruction);
+                synthetic_history.push(Role::User, &synthetic_turn_zero_user);
+                synthetic_history.push(Role::Assistant, SYNTHETIC_TURN_ZERO_ASSISTANT_CODE);
 
-        clear_submit_slot(&submit_slot);
-        let synthetic_feedback = Python::attach(|py| {
-            self.runtime.execute_repl_code(
-                py,
-                &globals,
-                SYNTHETIC_TURN_ZERO_ASSISTANT_CODE,
-                self.config.max_output_chars,
-            )
-        });
+                clear_submit_slot(&submit_slot);
+                let synthetic_start = Instant::now();
+                let synthetic_feedback = Python::attach(|py| {
+                    self.runtime.execute_repl_code(
+                        py,
+                        &globals,
+                        SYNTHETIC_TURN_ZERO_ASSISTANT_CODE,
+                        self.config.max_output_chars,
+                    )
+                });
+                let synthetic_execution_time = synthetic_start.elapsed();
 
-        let mut history: Option<Chat> = Some(synthetic_history);
-        let mut feedback: Option<PerceptionFeedback> = Some(match synthetic_feedback {
-            Ok(stdout) => PerceptionFeedback {
-                stdout: Some(stdout),
-                stderr: None,
-            },
-            Err(stderr) => PerceptionFeedback {
-                stdout: None,
-                stderr: Some(stderr),
-            },
-        });
+                (
+                    Some(synthetic_history),
+                    Some(match synthetic_feedback {
+                        Ok(stdout) => PerceptionFeedback {
+                            stdout: Some(stdout),
+                            stderr: None,
+                            execution_time: Some(synthetic_execution_time),
+                        },
+                        Err(stderr) => PerceptionFeedback {
+                            stdout: None,
+                            stderr: Some(stderr),
+                            execution_time: Some(synthetic_execution_time),
+                        },
+                    }),
+                )
+            } else {
+                (None, None)
+            };
+        if enable_turn_zero_demo {
+            previous_namespace_snapshot = Some(
+                Python::attach(|py| {
+                    collect_namespace_snapshot(py, &globals, input.rlm_field_names())
+                        .map(|snapshot| namespace_snapshot_map(&snapshot))
+                })
+                .map_err(|message| RlmError::Configuration { message })?,
+            );
+        }
         let mut turn_index = 1usize;
         let mut acc = MetadataAcc::default();
         let mut repl_history = REPLHistory {
@@ -496,6 +539,8 @@ where
                 .saturating_sub(turn_index)
                 .saturating_add(1);
             let sub_lm_remaining = self.runtime.sub_lm_budget_remaining(llm_tools.as_ref());
+            let sub_lm_spent_last_turn =
+                previous_sub_lm_remaining.map(|prev| prev.saturating_sub(sub_lm_remaining));
             let perception = Python::attach(|py| {
                 build_perception_message::<S>(
                     py,
@@ -506,10 +551,15 @@ where
                     budget_remaining,
                     sub_lm_remaining,
                     is_first_turn,
+                    turn_index,
+                    sub_lm_spent_last_turn,
+                    previous_namespace_snapshot.as_ref(),
                 )
             })
             .map_err(|message| RlmError::Configuration { message })?;
-            let action_input = RlmActionSigInput::new(perception);
+            previous_sub_lm_remaining = Some(sub_lm_remaining);
+            previous_namespace_snapshot = Some(perception.namespace_snapshot);
+            let action_input = RlmActionSigInput::new(perception.text);
 
             info!(
                 iteration = turn_index,
@@ -539,6 +589,7 @@ where
                     feedback = Some(PerceptionFeedback {
                         stdout: None,
                         stderr: Some(reason),
+                        execution_time: None,
                     });
                     turn_index += 1;
                 }
@@ -550,6 +601,7 @@ where
                     let code = action_output.code;
                     clear_submit_slot(&submit_slot);
 
+                    let execution_started = Instant::now();
                     let exec_result = Python::attach(|py| {
                         self.runtime.execute_repl_code(
                             py,
@@ -558,6 +610,7 @@ where
                             self.config.max_output_chars,
                         )
                     });
+                    let execution_time = execution_started.elapsed();
                     let submit_result = take_submit_result(&submit_slot);
                     let outcome = classify_exec_outcome(exec_result, submit_result);
 
@@ -592,7 +645,10 @@ where
                                 outcome = exec_outcome_kind(&other),
                                 "predict response received"
                             );
-                            feedback = Some(perception_feedback_from_outcome(&other));
+                            feedback = Some(perception_feedback_from_outcome(
+                                &other,
+                                Some(execution_time),
+                            ));
                             repl_history.entries.push(REPLEntry {
                                 turn: turn_index.min(u32::MAX as usize) as u32,
                                 code,
@@ -823,19 +879,43 @@ fn build_perception_message<S>(
     budget_remaining: usize,
     sub_lm_remaining: usize,
     first_turn: bool,
-) -> Result<String, String>
+    turn_index: usize,
+    sub_lm_spent_last_turn: Option<usize>,
+    previous_namespace_snapshot: Option<&BTreeMap<String, String>>,
+) -> Result<PerceptionMessage, String>
 where
     S: Signature,
     S::Input: BamlType + RlmInputFields,
 {
+    let namespace = collect_namespace_snapshot(py, globals, input.rlm_field_names())?;
+    let namespace_sections = partition_namespace_snapshot(
+        &namespace,
+        input.rlm_field_names(),
+        previous_namespace_snapshot,
+    );
+
     let mut lines = Vec::new();
-    let turns_label = if budget_remaining == 1 {
-        "1 turn".to_string()
-    } else {
-        format!("{budget_remaining} turns")
-    };
+    lines.push(format!("=== Execution Receipt (Turn {turn_index}) ==="));
     lines.push(format!(
-        "[env] {turns_label} | {sub_lm_remaining} sub-LLM calls"
+        "Time: {}",
+        format_execution_time(feedback.and_then(|item| item.execution_time))
+    ));
+    lines.push(format!(
+        "Budget: {} remaining | {} sub-LLM calls remaining",
+        turns_label(budget_remaining),
+        sub_lm_remaining
+    ));
+    let sub_lm_cost_line = match sub_lm_spent_last_turn {
+        Some(spent) => format!(
+            "Sub-LLM cost: {spent} call{} spent last turn",
+            plural_suffix(spent)
+        ),
+        None => "Sub-LLM cost: n/a (first turn)".to_string(),
+    };
+    lines.push(sub_lm_cost_line);
+    lines.push(format!(
+        "Updated: {}",
+        render_updated_names(&namespace_sections)
     ));
 
     if let Some(feedback) = feedback {
@@ -843,8 +923,9 @@ where
             && !stdout.trim().is_empty()
         {
             lines.push(String::new());
-            lines.push("[stdout]".to_string());
+            lines.push("--- stdout ---".to_string());
             lines.push(stdout.to_string());
+            lines.push("--------------".to_string());
         }
         if let Some(stderr) = feedback.stderr.as_deref()
             && !stderr.trim().is_empty()
@@ -867,38 +948,140 @@ where
         lines.push("⚠ LAST TURN — you MUST call SUBMIT() now with your best answer.".to_string());
     }
 
-    let namespace = collect_namespace_snapshot(py, globals, input.rlm_field_names())?;
     lines.push(String::new());
-    if first_turn {
-        lines.push("--- namespace ---".to_string());
-    } else {
-        lines.push(format!("--- namespace ({} names) ---", namespace.len()));
-    }
-    for (name, repr_value) in namespace {
-        lines.push(format!("{name} = {repr_value}"));
-    }
+    lines.push("=== Namespace ===".to_string());
+    render_namespace_section(&mut lines, "Injected", &namespace_sections.injected);
+    render_namespace_section(&mut lines, "Recent", &namespace_sections.recent);
+    render_namespace_section(&mut lines, "Stable", &namespace_sections.stable);
     lines.push(String::new());
     lines.push(">>>".to_string());
 
-    Ok(lines.join("\n"))
+    Ok(PerceptionMessage {
+        text: lines.join("\n"),
+        namespace_snapshot: namespace_sections.namespace_snapshot,
+    })
 }
 
 fn build_synthetic_turn_zero_user_message(
     budget_remaining: usize,
     sub_lm_remaining: usize,
 ) -> String {
-    let turns_label = if budget_remaining == 1 {
-        "1 turn".to_string()
-    } else {
-        format!("{budget_remaining} turns")
-    };
     [
-        format!("[env] {turns_label} | {sub_lm_remaining} sub-LLM calls"),
+        "=== Execution Receipt (Turn 0) ===".to_string(),
+        "Time: n/a".to_string(),
+        format!(
+            "Budget: {} remaining | {} sub-LLM calls remaining",
+            turns_label(budget_remaining),
+            sub_lm_remaining
+        ),
+        "Sub-LLM cost: n/a (synthetic setup turn)".to_string(),
+        "Updated: (initial state — no prior diff)".to_string(),
         String::new(),
-        "--- namespace ---".to_string(),
+        "=== Namespace ===".to_string(),
+        "[Injected]".to_string(),
+        "(none)".to_string(),
+        String::new(),
+        "[Recent]".to_string(),
+        "(none)".to_string(),
+        String::new(),
+        "[Stable]".to_string(),
+        "(none)".to_string(),
+        String::new(),
         ">>>".to_string(),
     ]
     .join("\n")
+}
+
+fn partition_namespace_snapshot(
+    namespace: &[(String, String)],
+    injected_roots: &[&str],
+    previous_namespace_snapshot: Option<&BTreeMap<String, String>>,
+) -> NamespaceSections {
+    let roots = injected_roots
+        .iter()
+        .map(|name| (*name).to_string())
+        .collect::<BTreeSet<_>>();
+    let mut sections = NamespaceSections {
+        initial_state: previous_namespace_snapshot.is_none(),
+        ..NamespaceSections::default()
+    };
+
+    for (name, repr_value) in namespace {
+        sections
+            .namespace_snapshot
+            .insert(name.clone(), repr_value.clone());
+
+        let changed_since_last_turn = previous_namespace_snapshot
+            .and_then(|snapshot| snapshot.get(name))
+            .map(|previous| previous != repr_value)
+            .unwrap_or(previous_namespace_snapshot.is_some());
+
+        if changed_since_last_turn {
+            sections.updated_names.push(name.clone());
+        }
+
+        if roots.contains(name) {
+            sections.injected.push((name.clone(), repr_value.clone()));
+        } else if previous_namespace_snapshot.is_none() || changed_since_last_turn {
+            sections.recent.push((name.clone(), repr_value.clone()));
+        } else {
+            sections.stable.push((name.clone(), repr_value.clone()));
+        }
+    }
+
+    sections
+}
+
+fn namespace_snapshot_map(namespace: &[(String, String)]) -> BTreeMap<String, String> {
+    namespace
+        .iter()
+        .map(|(name, repr_value)| (name.clone(), repr_value.clone()))
+        .collect()
+}
+
+fn render_namespace_section(lines: &mut Vec<String>, title: &str, entries: &[(String, String)]) {
+    lines.push(String::new());
+    lines.push(format!("[{title}]"));
+    if entries.is_empty() {
+        lines.push("(none)".to_string());
+        return;
+    }
+    for (name, repr_value) in entries {
+        lines.push(format!("{name} = {repr_value}"));
+    }
+}
+
+fn render_updated_names(sections: &NamespaceSections) -> String {
+    if sections.initial_state {
+        return "(initial state — no prior diff)".to_string();
+    }
+    if sections.updated_names.is_empty() {
+        return "none".to_string();
+    }
+    sections
+        .updated_names
+        .iter()
+        .map(|name| format!("`{name}`"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn format_execution_time(duration: Option<Duration>) -> String {
+    duration
+        .map(|value| format!("{:.1}s", value.as_secs_f64()))
+        .unwrap_or_else(|| "n/a".to_string())
+}
+
+fn turns_label(turns: usize) -> String {
+    if turns == 1 {
+        "1 turn".to_string()
+    } else {
+        format!("{turns} turns")
+    }
+}
+
+fn plural_suffix(count: usize) -> &'static str {
+    if count == 1 { "" } else { "s" }
 }
 
 fn collect_namespace_snapshot(
@@ -1087,11 +1270,15 @@ fn sanitize_python_surface(text: &str) -> String {
     out
 }
 
-fn perception_feedback_from_outcome(outcome: &ExecOutcome) -> PerceptionFeedback {
+fn perception_feedback_from_outcome(
+    outcome: &ExecOutcome,
+    execution_time: Option<Duration>,
+) -> PerceptionFeedback {
     match outcome {
         ExecOutcome::Continue { output } => PerceptionFeedback {
             stdout: (!output.trim().is_empty()).then(|| output.clone()),
             stderr: None,
+            execution_time,
         },
         ExecOutcome::SubmitAccepted { .. } => PerceptionFeedback::default(),
         ExecOutcome::SubmitValidationError { .. }
@@ -1100,6 +1287,7 @@ fn perception_feedback_from_outcome(outcome: &ExecOutcome) -> PerceptionFeedback
         | ExecOutcome::RecoverableParse { .. } => PerceptionFeedback {
             stdout: None,
             stderr: Some(outcome_to_raw_output(outcome)),
+            execution_time,
         },
     }
 }
@@ -1288,7 +1476,7 @@ mod tests {
     }
 
     #[test]
-    fn perception_message_uses_env_task_namespace_and_prompt_markers() {
+    fn perception_message_uses_execution_receipt_and_namespace_sections() {
         Python::attach(|py| {
             let globals = PyDict::new(py);
             globals
@@ -1311,12 +1499,21 @@ mod tests {
                 3,
                 11,
                 true,
+                1,
+                None,
+                None,
             )
             .expect("message");
+            let message = message.text;
 
-            assert!(message.contains("[env] 3 turns | 11 sub-LLM calls"));
+            assert!(message.contains("=== Execution Receipt (Turn 1) ==="));
+            assert!(message.contains("Budget: 3 turns remaining | 11 sub-LLM calls remaining"));
+            assert!(message.contains("Sub-LLM cost: n/a (first turn)"));
             assert!(message.contains("[query] Inspect trajectories"));
-            assert!(message.contains("--- namespace ---"));
+            assert!(message.contains("=== Namespace ==="));
+            assert!(message.contains("[Injected]"));
+            assert!(message.contains("[Recent]"));
+            assert!(message.contains("[Stable]"));
             assert!(message.contains("prompt ="));
             assert!(message.contains("result_count = 7"));
             assert!(!message.contains("_tmp ="));
@@ -1335,6 +1532,7 @@ mod tests {
             let feedback = PerceptionFeedback {
                 stdout: Some("computed summary".to_string()),
                 stderr: None,
+                execution_time: Some(Duration::from_millis(1250)),
             };
 
             let message = build_perception_message::<RuntimePolicySig>(
@@ -1346,11 +1544,16 @@ mod tests {
                 1,
                 3,
                 false,
+                2,
+                Some(2),
+                None,
             )
             .expect("message");
+            let message = message.text;
 
-            assert!(message.contains("[env] 1 turn | 3 sub-LLM calls"));
-            assert!(message.contains("[stdout]"));
+            assert!(message.contains("Time: 1.2s"));
+            assert!(message.contains("Sub-LLM cost: 2 calls spent last turn"));
+            assert!(message.contains("--- stdout ---"));
             assert!(message.contains("computed summary"));
             assert!(
                 message.contains("⚠ LAST TURN — you MUST call SUBMIT() now with your best answer.")
@@ -1362,8 +1565,9 @@ mod tests {
     #[test]
     fn synthetic_turn_zero_user_message_matches_demo_shape() {
         let message = build_synthetic_turn_zero_user_message(12, 20);
-        assert!(message.contains("[env] 12 turns | 20 sub-LLM calls"));
-        assert!(message.contains("--- namespace ---"));
+        assert!(message.contains("=== Execution Receipt (Turn 0) ==="));
+        assert!(message.contains("Budget: 12 turns remaining | 20 sub-LLM calls remaining"));
+        assert!(message.contains("=== Namespace ==="));
         assert!(message.ends_with(">>>"));
         assert!(!message.contains("[query]"));
     }
@@ -1379,6 +1583,7 @@ mod tests {
             let feedback = PerceptionFeedback {
                 stdout: Some("hello world".to_string()),
                 stderr: None,
+                execution_time: Some(Duration::from_millis(100)),
             };
             let message = build_perception_message::<RuntimePolicySig>(
                 py,
@@ -1389,11 +1594,62 @@ mod tests {
                 12,
                 20,
                 true,
+                1,
+                None,
+                None,
             )
             .expect("message");
-            let stdout_idx = message.find("[stdout]").expect("stdout marker");
+            let message = message.text;
+            let stdout_idx = message.find("--- stdout ---").expect("stdout marker");
             let query_idx = message.find("[query]").expect("query marker");
             assert!(stdout_idx < query_idx, "stdout should appear before query");
+        });
+    }
+
+    #[test]
+    fn perception_message_partitions_recent_and_stable_with_snapshot_diff() {
+        Python::attach(|py| {
+            let globals = PyDict::new(py);
+            globals.set_item("prompt", "x").expect("set prompt");
+            globals
+                .set_item("stable_value", 1)
+                .expect("set stable value");
+            let globals = globals.unbind();
+            let previous_snapshot = collect_namespace_snapshot(py, &globals, &["prompt"])
+                .map(|snapshot| namespace_snapshot_map(&snapshot))
+                .expect("previous snapshot");
+
+            let globals = PyDict::new(py);
+            globals.set_item("prompt", "x").expect("set prompt");
+            globals
+                .set_item("stable_value", 1)
+                .expect("set stable value");
+            globals
+                .set_item("recent_value", 2)
+                .expect("set recent value");
+
+            let input = RuntimePolicySigInput {
+                prompt: "x".to_string(),
+            };
+            let message = build_perception_message::<RuntimePolicySig>(
+                py,
+                &globals.unbind(),
+                &input,
+                "Inspect trajectories",
+                None,
+                8,
+                5,
+                false,
+                4,
+                Some(1),
+                Some(&previous_snapshot),
+            )
+            .expect("message")
+            .text;
+
+            assert!(message.contains("Updated: `recent_value`"));
+            assert!(message.contains("[Recent]\nrecent_value = 2"));
+            assert!(message.contains("[Stable]\nstable_value = 1"));
         });
     }
 
@@ -1436,8 +1692,12 @@ mod tests {
                 3,
                 9,
                 true,
+                1,
+                None,
+                None,
             )
             .expect("message");
+            let message = message.text;
 
             assert!(message.contains("prompt ="));
             assert!(message.contains("kept_value = 42"));
@@ -1517,17 +1777,35 @@ mod tests {
 
     #[test]
     fn perception_feedback_maps_stdout_and_stderr_honestly() {
-        let continue_feedback = perception_feedback_from_outcome(&ExecOutcome::Continue {
-            output: "ok".to_string(),
-        });
+        let continue_feedback = perception_feedback_from_outcome(
+            &ExecOutcome::Continue {
+                output: "ok".to_string(),
+            },
+            Some(Duration::from_secs(2)),
+        );
         assert_eq!(continue_feedback.stdout.as_deref(), Some("ok"));
         assert!(continue_feedback.stderr.is_none());
+        assert_eq!(
+            continue_feedback
+                .execution_time
+                .map(|value| value.as_secs()),
+            Some(2)
+        );
 
-        let error_feedback = perception_feedback_from_outcome(&ExecOutcome::PythonException {
-            message: "Traceback...".to_string(),
-        });
+        let error_feedback = perception_feedback_from_outcome(
+            &ExecOutcome::PythonException {
+                message: "Traceback...".to_string(),
+            },
+            Some(Duration::from_millis(750)),
+        );
         assert_eq!(error_feedback.stderr.as_deref(), Some("Traceback..."));
         assert!(error_feedback.stdout.is_none());
+        assert_eq!(
+            error_feedback
+                .execution_time
+                .map(|value| value.as_millis() as u64),
+            Some(750)
+        );
     }
 
     #[test]

--- a/crates/dspy-rs/src/modules/rlm/mod.rs
+++ b/crates/dspy-rs/src/modules/rlm/mod.rs
@@ -806,7 +806,7 @@ fn outcome_to_raw_output(outcome: &ExecOutcome) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Signature;
+    use crate::{ParseError, Signature};
     use std::sync::Arc;
     use temp_env::with_var;
 
@@ -865,6 +865,28 @@ mod tests {
     }
 
     #[test]
+    fn turn_policy_reserves_last_turn_for_finalization_then_fallback() {
+        let module = Rlm::<RuntimePolicySig>::builder().build();
+
+        assert!(matches!(
+            module.decide_turn_policy(1, 3),
+            TurnDecision::Continue
+        ));
+        assert!(matches!(
+            module.decide_turn_policy(2, 3),
+            TurnDecision::Continue
+        ));
+        assert!(matches!(
+            module.decide_turn_policy(3, 3),
+            TurnDecision::Finalization
+        ));
+        assert!(matches!(
+            module.decide_turn_policy(4, 3),
+            TurnDecision::Fallback
+        ));
+    }
+
+    #[test]
     fn feedback_uses_next_turn_framing_and_supports_finalization_directive() {
         let feedback = format_feedback(
             2,
@@ -881,6 +903,110 @@ mod tests {
         assert!(feedback.contains("[Turn 2 | 19 turns, 50/50 sub-model calls remaining]"));
         assert!(feedback.contains("\n\nok"));
         assert!(feedback.contains("This is your final turn. Call SUBMIT(answer=...) now"));
+    }
+
+    #[test]
+    fn classify_exec_outcome_covers_all_variants_and_feedback_projection() {
+        let continue_outcome =
+            classify_exec_outcome("print('x')".to_string(), Ok("x\n".into()), None);
+        assert!(matches!(
+            continue_outcome,
+            ExecOutcome::Continue { ref code, ref output } if code == "print('x')" && output == "x\n"
+        ));
+        assert_eq!(outcome_to_raw_output(&continue_outcome), "x\n");
+
+        let submit_ok = classify_exec_outcome(
+            "SUBMIT(answer='ok')".to_string(),
+            Ok(String::new()),
+            Some(Ok((BamlValue::String("ok".to_string()), IndexMap::new()))),
+        );
+        assert!(matches!(submit_ok, ExecOutcome::SubmitAccepted { .. }));
+        assert!(outcome_to_raw_output(&submit_ok).is_empty());
+
+        let submit_validation = classify_exec_outcome(
+            "SUBMIT(answer=123)".to_string(),
+            Err("Traceback...\nSubmitError".to_string()),
+            Some(Err(SubmitError::ValidationError {
+                message: "validation failed".to_string(),
+                errors: vec!["field `answer` expected string".to_string()],
+            })),
+        );
+        assert!(matches!(
+            submit_validation,
+            ExecOutcome::SubmitValidationError { .. }
+        ));
+        assert_eq!(
+            outcome_to_raw_output(&submit_validation),
+            "Traceback...\nSubmitError"
+        );
+
+        let submit_assert = classify_exec_outcome(
+            "SUBMIT(answer='')".to_string(),
+            Err("SubmitError: Assertion failed".to_string()),
+            Some(Err(SubmitError::AssertionFailed {
+                label: "non_empty".to_string(),
+                expression: "this.len() > 0".to_string(),
+            })),
+        );
+        assert!(matches!(
+            submit_assert,
+            ExecOutcome::SubmitAssertionFailed { .. }
+        ));
+        assert_eq!(
+            outcome_to_raw_output(&submit_assert),
+            "SubmitError: Assertion failed"
+        );
+
+        let python_exception = classify_exec_outcome(
+            "raise ValueError('boom')".to_string(),
+            Err("Traceback...".into()),
+            None,
+        );
+        assert!(matches!(
+            python_exception,
+            ExecOutcome::PythonException { ref message } if message == "Traceback..."
+        ));
+        assert_eq!(outcome_to_raw_output(&python_exception), "Traceback...");
+
+        let recoverable = ExecOutcome::RecoverableParse {
+            message: "Your response was empty.".to_string(),
+        };
+        assert_eq!(
+            outcome_to_raw_output(&recoverable),
+            "Your response was empty."
+        );
+    }
+
+    #[test]
+    fn recoverable_parse_error_detection_only_triggers_on_empty_response() {
+        let empty_err = PredictError::Parse {
+            source: ParseError::ExtractionFailed {
+                field: "code".to_string(),
+                raw_response: String::new(),
+                reason: "empty passthrough response".to_string(),
+            },
+            raw_response: "   \n\t".to_string(),
+            lm_usage: LmUsage::default(),
+            chat: Chat::new(vec![]),
+        };
+        let recovered = recoverable_outcome_from_parse_error(&empty_err)
+            .expect("empty response should be recoverable");
+        assert!(recovered.0.contains("Empty response from model"));
+
+        let non_empty_err = PredictError::Parse {
+            source: ParseError::ExtractionFailed {
+                field: "code".to_string(),
+                raw_response: "no code".to_string(),
+                reason: "failed extraction".to_string(),
+            },
+            raw_response: "I refuse".to_string(),
+            lm_usage: LmUsage::default(),
+            chat: Chat::new(vec![]),
+        };
+        assert!(
+            recoverable_outcome_from_parse_error(&non_empty_err).is_none(),
+            "non-empty parse failures should remain terminal"
+        );
     }
 
     #[tokio::test]

--- a/crates/dspy-rs/src/modules/rlm/mod.rs
+++ b/crates/dspy-rs/src/modules/rlm/mod.rs
@@ -13,7 +13,7 @@ use tracing::{debug, info, info_span};
 
 use crate::{
     BamlType, BamlValue, CallMetadata, Chat, ChatAdapter, Facet, FieldMeta, LmUsage, Module,
-    Predict, PredictError, Predicted, Signature,
+    Predict, PredictError, Predicted, Role, Signature,
 };
 
 mod exec;
@@ -36,6 +36,8 @@ const DEFAULT_MAX_LLM_CALLS: usize = 50;
 const DEFAULT_MAX_OUTPUT_CHARS: usize = 100_000;
 const DEFAULT_ENABLE_EXTRACTION_FALLBACK: bool = true;
 const MAX_RECOVERABLE_PARSE_SNIPPET_CHARS: usize = 80;
+const SYNTHETIC_TURN_ZERO_ASSISTANT_CODE: &str =
+    "# sanity check: does this thing work?\nprint('hello world')";
 
 const REPL_HISTORY_INPUT_RENDER_TEMPLATE: &str = r#"{% if this.entries|length == 0 %}(no executed REPL turns captured){% else %}{% for entry in this.entries %}=== Turn {{ entry.turn }} ===
 Code:
@@ -412,7 +414,7 @@ where
         // 1) public post-build instruction override on Predict, or
         // 2) build-time instruction composition using compile-time method metadata.
         let generate_action = Predict::<RlmActionSig>::builder()
-            .instruction(action_instruction)
+            .instruction(action_instruction.clone())
             .adapter(ChatAdapter::passthrough())
             .build();
         let task_hint = task_hint_from_input::<S>(input).unwrap_or_else(|| {
@@ -423,8 +425,37 @@ where
             }
         });
 
-        let mut history: Option<Chat> = None;
-        let mut feedback: Option<PerceptionFeedback> = None;
+        let initial_sub_lm_remaining = self.runtime.sub_lm_budget_remaining(llm_tools.as_ref());
+        let synthetic_turn_zero_user = build_synthetic_turn_zero_user_message(
+            self.config.max_iterations,
+            initial_sub_lm_remaining,
+        );
+        let mut synthetic_history = Chat::new(vec![]);
+        synthetic_history.push(Role::System, &action_instruction);
+        synthetic_history.push(Role::User, &synthetic_turn_zero_user);
+        synthetic_history.push(Role::Assistant, SYNTHETIC_TURN_ZERO_ASSISTANT_CODE);
+
+        clear_submit_slot(&submit_slot);
+        let synthetic_feedback = Python::attach(|py| {
+            self.runtime.execute_repl_code(
+                py,
+                &globals,
+                SYNTHETIC_TURN_ZERO_ASSISTANT_CODE,
+                self.config.max_output_chars,
+            )
+        });
+
+        let mut history: Option<Chat> = Some(synthetic_history);
+        let mut feedback: Option<PerceptionFeedback> = Some(match synthetic_feedback {
+            Ok(stdout) => PerceptionFeedback {
+                stdout: Some(stdout),
+                stderr: None,
+            },
+            Err(stderr) => PerceptionFeedback {
+                stdout: None,
+                stderr: Some(stderr),
+            },
+        });
         let mut turn_index = 1usize;
         let mut acc = MetadataAcc::default();
         let mut repl_history = REPLHistory {
@@ -796,10 +827,6 @@ where
         "[env] {turns_label} | {sub_lm_remaining} sub-LLM calls"
     ));
 
-    if first_turn {
-        lines.push(format!("[query] {}", truncate_chars(task_hint, 180)));
-    }
-
     if let Some(feedback) = feedback {
         if let Some(stdout) = feedback.stdout.as_deref()
             && !stdout.trim().is_empty()
@@ -815,6 +842,13 @@ where
             lines.push("[stderr]".to_string());
             lines.push(stderr.to_string());
         }
+    }
+
+    if first_turn {
+        if !lines.is_empty() {
+            lines.push(String::new());
+        }
+        lines.push(format!("[query] {}", truncate_chars(task_hint, 180)));
     }
 
     if budget_remaining == 1 {
@@ -836,6 +870,24 @@ where
     lines.push(">>>".to_string());
 
     Ok(lines.join("\n"))
+}
+
+fn build_synthetic_turn_zero_user_message(
+    budget_remaining: usize,
+    sub_lm_remaining: usize,
+) -> String {
+    let turns_label = if budget_remaining == 1 {
+        "1 turn".to_string()
+    } else {
+        format!("{budget_remaining} turns")
+    };
+    [
+        format!("[env] {turns_label} | {sub_lm_remaining} sub-LLM calls"),
+        String::new(),
+        "--- namespace ---".to_string(),
+        ">>>".to_string(),
+    ]
+    .join("\n")
 }
 
 fn collect_namespace_snapshot(
@@ -1293,6 +1345,44 @@ mod tests {
                 message.contains("⚠ LAST TURN — you MUST call SUBMIT() now with your best answer.")
             );
             assert!(!message.contains("[query]"));
+        });
+    }
+
+    #[test]
+    fn synthetic_turn_zero_user_message_matches_demo_shape() {
+        let message = build_synthetic_turn_zero_user_message(12, 20);
+        assert!(message.contains("[env] 12 turns | 20 sub-LLM calls"));
+        assert!(message.contains("--- namespace ---"));
+        assert!(message.ends_with(">>>"));
+        assert!(!message.contains("[query]"));
+    }
+
+    #[test]
+    fn first_turn_with_feedback_places_stdout_before_query() {
+        Python::attach(|py| {
+            let globals = PyDict::new(py);
+            globals.set_item("prompt", "x").expect("set prompt");
+            let input = RuntimePolicySigInput {
+                prompt: "x".to_string(),
+            };
+            let feedback = PerceptionFeedback {
+                stdout: Some("hello world".to_string()),
+                stderr: None,
+            };
+            let message = build_perception_message::<RuntimePolicySig>(
+                py,
+                &globals.unbind(),
+                &input,
+                "Inspect trajectories",
+                Some(&feedback),
+                12,
+                20,
+                true,
+            )
+            .expect("message");
+            let stdout_idx = message.find("[stdout]").expect("stdout marker");
+            let query_idx = message.find("[query]").expect("query marker");
+            assert!(stdout_idx < query_idx, "stdout should appear before query");
         });
     }
 

--- a/crates/dspy-rs/src/modules/rlm/mod.rs
+++ b/crates/dspy-rs/src/modules/rlm/mod.rs
@@ -154,7 +154,7 @@ struct MetadataAcc {
 
 impl MetadataAcc {
     fn absorb_call_metadata(&mut self, metadata: CallMetadata) {
-        self.lm_usage = self.lm_usage.clone() + metadata.lm_usage;
+        self.lm_usage = std::mem::take(&mut self.lm_usage) + metadata.lm_usage;
         self.tool_calls.extend(metadata.tool_calls);
         self.tool_executions.extend(metadata.tool_executions);
         self.raw_responses.push(metadata.raw_response);
@@ -162,11 +162,11 @@ impl MetadataAcc {
     }
 
     fn absorb_parse_metadata(&mut self, raw_response: String, lm_usage: LmUsage) {
-        self.lm_usage = self.lm_usage.clone() + lm_usage;
+        self.lm_usage = std::mem::take(&mut self.lm_usage) + lm_usage;
         self.raw_responses.push(raw_response);
     }
 
-    fn to_call_metadata(&self) -> CallMetadata {
+    fn into_call_metadata(self) -> CallMetadata {
         let raw_response = if self.raw_responses.is_empty() {
             String::new()
         } else {
@@ -175,11 +175,11 @@ impl MetadataAcc {
 
         CallMetadata::new(
             raw_response,
-            self.lm_usage.clone(),
-            self.tool_calls.clone(),
-            self.tool_executions.clone(),
+            self.lm_usage,
+            self.tool_calls,
+            self.tool_executions,
             None,
-            self.field_meta.clone(),
+            self.field_meta,
         )
     }
 }
@@ -392,7 +392,8 @@ where
                 budget_remaining,
             );
 
-            match self.run_action_turn(action_input, history.clone()).await? {
+            let turn_history = history.take();
+            match self.run_action_turn(action_input, turn_history).await? {
                 ActionTurn::RecoverableParse {
                     raw_response,
                     lm_usage,
@@ -450,7 +451,7 @@ where
                             let final_chat = history.unwrap_or_else(|| Chat::new(vec![]));
                             return Ok(Predicted::new(
                                 typed_output,
-                                acc.to_call_metadata(),
+                                acc.into_call_metadata(),
                                 final_chat,
                             ));
                         }
@@ -557,7 +558,8 @@ where
             .map_err(|source| RlmError::ExtractFallback { source })?;
         let (output, metadata, chat) = predicted.into_parts();
         acc.absorb_call_metadata(metadata);
-        Ok(Predicted::new(output, acc.to_call_metadata(), chat))
+        let metadata = std::mem::take(acc).into_call_metadata();
+        Ok(Predicted::new(output, metadata, chat))
     }
 
     fn finalization_directive(&self) -> String {
@@ -763,12 +765,11 @@ fn classify_exec_outcome(
     exec_result: Result<String, String>,
     submit_result: Option<SubmitResultDyn>,
 ) -> ExecOutcome {
-    let raw_exec_output = match &exec_result {
-        Ok(output) => output.clone(),
-        Err(message) => message.clone(),
-    };
-
     if let Some(submit_result) = submit_result {
+        let raw_exec_output = match exec_result {
+            Ok(output) => output,
+            Err(message) => message,
+        };
         return match submit_result {
             Ok((value, field_meta)) => ExecOutcome::SubmitAccepted { value, field_meta },
             Err(SubmitError::ValidationError { message, errors }) => {

--- a/crates/dspy-rs/src/modules/rlm/mod.rs
+++ b/crates/dspy-rs/src/modules/rlm/mod.rs
@@ -21,8 +21,8 @@ mod tools;
 use previews::render_previews;
 use prompt::{render_action_instruction, render_extract_instruction};
 pub use runtime::{
-    DynRuntime, LlmTools, PyO3Runtime, RlmRuntime, StubRuntime, SubmitError, SubmitHandler,
-    SubmitResultDyn, SubmitSlot, clear_submit_slot, take_submit_result,
+    DynRuntime, LlmTools, PyO3Runtime, RlmInputFields, RlmRuntime, StubRuntime, SubmitError,
+    SubmitHandler, SubmitResultDyn, SubmitSlot, clear_submit_slot, take_submit_result,
 };
 pub use tools::LlmQuery;
 
@@ -82,7 +82,7 @@ struct RlmExtractSig<S: Signature>(PhantomData<S>);
 impl<S> Signature for RlmExtractSig<S>
 where
     S: Signature,
-    S::Input: BamlType + for<'a> Facet<'a> + Clone + Send + Sync,
+    S::Input: BamlType + for<'a> Facet<'a> + Clone + Send + Sync + RlmInputFields,
     S::Output: BamlType + for<'a> Facet<'a> + Clone + Send + Sync,
 {
     type Input = RlmExtractInput;
@@ -271,7 +271,7 @@ impl From<RlmError> for PredictError {
 pub struct Rlm<S>
 where
     S: Signature,
-    S::Input: BamlType + for<'a> Facet<'a> + Clone + Send + Sync,
+    S::Input: BamlType + for<'a> Facet<'a> + Clone + Send + Sync + RlmInputFields,
     S::Output: BamlType + for<'a> Facet<'a> + Clone + Send + Sync,
 {
     generate_action: Predict<RlmActionSig>,
@@ -288,7 +288,7 @@ where
 impl<S> Default for Rlm<S>
 where
     S: Signature,
-    S::Input: BamlType + for<'a> Facet<'a> + Clone + Send + Sync,
+    S::Input: BamlType + for<'a> Facet<'a> + Clone + Send + Sync + RlmInputFields,
     S::Output: BamlType + for<'a> Facet<'a> + Clone + Send + Sync,
 {
     fn default() -> Self {
@@ -299,7 +299,7 @@ where
 impl<S> Rlm<S>
 where
     S: Signature,
-    S::Input: BamlType + for<'a> Facet<'a> + Clone + Send + Sync,
+    S::Input: BamlType + for<'a> Facet<'a> + Clone + Send + Sync + RlmInputFields,
     S::Output: BamlType + for<'a> Facet<'a> + Clone + Send + Sync,
 {
     pub fn new() -> Self {
@@ -348,15 +348,16 @@ where
         } else {
             None
         };
-        let globals: Py<PyDict> = Python::attach(|py| {
+        let setup = Python::attach(|py| {
             self.runtime
                 .setup_interpreter_globals(py, input, &submit_handler, llm_tools.as_ref())
         })
         .map_err(|err| RlmError::Configuration {
             message: err.to_string(),
         })?;
+        let globals = setup.globals;
 
-        let previews = render_previews::<S>(input);
+        let previews = render_previews::<S>(input, &setup.methods_by_var);
         let mut history: Option<Chat> = None;
         let mut feedback: Option<String> = None;
         let mut turn_index = 1usize;
@@ -576,7 +577,7 @@ where
 impl<S> Module for Rlm<S>
 where
     S: Signature,
-    S::Input: BamlType + for<'a> Facet<'a> + Clone + Send + Sync,
+    S::Input: BamlType + for<'a> Facet<'a> + Clone + Send + Sync + RlmInputFields,
     S::Output: BamlType + for<'a> Facet<'a> + Clone + Send + Sync,
 {
     type Input = S::Input;
@@ -590,7 +591,7 @@ where
 pub struct RlmBuilder<S>
 where
     S: Signature,
-    S::Input: BamlType + for<'a> Facet<'a> + Clone + Send + Sync,
+    S::Input: BamlType + for<'a> Facet<'a> + Clone + Send + Sync + RlmInputFields,
     S::Output: BamlType + for<'a> Facet<'a> + Clone + Send + Sync,
 {
     config: RlmConfig,
@@ -603,7 +604,7 @@ where
 impl<S> RlmBuilder<S>
 where
     S: Signature,
-    S::Input: BamlType + for<'a> Facet<'a> + Clone + Send + Sync,
+    S::Input: BamlType + for<'a> Facet<'a> + Clone + Send + Sync + RlmInputFields,
     S::Output: BamlType + for<'a> Facet<'a> + Clone + Send + Sync,
 {
     fn new() -> Self {
@@ -681,7 +682,7 @@ where
 
 fn default_runtime<S: Signature>(max_llm_calls: usize) -> Arc<dyn RlmRuntime<S>>
 where
-    S::Input: BamlType + for<'a> Facet<'a> + Clone + Send + Sync,
+    S::Input: BamlType + for<'a> Facet<'a> + Clone + Send + Sync + RlmInputFields,
     S::Output: BamlType + for<'a> Facet<'a> + Clone + Send + Sync,
 {
     if let Ok(runtime_override) = std::env::var("DSPY_RS_RLM_RUNTIME") {

--- a/crates/dspy-rs/src/modules/rlm/mod.rs
+++ b/crates/dspy-rs/src/modules/rlm/mod.rs
@@ -195,10 +195,12 @@ pub enum ExecOutcome {
     SubmitValidationError {
         message: String,
         errors: Vec<String>,
+        raw_output: String,
     },
     SubmitAssertionFailed {
         label: String,
         expression: String,
+        raw_output: String,
     },
     PythonException {
         message: String,
@@ -709,14 +711,27 @@ fn classify_exec_outcome(
     exec_result: Result<String, String>,
     submit_result: Option<SubmitResultDyn>,
 ) -> ExecOutcome {
+    let raw_exec_output = match &exec_result {
+        Ok(output) => output.clone(),
+        Err(message) => message.clone(),
+    };
+
     if let Some(submit_result) = submit_result {
         return match submit_result {
             Ok((value, field_meta)) => ExecOutcome::SubmitAccepted { value, field_meta },
             Err(SubmitError::ValidationError { message, errors }) => {
-                ExecOutcome::SubmitValidationError { message, errors }
+                ExecOutcome::SubmitValidationError {
+                    message,
+                    errors,
+                    raw_output: raw_exec_output,
+                }
             }
             Err(SubmitError::AssertionFailed { label, expression }) => {
-                ExecOutcome::SubmitAssertionFailed { label, expression }
+                ExecOutcome::SubmitAssertionFailed {
+                    label,
+                    expression,
+                    raw_output: raw_exec_output,
+                }
             }
         };
     }
@@ -731,14 +746,28 @@ fn outcome_to_raw_output(outcome: &ExecOutcome) -> String {
     match outcome {
         ExecOutcome::Continue { output, .. } => output.clone(),
         ExecOutcome::SubmitAccepted { .. } => String::new(),
-        ExecOutcome::SubmitValidationError { message, errors } => {
+        ExecOutcome::SubmitValidationError {
+            message,
+            errors,
+            raw_output,
+        } => {
+            if !raw_output.is_empty() {
+                return raw_output.clone();
+            }
             if errors.is_empty() {
                 message.clone()
             } else {
                 format!("{message}\n{}", errors.join("\n"))
             }
         }
-        ExecOutcome::SubmitAssertionFailed { label, expression } => {
+        ExecOutcome::SubmitAssertionFailed {
+            label,
+            expression,
+            raw_output,
+        } => {
+            if !raw_output.is_empty() {
+                return raw_output.clone();
+            }
             format!("Submit assertion failed: `{label}` ({expression})")
         }
         ExecOutcome::PythonException { message } => message.clone(),

--- a/crates/dspy-rs/src/modules/rlm/mod.rs
+++ b/crates/dspy-rs/src/modules/rlm/mod.rs
@@ -32,8 +32,6 @@ const DEFAULT_MAX_OUTPUT_CHARS: usize = 100_000;
 const DEFAULT_ENABLE_EXTRACTION_FALLBACK: bool = true;
 const MAX_RECOVERABLE_PARSE_SNIPPET_CHARS: usize = 80;
 
-const EXTRACT_INSTRUCTION: &str = "Extract the final typed answer from the REPL history.\n\
-Use the expected output schema exactly.";
 const REPL_HISTORY_INPUT_RENDER_TEMPLATE: &str = r#"{% if this.entries|length == 0 %}(no executed REPL turns captured){% else %}{% for entry in this.entries %}=== Turn {{ entry.turn }} ===
 Code:
 {{ entry.code }}
@@ -60,26 +58,26 @@ struct RlmActionSig {
 
 #[derive(Clone, Debug)]
 #[BamlType]
-pub struct REPLHistory {
-    pub entries: Vec<REPLEntry>,
+struct REPLHistory {
+    entries: Vec<REPLEntry>,
 }
 
 #[derive(Clone, Debug)]
 #[BamlType]
-pub struct REPLEntry {
-    pub turn: u32,
-    pub code: String,
-    pub output: String,
+struct REPLEntry {
+    turn: u32,
+    code: String,
+    output: String,
 }
 
 #[derive(Clone, Debug)]
 #[BamlType]
-pub struct RlmExtractInput {
-    pub variables_info: String,
-    pub repl_history: REPLHistory,
+struct RlmExtractInput {
+    variables_info: String,
+    repl_history: REPLHistory,
 }
 
-pub struct RlmExtractSig<S: Signature>(PhantomData<S>);
+struct RlmExtractSig<S: Signature>(PhantomData<S>);
 
 impl<S> Signature for RlmExtractSig<S>
 where
@@ -91,7 +89,7 @@ where
     type Output = S::Output;
 
     fn instruction() -> &'static str {
-        EXTRACT_INSTRUCTION
+        S::instruction()
     }
 
     fn input_shape() -> &'static facet::Shape {
@@ -146,12 +144,12 @@ impl Default for RlmConfig {
 }
 
 #[derive(Debug, Clone, Default)]
-pub struct MetadataAcc {
-    pub lm_usage: LmUsage,
-    pub tool_calls: Vec<ToolCall>,
-    pub tool_executions: Vec<String>,
-    pub raw_responses: Vec<String>,
-    pub field_meta: IndexMap<String, FieldMeta>,
+struct MetadataAcc {
+    lm_usage: LmUsage,
+    tool_calls: Vec<ToolCall>,
+    tool_executions: Vec<String>,
+    raw_responses: Vec<String>,
+    field_meta: IndexMap<String, FieldMeta>,
 }
 
 impl MetadataAcc {
@@ -186,7 +184,7 @@ impl MetadataAcc {
     }
 }
 
-pub enum ActionTurn {
+enum ActionTurn {
     Parsed(Predicted<RlmActionSigOutput>),
     RecoverableParse {
         raw_response: String,
@@ -196,9 +194,8 @@ pub enum ActionTurn {
     },
 }
 
-pub enum ExecOutcome {
+enum ExecOutcome {
     Continue {
-        code: String,
         output: String,
     },
     SubmitAccepted {
@@ -395,10 +392,7 @@ where
                 budget_remaining,
             );
 
-            match self
-                .run_action_turn(action_input, history.clone(), &mut acc)
-                .await?
-            {
+            match self.run_action_turn(action_input, history.clone()).await? {
                 ActionTurn::RecoverableParse {
                     raw_response,
                     lm_usage,
@@ -439,7 +433,7 @@ where
                         )
                     });
                     let submit_result = take_submit_result(&submit_slot);
-                    let outcome = classify_exec_outcome(code.clone(), exec_result, submit_result);
+                    let outcome = classify_exec_outcome(exec_result, submit_result);
 
                     match outcome {
                         ExecOutcome::SubmitAccepted { value, field_meta } => {
@@ -513,7 +507,6 @@ where
         &self,
         action_input: RlmActionSigInput,
         history: Option<Chat>,
-        _acc: &mut MetadataAcc,
     ) -> Result<ActionTurn, RlmError> {
         match self.generate_action.forward(action_input, history).await {
             Ok(predicted) => Ok(ActionTurn::Parsed(predicted)),
@@ -708,7 +701,7 @@ where
     }
 }
 
-pub fn format_feedback(
+fn format_feedback(
     turn_index: usize,
     budget_remaining: usize,
     sub_lm_remaining: usize,
@@ -732,7 +725,8 @@ pub fn format_feedback(
     rendered
 }
 
-pub fn recoverable_outcome_from_parse_error(error: &PredictError) -> Option<(String, Chat)> {
+#[cfg(test)]
+fn recoverable_outcome_from_parse_error(error: &PredictError) -> Option<(String, Chat)> {
     match error {
         PredictError::Parse {
             raw_response,
@@ -766,7 +760,6 @@ fn format_empty_response_recovery_reason(
 }
 
 fn classify_exec_outcome(
-    code: String,
     exec_result: Result<String, String>,
     submit_result: Option<SubmitResultDyn>,
 ) -> ExecOutcome {
@@ -796,7 +789,7 @@ fn classify_exec_outcome(
     }
 
     match exec_result {
-        Ok(output) => ExecOutcome::Continue { code, output },
+        Ok(output) => ExecOutcome::Continue { output },
         Err(message) => ExecOutcome::PythonException { message },
     }
 }
@@ -939,7 +932,6 @@ mod tests {
             50,
             50,
             &ExecOutcome::Continue {
-                code: "print('ok')".to_string(),
                 output: "ok".to_string(),
             },
             Some("This is your final turn. Call SUBMIT(answer=...) now with your best answer."),
@@ -952,16 +944,14 @@ mod tests {
 
     #[test]
     fn classify_exec_outcome_covers_all_variants_and_feedback_projection() {
-        let continue_outcome =
-            classify_exec_outcome("print('x')".to_string(), Ok("x\n".into()), None);
+        let continue_outcome = classify_exec_outcome(Ok("x\n".into()), None);
         assert!(matches!(
             continue_outcome,
-            ExecOutcome::Continue { ref code, ref output } if code == "print('x')" && output == "x\n"
+            ExecOutcome::Continue { ref output } if output == "x\n"
         ));
         assert_eq!(outcome_to_raw_output(&continue_outcome), "x\n");
 
         let submit_ok = classify_exec_outcome(
-            "SUBMIT(answer='ok')".to_string(),
             Ok(String::new()),
             Some(Ok((BamlValue::String("ok".to_string()), IndexMap::new()))),
         );
@@ -969,7 +959,6 @@ mod tests {
         assert!(outcome_to_raw_output(&submit_ok).is_empty());
 
         let submit_validation = classify_exec_outcome(
-            "SUBMIT(answer=123)".to_string(),
             Err("Traceback...\nSubmitError".to_string()),
             Some(Err(SubmitError::ValidationError {
                 message: "validation failed".to_string(),
@@ -986,7 +975,6 @@ mod tests {
         );
 
         let submit_assert = classify_exec_outcome(
-            "SUBMIT(answer='')".to_string(),
             Err("SubmitError: Assertion failed".to_string()),
             Some(Err(SubmitError::AssertionFailed {
                 label: "non_empty".to_string(),
@@ -1002,11 +990,7 @@ mod tests {
             "SubmitError: Assertion failed"
         );
 
-        let python_exception = classify_exec_outcome(
-            "raise ValueError('boom')".to_string(),
-            Err("Traceback...".into()),
-            None,
-        );
+        let python_exception = classify_exec_outcome(Err("Traceback...".into()), None);
         assert!(matches!(
             python_exception,
             ExecOutcome::PythonException { ref message } if message == "Traceback..."

--- a/crates/dspy-rs/src/modules/rlm/mod.rs
+++ b/crates/dspy-rs/src/modules/rlm/mod.rs
@@ -19,7 +19,7 @@ pub mod runtime;
 mod submit;
 mod tools;
 use previews::render_previews;
-use prompt::render_action_instruction;
+use prompt::{render_action_instruction, render_extract_instruction};
 pub use runtime::{
     DynRuntime, LlmTools, PyO3Runtime, RlmRuntime, StubRuntime, SubmitError, SubmitHandler,
     SubmitResultDyn, SubmitSlot, clear_submit_slot, take_submit_result,
@@ -34,6 +34,14 @@ const MAX_RECOVERABLE_PARSE_SNIPPET_CHARS: usize = 80;
 
 const EXTRACT_INSTRUCTION: &str = "Extract the final typed answer from the REPL history.\n\
 Use the expected output schema exactly.";
+const REPL_HISTORY_INPUT_RENDER_TEMPLATE: &str = r#"{% if this.entries|length == 0 %}(no executed REPL turns captured){% else %}{% for entry in this.entries %}=== Turn {{ entry.turn }} ===
+Code:
+{{ entry.code }}
+
+Output:
+{% if entry.output %}{{ entry.output }}{% else %}<empty>{% endif %}{% if not loop.last %}
+
+{% endif %}{% endfor %}{% endif %}"#;
 
 #[derive(Signature, Clone, Debug)]
 struct RlmActionSig {
@@ -106,7 +114,7 @@ where
                 rust_name: "repl_history",
                 alias: None,
                 constraints: &[],
-                input_render: crate::InputRenderSpec::Default,
+                input_render: crate::InputRenderSpec::Jinja(REPL_HISTORY_INPUT_RENDER_TEMPLATE),
             },
         ];
         &INPUT_META
@@ -651,12 +659,15 @@ where
     pub fn build(self) -> Rlm<S> {
         let action_instruction =
             render_action_instruction::<S>(&self.config, self.instruction_override.as_deref());
+        let extract_instruction =
+            render_extract_instruction::<S>(self.instruction_override.as_deref());
         let generate_action = Predict::<RlmActionSig>::builder()
             .instruction(action_instruction)
             .adapter(ChatAdapter::passthrough())
             .build();
         let extract = Predict::<RlmExtractSig<S>>::builder()
-            .instruction(EXTRACT_INSTRUCTION)
+            .instruction(extract_instruction)
+            .adapter(ChatAdapter::new())
             .build();
 
         let runtime = self
@@ -882,6 +893,20 @@ mod tests {
         assert!(turn2.variables_info.is_none());
         assert_eq!(turn2.execution_feedback.as_deref(), Some("feedback"));
         assert_eq!(turn2.budget_remaining, 19);
+    }
+
+    #[test]
+    fn extract_signature_uses_custom_repl_history_render_template() {
+        let fields = RlmExtractSig::<RuntimePolicySig>::input_field_metadata();
+        assert_eq!(fields.len(), 2);
+        match fields[1].input_render {
+            crate::InputRenderSpec::Jinja(template) => {
+                assert!(template.contains("=== Turn {{ entry.turn }} ==="));
+                assert!(template.contains("Code:"));
+                assert!(template.contains("Output:"));
+            }
+            other => panic!("expected jinja render template, got: {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/dspy-rs/src/modules/rlm/mod.rs
+++ b/crates/dspy-rs/src/modules/rlm/mod.rs
@@ -38,8 +38,14 @@ const DEFAULT_MAX_OUTPUT_CHARS: usize = 10_000;
 const DEFAULT_ENABLE_EXTRACTION_FALLBACK: bool = true;
 const MAX_RECOVERABLE_PARSE_SNIPPET_CHARS: usize = 80;
 const STDOUT_TRUNCATION_NOTICE_PREFIX: &str = "[STDOUT TRUNCATED at ";
-const SYNTHETIC_TURN_ZERO_ASSISTANT_CODE: &str =
-    "# sanity check: does this thing work?\nprint('hello world')";
+const SYNTHETIC_TURN_ZERO_ASSISTANT_CODE: &str = r#"# turn-0 API orientation
+if "sessions" in globals() and hasattr(sessions, "items") and len(sessions.items) > 0:
+    s = sessions.items[0]
+    print(s.render()[:500])
+    msgs = s.thread("darin")
+    print(f"darin messages: {len(msgs)}")
+else:
+    print("hello world")"#;
 
 const REPL_HISTORY_INPUT_RENDER_TEMPLATE: &str = r#"{% if this.entries|length == 0 %}(no executed REPL turns captured){% else %}{% for entry in this.entries %}=== Turn {{ entry.turn }} ===
 Code:
@@ -416,7 +422,7 @@ where
         );
         let previews = {
             let _preview_span = preview_span.enter();
-            render_previews::<S>(input, &setup.methods_by_var)
+            render_previews::<S>(input, &setup.methods_by_var, &setup.methods_by_type)
         };
         let preview_len = previews.chars().count();
         preview_span.record("preview_len", preview_len);

--- a/crates/dspy-rs/src/modules/rlm/previews.rs
+++ b/crates/dspy-rs/src/modules/rlm/previews.rs
@@ -27,6 +27,7 @@ impl RenderBudget {
 pub(super) fn render_previews<S: Signature>(
     _input: &S::Input,
     methods_by_var: &BTreeMap<String, Vec<MethodSignature>>,
+    methods_by_type: &BTreeMap<String, Vec<MethodSignature>>,
 ) -> String
 where
     S::Input: BamlType + for<'a> Facet<'a>,
@@ -43,7 +44,13 @@ where
     let _render_guard = render_span.enter();
 
     let budget = RenderBudget::relaxed();
-    let rendered = render_with_budget(schema, input_format, methods_by_var, budget);
+    let rendered = render_with_budget(
+        schema,
+        input_format,
+        methods_by_var,
+        methods_by_type,
+        budget,
+    );
     let output_len = rendered.chars().count();
     debug!(
         output_len,
@@ -79,9 +86,11 @@ pub(super) fn render_type_shape(
     indent: usize,
 ) -> Vec<String> {
     let mut visited = BTreeSet::new();
+    let methods_by_type = BTreeMap::new();
     render_type_node(
         type_ir,
         output_format,
+        &methods_by_type,
         indent,
         0,
         RenderBudget::relaxed().max_depth,
@@ -93,6 +102,7 @@ fn render_with_budget(
     schema: &SignatureSchema,
     input_format: &OutputFormatContent,
     methods_by_var: &BTreeMap<String, Vec<MethodSignature>>,
+    methods_by_type: &BTreeMap<String, Vec<MethodSignature>>,
     budget: RenderBudget,
 ) -> String {
     let mut lines = Vec::new();
@@ -110,6 +120,7 @@ fn render_with_budget(
             methods_by_var
                 .get(field.rust_name.as_str())
                 .map(Vec::as_slice),
+            methods_by_type,
             budget,
         ));
         lines.push(String::new());
@@ -130,6 +141,7 @@ fn render_variable_block(
     field: &FieldSchema,
     output_format: &OutputFormatContent,
     methods: Option<&[MethodSignature]>,
+    methods_by_type: &BTreeMap<String, Vec<MethodSignature>>,
     budget: RenderBudget,
 ) -> Vec<String> {
     let mut lines = Vec::new();
@@ -154,6 +166,7 @@ fn render_variable_block(
         &field.type_ir,
         output_format,
         methods,
+        methods_by_type,
         2,
         0,
         budget,
@@ -167,6 +180,7 @@ fn render_root_schema(
     type_ir: &TypeIR,
     output_format: &OutputFormatContent,
     methods: Option<&[MethodSignature]>,
+    methods_by_type: &BTreeMap<String, Vec<MethodSignature>>,
     indent: usize,
     depth: usize,
     budget: RenderBudget,
@@ -179,6 +193,7 @@ fn render_root_schema(
             class,
             output_format,
             methods,
+            methods_by_type,
             indent,
             depth,
             budget,
@@ -189,6 +204,7 @@ fn render_root_schema(
     render_type_node(
         type_ir,
         output_format,
+        methods_by_type,
         indent,
         depth,
         budget.max_depth,
@@ -200,6 +216,7 @@ fn render_class_block(
     class: &Class,
     output_format: &OutputFormatContent,
     methods: Option<&[MethodSignature]>,
+    methods_by_type: &BTreeMap<String, Vec<MethodSignature>>,
     indent: usize,
     depth: usize,
     budget: RenderBudget,
@@ -207,16 +224,17 @@ fn render_class_block(
 ) -> Vec<String> {
     let class_name = class.name.rendered_name().to_string();
     if depth >= budget.max_depth || !visited.insert(class_name.clone()) {
-        return vec![format!("{}{} {{ ... }}", spaces(indent), class_name)];
+        return vec![format!("{}{}", spaces(indent), class_name)];
     }
 
     let mut lines = Vec::new();
     lines.push(format!("{}{} {{", spaces(indent), class_name));
 
+    let methods = methods.or_else(|| methods_by_type.get(&class_name).map(Vec::as_slice));
     if let Some(methods) = methods {
         let methods = methods
             .iter()
-            .filter(|method| !method.is_dunder && !method.doc.trim().is_empty())
+            .filter(|method| !method.is_dunder)
             .take(budget.max_methods)
             .collect::<Vec<_>>();
 
@@ -239,6 +257,7 @@ fn render_class_block(
             field_type,
             description.as_deref(),
             output_format,
+            methods_by_type,
             indent + 2,
             depth + 1,
             budget,
@@ -247,7 +266,6 @@ fn render_class_block(
     }
 
     lines.push(format!("{}}}", spaces(indent)));
-    visited.remove(&class_name);
     lines
 }
 
@@ -256,6 +274,7 @@ fn render_field_line(
     field_type: &TypeIR,
     description: Option<&str>,
     output_format: &OutputFormatContent,
+    methods_by_type: &BTreeMap<String, Vec<MethodSignature>>,
     indent: usize,
     depth: usize,
     budget: RenderBudget,
@@ -265,6 +284,7 @@ fn render_field_line(
     let rendered = render_type_node(
         field_type,
         output_format,
+        methods_by_type,
         indent + 2,
         depth,
         budget.max_depth,
@@ -309,6 +329,7 @@ fn render_field_line(
 fn render_type_node(
     type_ir: &TypeIR,
     output_format: &OutputFormatContent,
+    methods_by_type: &BTreeMap<String, Vec<MethodSignature>>,
     indent: usize,
     depth: usize,
     max_depth: usize,
@@ -334,7 +355,15 @@ fn render_type_node(
 
     match type_ir {
         TypeGeneric::List(inner, _) => {
-            render_list_node(inner, output_format, indent, depth + 1, max_depth, visited)
+            render_list_node(
+                inner,
+                output_format,
+                methods_by_type,
+                indent,
+                depth + 1,
+                max_depth,
+                visited,
+            )
         }
         TypeGeneric::Map(key, value, _) => {
             let key_name = type_label(key, output_format);
@@ -351,6 +380,7 @@ fn render_type_node(
             lines.extend(render_type_node(
                 value,
                 output_format,
+                methods_by_type,
                 indent + 2,
                 depth + 1,
                 max_depth,
@@ -361,10 +391,14 @@ fn render_type_node(
         }
         TypeGeneric::Class { name, mode, .. } => {
             if let Some(class) = output_format.classes.get(&(name.to_string(), *mode)) {
+                let class_methods = methods_by_type
+                    .get(class.name.rendered_name())
+                    .map(Vec::as_slice);
                 render_class_block(
                     class,
                     output_format,
-                    None,
+                    class_methods,
+                    methods_by_type,
                     indent,
                     depth,
                     RenderBudget::relaxed(),
@@ -380,11 +414,27 @@ fn render_type_node(
             enum_name(name, output_format)
         )],
         TypeGeneric::Union(union, _) => {
-            render_union_node(union, output_format, indent, depth, max_depth, visited)
+            render_union_node(
+                union,
+                output_format,
+                methods_by_type,
+                indent,
+                depth,
+                max_depth,
+                visited,
+            )
         }
         TypeGeneric::RecursiveTypeAlias { name, .. } => {
             if let Some(alias) = output_format.structural_recursive_aliases.get(name) {
-                render_type_node(alias, output_format, indent, depth + 1, max_depth, visited)
+                render_type_node(
+                    alias,
+                    output_format,
+                    methods_by_type,
+                    indent,
+                    depth + 1,
+                    max_depth,
+                    visited,
+                )
             } else {
                 vec![format!("{}{}", spaces(indent), short_name(name))]
             }
@@ -406,6 +456,7 @@ fn render_type_node(
 fn render_list_node(
     inner: &TypeIR,
     output_format: &OutputFormatContent,
+    methods_by_type: &BTreeMap<String, Vec<MethodSignature>>,
     indent: usize,
     depth: usize,
     max_depth: usize,
@@ -423,6 +474,7 @@ fn render_list_node(
     lines.extend(render_type_node(
         inner,
         output_format,
+        methods_by_type,
         indent + 2,
         depth,
         max_depth,
@@ -435,6 +487,7 @@ fn render_list_node(
 fn render_union_node(
     union: &bamltype::baml_types::ir_type::UnionTypeGeneric<TypeMeta>,
     output_format: &OutputFormatContent,
+    methods_by_type: &BTreeMap<String, Vec<MethodSignature>>,
     indent: usize,
     depth: usize,
     max_depth: usize,
@@ -452,9 +505,11 @@ fn render_union_node(
 
     let mut lines = vec![format!("{}one of:", spaces(indent))];
     for option in union.iter_include_null() {
+        let option = unwrap_single_payload_variant_class(option, output_format).unwrap_or(option);
         let rendered = render_type_node(
             option,
             output_format,
+            methods_by_type,
             indent + 4,
             depth + 1,
             max_depth,
@@ -470,11 +525,39 @@ fn render_union_node(
             rendered[0].trim_start()
         ));
         for extra in rendered.iter().skip(1) {
-            lines.push(format!("{}{}", spaces(indent + 4), extra.trim_start()));
+            lines.push(extra.to_string());
         }
     }
 
     lines
+}
+
+fn unwrap_single_payload_variant_class<'a>(
+    type_ir: &'a TypeIR,
+    output_format: &'a OutputFormatContent,
+) -> Option<&'a TypeIR> {
+    let TypeGeneric::Class { name, mode, .. } = type_ir else {
+        return None;
+    };
+    let class = output_format.classes.get(&(name.to_string(), *mode))?;
+    if class.fields.len() != 2 {
+        return None;
+    }
+
+    let mut literal_count = 0usize;
+    let mut payload: Option<&TypeIR> = None;
+    for (_, field_type, _, _) in &class.fields {
+        if matches!(field_type, TypeGeneric::Literal(..)) {
+            literal_count += 1;
+            continue;
+        }
+        if payload.is_some() {
+            return None;
+        }
+        payload = Some(field_type);
+    }
+
+    if literal_count == 1 { payload } else { None }
 }
 
 fn render_method_line(method: &MethodSignature) -> String {
@@ -638,11 +721,10 @@ fn short_name(path: &str) -> String {
 
 fn normalize_doc_text(text: &str) -> String {
     text.lines()
-        .map(str::trim_end)
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
         .collect::<Vec<_>>()
-        .join("\n")
-        .trim()
-        .to_string()
+        .join(" ")
 }
 
 fn spaces(count: usize) -> String {
@@ -711,7 +793,7 @@ mod tests {
             title: "x".to_string(),
             count: 3,
         };
-        let rendered = render_previews::<PreviewSig>(&input, &BTreeMap::new());
+        let rendered = render_previews::<PreviewSig>(&input, &BTreeMap::new(), &BTreeMap::new());
         assert!(rendered.contains("(No complex input variables.)"));
     }
 
@@ -720,6 +802,25 @@ mod tests {
         #[input]
         /// Turn-level trajectories for each development session.
         sessions: PreviewSessions,
+
+        #[output]
+        answer: String,
+    }
+
+    #[derive(Clone, Debug)]
+    #[BamlType]
+    struct DuplicateActions {
+        /// Primary action list.
+        primary: Vec<PreviewAction>,
+        /// Backup action list.
+        backup: Vec<PreviewAction>,
+    }
+
+    #[derive(Signature, Clone, Debug)]
+    struct DedupPreviewSig {
+        #[input]
+        /// Two fields that reference the same nested class.
+        actions: DuplicateActions,
 
         #[output]
         answer: String,
@@ -763,7 +864,7 @@ mod tests {
             ],
         )]);
 
-        let rendered = render_previews::<RichPreviewSig>(&input, &methods);
+        let rendered = render_previews::<RichPreviewSig>(&input, &methods, &BTreeMap::new());
         assert!(rendered.contains("Variable: `sessions` (access it in your code)"));
         assert!(rendered.contains("Type: PreviewSessions"));
         assert!(
@@ -771,7 +872,8 @@ mod tests {
         );
         assert!(rendered.contains("// methods"));
         assert!(rendered.contains(".search(query) // Find matching sessions."));
-        assert!(!rendered.contains(".hidden()"));
+        assert!(rendered.contains(".hidden()"));
+        assert!(!rendered.contains(".hidden() //"));
         assert!(rendered.contains("// shape"));
         assert!(rendered.contains("items: list[ // Stored sessions."));
         assert!(rendered.contains("brief: string | null // First user message, truncated."));
@@ -790,5 +892,220 @@ mod tests {
         assert!(!rendered.contains("String"));
         assert!(!rendered.contains("i64"));
         assert!(!rendered.contains("$self"));
+    }
+
+    #[test]
+    fn shared_nested_type_is_rendered_once_then_referenced() {
+        let input = DedupPreviewSigInput {
+            actions: DuplicateActions {
+                primary: vec![PreviewAction {
+                    name: "search".to_string(),
+                    arguments: "{}".to_string(),
+                    result: None,
+                    is_error: false,
+                }],
+                backup: vec![PreviewAction {
+                    name: "grep".to_string(),
+                    arguments: "{}".to_string(),
+                    result: None,
+                    is_error: false,
+                }],
+            },
+        };
+
+        let rendered =
+            render_previews::<DedupPreviewSig>(&input, &BTreeMap::new(), &BTreeMap::new());
+        assert_eq!(rendered.matches("PreviewAction {").count(), 1);
+        assert_eq!(rendered.matches("name: string // Tool name.").count(), 1);
+    }
+
+    #[derive(Clone, Debug)]
+    #[BamlType]
+    enum UnionIndentChoice {
+        First { data: PreviewSession },
+        Second { data: PreviewAction },
+    }
+
+    #[derive(Signature, Clone, Debug)]
+    struct UnionIndentSig {
+        #[input]
+        choice: UnionIndentChoice,
+
+        #[output]
+        answer: String,
+    }
+
+    #[test]
+    fn union_option_continuations_preserve_nested_indentation() {
+        let input = UnionIndentSigInput {
+            choice: UnionIndentChoice::First {
+                data: PreviewSession {
+                    brief: Some("Investigate signal drop".to_string()),
+                    turns: vec![PreviewTurn {
+                        trigger: Some("start".to_string()),
+                        actions: vec![PreviewAction {
+                            name: "search".to_string(),
+                            arguments: "{\"q\":\"start\"}".to_string(),
+                            result: Some("ok".to_string()),
+                            is_error: false,
+                        }],
+                    }],
+                },
+            },
+        };
+
+        let rendered =
+            render_previews::<UnionIndentSig>(&input, &BTreeMap::new(), &BTreeMap::new());
+        let option_indent = rendered
+            .lines()
+            .find(|line| line.contains("- PreviewSession {"))
+            .map(|line| line.chars().take_while(|ch| *ch == ' ').count())
+            .expect("union option line present");
+        let brief_indent = rendered
+            .lines()
+            .find(|line| line.contains("brief: string | null"))
+            .map(|line| line.chars().take_while(|ch| *ch == ' ').count())
+            .expect("nested brief line present");
+        assert!(
+            brief_indent > option_indent,
+            "nested field indent should be deeper than its union option line"
+        );
+    }
+
+    #[derive(Clone, Debug)]
+    #[BamlType]
+    struct WrapA {
+        value: String,
+    }
+
+    #[derive(Clone, Debug)]
+    #[BamlType]
+    struct WrapB {
+        value: String,
+    }
+
+    #[derive(Clone, Debug)]
+    #[BamlType]
+    enum WrapperUnion {
+        First { data: WrapA },
+        Second { data: WrapB },
+    }
+
+    #[derive(Signature, Clone, Debug)]
+    struct WrapperUnionSig {
+        #[input]
+        item: WrapperUnion,
+
+        #[output]
+        answer: String,
+    }
+
+    #[test]
+    fn single_payload_data_enum_variants_render_as_payload_union_arms() {
+        let input = WrapperUnionSigInput {
+            item: WrapperUnion::First {
+                data: WrapA {
+                    value: "x".to_string(),
+                },
+            },
+        };
+        let rendered =
+            render_previews::<WrapperUnionSig>(&input, &BTreeMap::new(), &BTreeMap::new());
+
+        assert!(rendered.contains("one of:"));
+        assert!(rendered.contains("WrapA {"));
+        assert!(rendered.contains("WrapB {"));
+        assert!(!rendered.contains("WrapperUnion_First {"));
+        assert!(!rendered.contains("WrapperUnion_Second {"));
+        assert!(!rendered.contains("type: String(\"First\")"));
+        assert!(!rendered.contains("type: String(\"Second\")"));
+        assert!(!rendered.contains("data: WrapA {"));
+        assert!(!rendered.contains("data: WrapB {"));
+    }
+
+    #[test]
+    fn render_method_line_collapses_multiline_docs_to_single_line() {
+        let method = MethodSignature {
+            name: "after".to_string(),
+            signature: "(date)".to_string(),
+            doc: "Returns `Sessions`: sessions on or after an ISO date prefix like `2026-02-25`.\n\nReturns a `Sessions` sub-collection so calls can be chained.".to_string(),
+            source: super::super::runtime::MethodSource::Custom,
+            is_dunder: false,
+        };
+
+        let rendered = render_method_line(&method);
+        assert_eq!(
+            rendered,
+            ".after(date) // Returns `Sessions`: sessions on or after an ISO date prefix like `2026-02-25`. Returns a `Sessions` sub-collection so calls can be chained."
+        );
+    }
+
+    #[test]
+    fn nested_class_methods_render_when_provided_by_type_name() {
+        let input = RichPreviewSigInput {
+            sessions: PreviewSessions {
+                items: vec![PreviewSession {
+                    brief: Some("Investigate signal drop".to_string()),
+                    turns: vec![PreviewTurn {
+                        trigger: Some("start".to_string()),
+                        actions: vec![PreviewAction {
+                            name: "search".to_string(),
+                            arguments: "{\"q\":\"start\"}".to_string(),
+                            result: Some("ok".to_string()),
+                            is_error: false,
+                        }],
+                    }],
+                }],
+            },
+        };
+        let methods_by_type = BTreeMap::from([(
+            "PreviewSession".to_string(),
+            vec![MethodSignature {
+                name: "thread".to_string(),
+                signature: "(participants)".to_string(),
+                doc: "Conversation view for selected participants.".to_string(),
+                source: super::super::runtime::MethodSource::Custom,
+                is_dunder: false,
+            }],
+        )]);
+
+        let rendered =
+            render_previews::<RichPreviewSig>(&input, &BTreeMap::new(), &methods_by_type);
+        assert!(rendered.contains("PreviewSession {"));
+        assert!(rendered.contains(".thread(participants) // Conversation view for selected participants."));
+    }
+
+    #[test]
+    fn methods_without_docstrings_are_rendered_without_comment_suffix() {
+        let input = RichPreviewSigInput {
+            sessions: PreviewSessions {
+                items: vec![PreviewSession {
+                    brief: Some("Investigate signal drop".to_string()),
+                    turns: vec![PreviewTurn {
+                        trigger: Some("start".to_string()),
+                        actions: vec![PreviewAction {
+                            name: "search".to_string(),
+                            arguments: "{\"q\":\"start\"}".to_string(),
+                            result: Some("ok".to_string()),
+                            is_error: false,
+                        }],
+                    }],
+                }],
+            },
+        };
+        let methods = BTreeMap::from([(
+            "sessions".to_string(),
+            vec![MethodSignature {
+                name: "undocumented".to_string(),
+                signature: "()".to_string(),
+                doc: "".to_string(),
+                source: super::super::runtime::MethodSource::Custom,
+                is_dunder: false,
+            }],
+        )]);
+
+        let rendered = render_previews::<RichPreviewSig>(&input, &methods, &BTreeMap::new());
+        assert!(rendered.contains(".undocumented()"));
+        assert!(!rendered.contains(".undocumented() //"));
     }
 }

--- a/crates/dspy-rs/src/modules/rlm/previews.rs
+++ b/crates/dspy-rs/src/modules/rlm/previews.rs
@@ -8,6 +8,7 @@ use bamltype::facet_reflect::{HasFields, Peek};
 use crate::{
     BamlType, ConstraintKind, Facet, FieldPath, OutputFormatContent, Signature, SignatureSchema,
 };
+use super::runtime::MethodSignature;
 
 const TOP_LEVEL_STRING_LIMIT: usize = 500;
 const NESTED_STRING_LIMIT: usize = 100;
@@ -50,7 +51,10 @@ impl RenderBudget {
     }
 }
 
-pub(super) fn render_previews<S: Signature>(input: &S::Input) -> String
+pub(super) fn render_previews<S: Signature>(
+    input: &S::Input,
+    _methods_by_var: &BTreeMap<String, Vec<MethodSignature>>,
+) -> String
 where
     S::Input: BamlType + for<'a> Facet<'a>,
 {
@@ -85,7 +89,7 @@ fn render_with_budget(
     for field in schema.input_fields() {
         lines.push(format!(
             "{}: {}",
-            field.lm_name,
+            field.rust_name,
             field.type_ir.diagnostic_repr()
         ));
 

--- a/crates/dspy-rs/src/modules/rlm/previews.rs
+++ b/crates/dspy-rs/src/modules/rlm/previews.rs
@@ -165,6 +165,7 @@ enum StructFieldValue<'mem, 'facet> {
 
 enum PeekSummary<'mem, 'facet> {
     None,
+    Media,
     String(&'mem str),
     Bool(bool),
     SignedInt(i128),
@@ -184,6 +185,10 @@ fn summarize_peek<'mem, 'facet>(value: Peek<'mem, 'facet>) -> PeekSummary<'mem, 
     let Some(value) = collapse_option_chain(value) else {
         return PeekSummary::None;
     };
+
+    if is_media_shape(value.shape()) {
+        return PeekSummary::Media;
+    }
 
     if let Some(text) = value.as_str() {
         return PeekSummary::String(text);
@@ -215,6 +220,7 @@ fn summarize_peek<'mem, 'facet>(value: Peek<'mem, 'facet>) -> PeekSummary<'mem, 
     if let Some((class_name, fields)) = struct_like_fields(value) {
         return PeekSummary::StructLike { class_name, fields };
     }
+    // Keep unknown types generic; known media goes through `PeekSummary::Media`.
     PeekSummary::Unknown(value)
 }
 
@@ -227,6 +233,7 @@ fn render_value_block_from_summary(
 ) -> Vec<String> {
     match summary {
         PeekSummary::None => vec!["None".to_string()],
+        PeekSummary::Media => vec!["Media (preview omitted)".to_string()],
         PeekSummary::String(text) => render_string_block(text, depth > 0, budget),
         PeekSummary::Bool(v) => vec![format!("Value: {v}")],
         PeekSummary::SignedInt(v) => vec![format!("Value: {v}")],
@@ -387,6 +394,7 @@ fn render_inline_value_from_summary(
 ) -> String {
     match summary {
         PeekSummary::None => "None".to_string(),
+        PeekSummary::Media => "Media".to_string(),
         PeekSummary::String(text) => truncate_string(text, budget.nested_limit),
         PeekSummary::Bool(v) => v.to_string(),
         PeekSummary::SignedInt(v) => v.to_string(),
@@ -907,6 +915,7 @@ fn render_inline_field_value(value: &StructFieldValue<'_, '_>, budget: RenderBud
         StructFieldValue::String(text) => truncate_string(text, budget.nested_limit),
         StructFieldValue::Peek(value) => match summarize_peek(*value) {
             PeekSummary::None => "None".to_string(),
+            PeekSummary::Media => "Media".to_string(),
             PeekSummary::String(text) => truncate_string(text, budget.nested_limit),
             PeekSummary::Bool(v) => v.to_string(),
             PeekSummary::SignedInt(v) => v.to_string(),
@@ -926,6 +935,7 @@ fn render_inline_field_value(value: &StructFieldValue<'_, '_>, budget: RenderBud
 fn primitive_type_name_peek(value: Peek<'_, '_>) -> &'static str {
     match summarize_peek(value) {
         PeekSummary::None => "null",
+        PeekSummary::Media => "media",
         PeekSummary::String(_) => "string",
         PeekSummary::Bool(_) => "bool",
         PeekSummary::SignedInt(_) | PeekSummary::UnsignedInt(_) => "int",
@@ -1047,6 +1057,11 @@ fn unit_enum_variant(value: Peek<'_, '_>) -> Option<String> {
             .effective_name()
             .to_string(),
     )
+}
+
+fn is_media_shape(shape: &'static bamltype::facet::Shape) -> bool {
+    shape.type_identifier.ends_with("BamlMedia")
+        || shape.type_identifier.contains("::media::BamlMedia")
 }
 
 fn enum_has_data_variants(shape: &'static bamltype::facet::Shape) -> bool {

--- a/crates/dspy-rs/src/modules/rlm/previews.rs
+++ b/crates/dspy-rs/src/modules/rlm/previews.rs
@@ -1,164 +1,122 @@
 use std::collections::{BTreeMap, BTreeSet};
 
-use bamltype::baml_types::TypeIR;
 use bamltype::baml_types::ir_type::{TypeGeneric, UnionTypeViewGeneric};
-use bamltype::facet::{Type, UserType};
-use bamltype::facet_reflect::{HasFields, Peek};
-use tracing::{debug, info_span, trace};
+use bamltype::baml_types::type_meta::base::TypeMeta;
+use bamltype::baml_types::{StreamingMode, TypeIR, TypeValue};
+use bamltype::internal_baml_jinja::types::{Class, OutputFormatContent};
+use tracing::{debug, info_span};
 
-use super::runtime::{MethodSignature, MethodSource};
-use crate::{
-    BamlType, ConstraintKind, Facet, FieldPath, OutputFormatContent, Signature, SignatureSchema,
-};
-
-const TOP_LEVEL_STRING_LIMIT: usize = 500;
-const NESTED_STRING_LIMIT: usize = 100;
-const STRUCT_PREVIEW_DEPTH_CAP: usize = 2;
-const STRUCT_PREVIEW_BREADTH_CAP: usize = 8;
-const SOFT_PREVIEW_BUDGET: usize = 4 * 1024;
-const FIELD_STATS_FULL_SCAN: usize = 2_000;
-const FIELD_STATS_SAMPLE: usize = 512;
-const MAX_METHODS_DEFAULT: usize = 5;
-const MAX_METHODS_SHORT: usize = 4;
-const MAX_METHODS_TIGHT: usize = 3;
+use super::runtime::MethodSignature;
+use crate::{BamlType, Facet, FieldSchema, Signature, SignatureSchema};
 
 #[derive(Clone, Copy)]
 struct RenderBudget {
-    top_level_limit: usize,
-    nested_limit: usize,
-    include_middle_samples: bool,
+    max_methods: usize,
+    max_depth: usize,
 }
 
 impl RenderBudget {
-    const fn default() -> Self {
+    const fn relaxed() -> Self {
         Self {
-            top_level_limit: TOP_LEVEL_STRING_LIMIT,
-            nested_limit: NESTED_STRING_LIMIT,
-            include_middle_samples: true,
-        }
-    }
-
-    const fn shorter_strings() -> Self {
-        Self {
-            top_level_limit: 320,
-            nested_limit: 64,
-            include_middle_samples: true,
-        }
-    }
-
-    const fn no_middle_samples() -> Self {
-        Self {
-            top_level_limit: 200,
-            nested_limit: 48,
-            include_middle_samples: false,
+            max_methods: usize::MAX,
+            max_depth: 12,
         }
     }
 }
 
 pub(super) fn render_previews<S: Signature>(
-    input: &S::Input,
+    _input: &S::Input,
     methods_by_var: &BTreeMap<String, Vec<MethodSignature>>,
 ) -> String
 where
     S::Input: BamlType + for<'a> Facet<'a>,
 {
     let schema = SignatureSchema::of::<S>();
+    let input_format = <S::Input as BamlType>::baml_output_format();
+
     let render_span = info_span!(
         "rlm.preview.render",
         input_fields = schema.input_fields().len(),
         method_vars = methods_by_var.len(),
-        soft_budget = SOFT_PREVIEW_BUDGET,
         output_len = tracing::field::Empty
     );
     let _render_guard = render_span.enter();
-    let root = Peek::new(input);
-    let input_format = <S::Input as BamlType>::baml_output_format();
 
-    let budgets = [
-        RenderBudget::default(),
-        RenderBudget::shorter_strings(),
-        RenderBudget::no_middle_samples(),
-    ];
+    let budget = RenderBudget::relaxed();
+    let rendered = render_with_budget(schema, input_format, methods_by_var, budget);
+    let output_len = rendered.chars().count();
+    debug!(
+        output_len,
+        max_methods = budget.max_methods,
+        max_depth = budget.max_depth,
+        "preview rendered"
+    );
+    render_span.record("output_len", output_len);
+    rendered
+}
 
-    for (attempt, budget) in budgets.into_iter().enumerate() {
-        let rendered = render_with_budget(schema, root, input_format, methods_by_var, budget);
-        let output_len = rendered.chars().count();
-        let within_budget = output_len <= SOFT_PREVIEW_BUDGET;
-        debug!(
-            attempt = attempt + 1,
-            top_level_limit = budget.top_level_limit,
-            nested_limit = budget.nested_limit,
-            include_middle_samples = budget.include_middle_samples,
-            output_len,
-            budget_consumed = output_len,
-            budget_remaining = SOFT_PREVIEW_BUDGET.saturating_sub(output_len),
-            within_budget,
-            "preview budget pass rendered"
-        );
-        if within_budget || !budget.include_middle_samples {
-            render_span.record("output_len", output_len);
-            return rendered;
-        }
-    }
+pub(super) fn is_primitive_input_type(type_ir: &TypeIR) -> bool {
+    let Some(inner) = strip_optional(type_ir) else {
+        return false;
+    };
 
-    unreachable!("preview budget cascade must return on final pass")
+    matches!(
+        inner,
+        TypeGeneric::Primitive(TypeValue::String, _)
+            | TypeGeneric::Primitive(TypeValue::Int, _)
+            | TypeGeneric::Primitive(TypeValue::Float, _)
+            | TypeGeneric::Primitive(TypeValue::Bool, _)
+    )
+}
+
+pub(super) fn type_label(type_ir: &TypeIR, output_format: &OutputFormatContent) -> String {
+    clean_type_expr(type_ir, output_format)
+}
+
+pub(super) fn render_type_shape(
+    type_ir: &TypeIR,
+    output_format: &OutputFormatContent,
+    indent: usize,
+) -> Vec<String> {
+    let mut visited = BTreeSet::new();
+    render_type_node(
+        type_ir,
+        output_format,
+        indent,
+        0,
+        RenderBudget::relaxed().max_depth,
+        &mut visited,
+    )
 }
 
 fn render_with_budget(
     schema: &SignatureSchema,
-    root: Peek<'_, '_>,
     input_format: &OutputFormatContent,
     methods_by_var: &BTreeMap<String, Vec<MethodSignature>>,
     budget: RenderBudget,
 ) -> String {
-    let mut lines = vec!["## Variables".to_string(), String::new()];
+    let mut lines = Vec::new();
+    let mut rendered_any = false;
 
     for field in schema.input_fields() {
-        lines.push(format!(
-            "{}: {}",
-            field.rust_name,
-            field.type_ir.diagnostic_repr()
-        ));
-
-        if !field.docs.trim().is_empty() {
-            lines.push(format!("  {}", field.docs.trim()));
+        if is_primitive_input_type(&field.type_ir) {
+            continue;
         }
 
-        for constraint in field.constraints {
-            let marker = match constraint.kind {
-                ConstraintKind::Check => "soft",
-                ConstraintKind::Assert => "hard",
-            };
-            lines.push(format!(
-                "  Constraint: {marker} {} ({})",
-                constraint.label, constraint.expression
-            ));
-        }
-
-        if let Some(value) = peek_at_field_path(root, field.path()) {
-            for line in render_value_block(value, Some(&field.type_ir), input_format, 0, budget) {
-                lines.push(format!("  {line}"));
-            }
-        } else {
-            lines.push("  <missing>".to_string());
-        }
-        render_methods_section(
-            &mut lines,
-            &field.rust_name,
-            methods_by_var.get(&field.rust_name).map(Vec::as_slice),
+        rendered_any = true;
+        lines.extend(render_variable_block(
+            field,
+            input_format,
+            methods_by_var
+                .get(field.rust_name.as_str())
+                .map(Vec::as_slice),
             budget,
-        );
-
+        ));
         lines.push(String::new());
     }
 
-    lines.push("## Expected Output".to_string());
-    for field in schema.output_fields() {
-        lines.push(format!(
-            "{}: {}",
-            field.lm_name,
-            field.type_ir.diagnostic_repr()
-        ));
+    if !rendered_any {
+        lines.push("(No complex input variables.)".to_string());
     }
 
     while lines.last().is_some_and(String::is_empty) {
@@ -168,577 +126,400 @@ fn render_with_budget(
     lines.join("\n")
 }
 
-fn render_methods_section(
-    lines: &mut Vec<String>,
-    var_name: &str,
+fn render_variable_block(
+    field: &FieldSchema,
+    output_format: &OutputFormatContent,
     methods: Option<&[MethodSignature]>,
     budget: RenderBudget,
-) {
-    let Some(methods) = methods else {
-        return;
-    };
-    if methods.is_empty() {
-        return;
+) -> Vec<String> {
+    let mut lines = Vec::new();
+
+    lines.push(format!(
+        "Variable: `{}` (access it in your code)",
+        field.rust_name
+    ));
+    lines.push(format!(
+        "Type: {}",
+        type_label(&field.type_ir, output_format)
+    ));
+
+    if !field.docs.trim().is_empty() {
+        lines.push(format!("Description: {}", normalize_doc_text(&field.docs)));
     }
 
-    let mut ordered = methods.iter().collect::<Vec<_>>();
-    ordered.sort_by_key(|method| {
-        (
-            method_source_rank(method.source),
-            method.is_dunder,
-            method.name.as_str(),
-        )
-    });
+    lines.push("Schema:".to_string());
 
-    lines.push("  Methods:".to_string());
-    let max_methods = max_methods_for_budget(budget);
-    let doc_limit = budget.nested_limit.max(48);
+    let mut visited = BTreeSet::new();
+    lines.extend(render_root_schema(
+        &field.type_ir,
+        output_format,
+        methods,
+        2,
+        0,
+        budget,
+        &mut visited,
+    ));
 
-    for method in ordered.iter().take(max_methods) {
-        lines.push(format!(
-            "    .{}{}",
-            method.name,
-            normalized_signature(&method.signature)
-        ));
-        let doc = truncate_one_line(&method.doc, doc_limit);
-        if !doc.is_empty() {
-            lines.push(format!("      {doc}"));
-        }
-    }
-
-    if ordered.len() > max_methods {
-        lines.push(format!(
-            "    ... ({} more methods; use help({var_name}) for full list)",
-            ordered.len() - max_methods
-        ));
-    }
+    lines
 }
 
-const fn max_methods_for_budget(budget: RenderBudget) -> usize {
-    if !budget.include_middle_samples {
-        MAX_METHODS_TIGHT
-    } else if budget.top_level_limit <= 320 {
-        MAX_METHODS_SHORT
-    } else {
-        MAX_METHODS_DEFAULT
-    }
-}
-
-const fn method_source_rank(source: MethodSource) -> u8 {
-    match source {
-        MethodSource::Custom => 0,
-        MethodSource::Generated => 1,
-    }
-}
-
-fn normalized_signature(signature: &str) -> String {
-    let sig = signature.trim();
-    if sig.is_empty() {
-        "()".to_string()
-    } else if sig.starts_with('(') {
-        sig.to_string()
-    } else {
-        format!("({sig})")
-    }
-}
-
-fn truncate_one_line(text: &str, limit: usize) -> String {
-    let collapsed = text.split_whitespace().collect::<Vec<_>>().join(" ");
-    if collapsed.chars().count() <= limit {
-        return collapsed;
-    }
-    let head = collapsed
-        .chars()
-        .take(limit.saturating_sub(3))
-        .collect::<String>();
-    format!("{head}...")
-}
-
-fn render_value_block(
-    value: Peek<'_, '_>,
-    type_ir: Option<&TypeIR>,
-    input_format: &OutputFormatContent,
+fn render_root_schema(
+    type_ir: &TypeIR,
+    output_format: &OutputFormatContent,
+    methods: Option<&[MethodSignature]>,
+    indent: usize,
     depth: usize,
     budget: RenderBudget,
+    visited: &mut BTreeSet<String>,
 ) -> Vec<String> {
-    if let Some(inner) = optional_inner(type_ir) {
-        return match summarize_peek(value) {
-            PeekSummary::None => vec!["None".to_string()],
-            summary => {
-                let mut lines = vec!["(Present)".to_string()];
-                lines.extend(render_value_block_from_summary(
-                    summary,
-                    Some(inner),
-                    input_format,
-                    depth,
-                    budget,
-                ));
-                lines
-            }
-        };
-    }
-    render_value_block_from_summary(summarize_peek(value), type_ir, input_format, depth, budget)
-}
-
-#[derive(Clone)]
-enum StructFieldValue<'mem, 'facet> {
-    Peek(Peek<'mem, 'facet>),
-    String(String),
-}
-
-enum PeekSummary<'mem, 'facet> {
-    None,
-    Media,
-    String(&'mem str),
-    Bool(bool),
-    SignedInt(i128),
-    UnsignedInt(u128),
-    Float(f64),
-    UnitEnum(String),
-    List(bamltype::facet_reflect::PeekListLike<'mem, 'facet>),
-    Map(Vec<(String, Peek<'mem, 'facet>)>),
-    StructLike {
-        class_name: String,
-        fields: Vec<(String, StructFieldValue<'mem, 'facet>)>,
-    },
-    Unknown(Peek<'mem, 'facet>),
-}
-
-fn summarize_peek<'mem, 'facet>(value: Peek<'mem, 'facet>) -> PeekSummary<'mem, 'facet> {
-    let Some(value) = collapse_option_chain(value) else {
-        return PeekSummary::None;
-    };
-
-    if is_media_shape(value.shape()) {
-        return PeekSummary::Media;
-    }
-
-    if let Some(text) = value.as_str() {
-        return PeekSummary::String(text);
-    }
-    if let Ok(v) = value.get::<bool>() {
-        return PeekSummary::Bool(*v);
-    }
-    if let Some(v) = peek_signed_i128(value) {
-        return PeekSummary::SignedInt(v);
-    }
-    if let Some(v) = peek_unsigned_u128(value) {
-        return PeekSummary::UnsignedInt(v);
-    }
-    if let Ok(v) = value.get::<f64>() {
-        return PeekSummary::Float(*v);
-    }
-    if let Ok(v) = value.get::<f32>() {
-        return PeekSummary::Float(*v as f64);
-    }
-    if let Some(v) = unit_enum_variant(value) {
-        return PeekSummary::UnitEnum(v);
-    }
-    if let Ok(list) = value.into_list_like() {
-        return PeekSummary::List(list);
-    }
-    if let Ok(map) = value.into_map() {
-        return PeekSummary::Map(map_entries_for_preview(map));
-    }
-    if let Some((class_name, fields)) = struct_like_fields(value) {
-        return PeekSummary::StructLike { class_name, fields };
-    }
-    // Keep unknown types generic; known media goes through `PeekSummary::Media`.
-    PeekSummary::Unknown(value)
-}
-
-fn render_value_block_from_summary(
-    summary: PeekSummary<'_, '_>,
-    type_ir: Option<&TypeIR>,
-    input_format: &OutputFormatContent,
-    depth: usize,
-    budget: RenderBudget,
-) -> Vec<String> {
-    match summary {
-        PeekSummary::None => vec!["None".to_string()],
-        PeekSummary::Media => vec!["Media (preview omitted)".to_string()],
-        PeekSummary::String(text) => render_string_block(text, depth > 0, budget),
-        PeekSummary::Bool(v) => vec![format!("Value: {v}")],
-        PeekSummary::SignedInt(v) => vec![format!("Value: {v}")],
-        PeekSummary::UnsignedInt(v) => vec![format!("Value: {v}")],
-        PeekSummary::Float(v) => vec![format!("Value: {v}")],
-        PeekSummary::UnitEnum(variant) => vec![format!("Variant: {variant}")],
-        PeekSummary::List(list) => {
-            render_list_block(&list, item_type(type_ir), input_format, depth, budget)
-        }
-        PeekSummary::Map(entries) => render_map_block(
-            &entries,
-            map_value_type(type_ir),
-            input_format,
+    if let Some((class_name, mode)) = class_type_ref(type_ir)
+        && let Some(class) = output_format.classes.get(&(class_name.to_string(), mode))
+    {
+        return render_class_block(
+            class,
+            output_format,
+            methods,
+            indent,
             depth,
             budget,
-        ),
-        PeekSummary::StructLike { class_name, fields } => {
-            render_struct_block(&class_name, &fields, type_ir, input_format, depth, budget)
-        }
-        PeekSummary::Unknown(value) => vec![format!("Value: {}", value)],
+            visited,
+        );
     }
+
+    render_type_node(
+        type_ir,
+        output_format,
+        indent,
+        depth,
+        budget.max_depth,
+        visited,
+    )
 }
 
-fn render_string_block(text: &str, nested: bool, budget: RenderBudget) -> Vec<String> {
-    if nested {
-        return vec![truncate_string(text, budget.nested_limit)];
+fn render_class_block(
+    class: &Class,
+    output_format: &OutputFormatContent,
+    methods: Option<&[MethodSignature]>,
+    indent: usize,
+    depth: usize,
+    budget: RenderBudget,
+    visited: &mut BTreeSet<String>,
+) -> Vec<String> {
+    let class_name = class.name.rendered_name().to_string();
+    if depth >= budget.max_depth || !visited.insert(class_name.clone()) {
+        return vec![format!("{}{} {{ ... }}", spaces(indent), class_name)];
     }
 
-    let len = text.chars().count();
-    let lines = text.lines().count().max(1);
-    let mut out = vec![format!("Length: {len} chars, Lines: {lines}")];
+    let mut lines = Vec::new();
+    lines.push(format!("{}{} {{", spaces(indent), class_name));
 
-    if len > 50
-        && let Some(summary) = summarize_json_string(text)
+    if let Some(methods) = methods {
+        let methods = methods
+            .iter()
+            .filter(|method| !method.is_dunder && !method.doc.trim().is_empty())
+            .take(budget.max_methods)
+            .collect::<Vec<_>>();
+
+        if !methods.is_empty() {
+            lines.push(format!("{}// methods", spaces(indent + 2)));
+            for method in methods {
+                lines.push(format!(
+                    "{}{}",
+                    spaces(indent + 2),
+                    render_method_line(method)
+                ));
+            }
+        }
+    }
+
+    lines.push(format!("{}// shape", spaces(indent + 2)));
+    for (field_name, field_type, description, _) in &class.fields {
+        lines.extend(render_field_line(
+            field_name.real_name(),
+            field_type,
+            description.as_deref(),
+            output_format,
+            indent + 2,
+            depth + 1,
+            budget,
+            visited,
+        ));
+    }
+
+    lines.push(format!("{}}}", spaces(indent)));
+    visited.remove(&class_name);
+    lines
+}
+
+fn render_field_line(
+    field_name: &str,
+    field_type: &TypeIR,
+    description: Option<&str>,
+    output_format: &OutputFormatContent,
+    indent: usize,
+    depth: usize,
+    budget: RenderBudget,
+    visited: &mut BTreeSet<String>,
+) -> Vec<String> {
+    let mut lines = Vec::new();
+    let rendered = render_type_node(
+        field_type,
+        output_format,
+        indent + 2,
+        depth,
+        budget.max_depth,
+        visited,
+    );
+
+    if rendered.len() == 1 {
+        let mut line = format!(
+            "{}{}: {}",
+            spaces(indent),
+            field_name,
+            rendered[0].trim_start()
+        );
+        if let Some(description) = description
+            && !description.trim().is_empty()
+        {
+            line.push_str(" // ");
+            line.push_str(&normalize_doc_text(description));
+        }
+        lines.push(line);
+        return lines;
+    }
+
+    let mut first_line = format!(
+        "{}{}: {}",
+        spaces(indent),
+        field_name,
+        rendered[0].trim_start()
+    );
+    if let Some(description) = description
+        && !description.trim().is_empty()
     {
-        out.push(format!("(JSON String) {summary}"));
+        first_line.push_str(" // ");
+        first_line.push_str(&normalize_doc_text(description));
     }
-
-    out.push(format!(
-        "Value: {}",
-        truncate_string(text, budget.top_level_limit)
-    ));
-    out
-}
-
-fn render_list_block(
-    items: &bamltype::facet_reflect::PeekListLike<'_, '_>,
-    item_type: Option<&TypeIR>,
-    input_format: &OutputFormatContent,
-    depth: usize,
-    budget: RenderBudget,
-) -> Vec<String> {
-    trace!(depth, size = items.len(), "rendering list preview");
-    let mut lines = vec![format!("Count: {} items", items.len())];
-
-    if let Some(schema_line) = class_schema_line(item_type, input_format) {
-        lines.push(format!("Schema: {schema_line}"));
-    }
-
-    let sample = items.iter().collect::<Vec<_>>();
-
-    if let Some(distribution) = scalar_distribution(&sample) {
-        lines.push(format!("Distribution: {distribution}"));
-    }
-
-    if let Some(stats) = compute_field_stats(&sample) {
-        lines.push(format!("Field stats: {}", stats.summary));
-        if let Some(note) = stats.sampling_note {
-            lines.push(note);
-        }
-    }
-
-    if depth >= STRUCT_PREVIEW_DEPTH_CAP {
-        return lines;
-    }
-
-    for idx in sample_indices(items.len(), depth, budget.include_middle_samples) {
-        if let Some(item) = items.get(idx) {
-            let rendered = render_inline_value(item, item_type, input_format, depth + 1, budget);
-            lines.push(format!("Sample [{idx}]: {rendered}"));
-        }
-    }
+    lines.push(first_line);
+    lines.extend(rendered.into_iter().skip(1));
 
     lines
 }
 
-fn render_map_block(
-    entries: &[(String, Peek<'_, '_>)],
-    value_type: Option<&TypeIR>,
-    input_format: &OutputFormatContent,
+fn render_type_node(
+    type_ir: &TypeIR,
+    output_format: &OutputFormatContent,
+    indent: usize,
     depth: usize,
-    budget: RenderBudget,
+    max_depth: usize,
+    visited: &mut BTreeSet<String>,
 ) -> Vec<String> {
-    trace!(depth, size = entries.len(), "rendering map preview");
-    let mut lines = vec![format!("Keys: {} items", entries.len())];
-    if entries.is_empty() || depth >= STRUCT_PREVIEW_DEPTH_CAP {
-        return lines;
+    if depth >= max_depth {
+        return vec![format!(
+            "{}{}",
+            spaces(indent),
+            type_label(type_ir, output_format)
+        )];
     }
 
-    for idx in sample_indices(entries.len(), depth, budget.include_middle_samples) {
-        let (key, value) = &entries[idx];
-        let rendered = render_inline_value(*value, value_type, input_format, depth + 1, budget);
-        lines.push(format!("Sample [{key:?}]: {rendered}"));
-    }
-
-    lines
-}
-
-fn render_struct_block(
-    class_name: &str,
-    fields: &[(String, StructFieldValue<'_, '_>)],
-    type_ir: Option<&TypeIR>,
-    input_format: &OutputFormatContent,
-    depth: usize,
-    budget: RenderBudget,
-) -> Vec<String> {
-    let mut lines = vec![];
-
-    if let Some(schema_line) = class_schema_line(type_ir, input_format) {
-        lines.push(format!("Schema: {schema_line}"));
-    } else {
-        lines.push(format!("Schema: {}", fallback_schema(fields)));
-    }
-
-    if depth >= STRUCT_PREVIEW_DEPTH_CAP {
-        lines.push(format!("Preview: {class_name} ({} fields)", fields.len()));
-        return lines;
-    }
-
-    let preview = render_inline_struct(class_name, fields, type_ir, input_format, depth, budget);
-    lines.push(format!("Preview: {preview}"));
-    lines
-}
-
-fn render_inline_value(
-    value: Peek<'_, '_>,
-    type_ir: Option<&TypeIR>,
-    input_format: &OutputFormatContent,
-    depth: usize,
-    budget: RenderBudget,
-) -> String {
-    if let Some(inner) = optional_inner(type_ir) {
-        return match summarize_peek(value) {
-            PeekSummary::None => "None".to_string(),
-            summary => format!(
-                "(Present) {}",
-                render_inline_value_from_summary(summary, Some(inner), input_format, depth, budget)
-            ),
-        };
-    }
-    render_inline_value_from_summary(summarize_peek(value), type_ir, input_format, depth, budget)
-}
-
-fn render_inline_value_from_summary(
-    summary: PeekSummary<'_, '_>,
-    type_ir: Option<&TypeIR>,
-    input_format: &OutputFormatContent,
-    depth: usize,
-    budget: RenderBudget,
-) -> String {
-    match summary {
-        PeekSummary::None => "None".to_string(),
-        PeekSummary::Media => "Media".to_string(),
-        PeekSummary::String(text) => truncate_string(text, budget.nested_limit),
-        PeekSummary::Bool(v) => v.to_string(),
-        PeekSummary::SignedInt(v) => v.to_string(),
-        PeekSummary::UnsignedInt(v) => v.to_string(),
-        PeekSummary::Float(v) => v.to_string(),
-        PeekSummary::UnitEnum(variant) => variant,
-        PeekSummary::List(list) => {
-            if depth >= STRUCT_PREVIEW_DEPTH_CAP {
-                return format!("Count: {} items", list.len());
-            }
-            let idxs = sample_indices(list.len(), depth, budget.include_middle_samples);
-            let inner = item_type(type_ir);
-            if idxs.is_empty() {
-                return "Count: 0 items".to_string();
-            }
-            let samples = idxs
-                .iter()
-                .filter_map(|idx| {
-                    list.get(*idx).map(|item| {
-                        format!(
-                            "sample[{idx}]={}",
-                            render_inline_value(item, inner, input_format, depth + 1, budget)
-                        )
-                    })
-                })
-                .collect::<Vec<_>>()
-                .join(", ");
-            format!("Count: {} items; {samples}", list.len())
-        }
-        PeekSummary::Map(entries) => {
-            if depth >= STRUCT_PREVIEW_DEPTH_CAP {
-                return format!("Keys: {} items", entries.len());
-            }
-            let value_type = map_value_type(type_ir);
-            let pairs = sample_indices(entries.len(), depth, budget.include_middle_samples)
-                .into_iter()
-                .map(|idx| {
-                    let (key, entry) = &entries[idx];
-                    format!(
-                        "{key:?}: {}",
-                        render_inline_value(*entry, value_type, input_format, depth + 1, budget)
-                    )
-                })
-                .collect::<Vec<_>>();
-            if pairs.is_empty() {
-                format!("Keys: {} items", entries.len())
-            } else {
-                format!("Keys: {} items; {}", entries.len(), pairs.join(", "))
-            }
-        }
-        PeekSummary::StructLike { class_name, fields } => {
-            render_inline_struct(&class_name, &fields, type_ir, input_format, depth, budget)
-        }
-        PeekSummary::Unknown(value) => format!("{}", value),
-    }
-}
-
-fn render_inline_struct(
-    class_name: &str,
-    fields: &[(String, StructFieldValue<'_, '_>)],
-    type_ir: Option<&TypeIR>,
-    input_format: &OutputFormatContent,
-    depth: usize,
-    budget: RenderBudget,
-) -> String {
-    if depth >= STRUCT_PREVIEW_DEPTH_CAP {
-        return format!("{class_name} ({} fields)", fields.len());
-    }
-
-    let ordered = ordered_struct_fields(fields, type_ir, input_format);
-    let mut parts = Vec::new();
-
-    for (idx, (name, value, _child_ty)) in ordered.into_iter().enumerate() {
-        if idx >= STRUCT_PREVIEW_BREADTH_CAP {
-            break;
-        }
-        let rendered = render_inline_field_value(value, budget);
-        parts.push(format!("{name}: {rendered}"));
-    }
-
-    if fields.len() > STRUCT_PREVIEW_BREADTH_CAP {
-        parts.push(format!(
-            "... (+{} fields)",
-            fields.len() - STRUCT_PREVIEW_BREADTH_CAP
-        ));
-    }
-
-    format!("{class_name} {{ {} }}", parts.join(", "))
-}
-
-fn ordered_struct_fields<'a, 'mem, 'facet>(
-    fields: &'a [(String, StructFieldValue<'mem, 'facet>)],
-    type_ir: Option<&'a TypeIR>,
-    input_format: &'a OutputFormatContent,
-) -> Vec<(
-    &'a str,
-    &'a StructFieldValue<'mem, 'facet>,
-    Option<&'a TypeIR>,
-)> {
-    if let Some((class_name, mode)) = class_type_ref(type_ir)
-        && let Some(class) = input_format.classes.get(&(class_name.to_string(), mode))
+    if let Some(optional_inner) = optional_inner(type_ir)
+        && is_simple_type(optional_inner)
     {
-        let mut ordered = Vec::new();
-        for (field_name, field_ty, _, _) in &class.fields {
-            let key = field_name.real_name();
-            if let Some((_, value)) = fields.iter().find(|(name, _)| name == key) {
-                ordered.push((key, value, Some(field_ty)));
-            }
-        }
-
-        for (key, value) in fields {
-            if !ordered
-                .iter()
-                .any(|(existing, _, _)| *existing == key.as_str())
-            {
-                ordered.push((key.as_str(), value, None));
-            }
-        }
-        return ordered;
+        return vec![format!(
+            "{}{} | null",
+            spaces(indent),
+            type_label(optional_inner, output_format)
+        )];
     }
 
-    let mut fallback = fields
-        .iter()
-        .map(|(key, value)| (key.as_str(), value, None))
-        .collect::<Vec<_>>();
-    fallback.sort_by(|a, b| a.0.cmp(b.0));
-    fallback
-}
-
-fn class_schema_line(
-    type_ir: Option<&TypeIR>,
-    input_format: &OutputFormatContent,
-) -> Option<String> {
-    let (class_name, mode) = class_type_ref(type_ir)?;
-    let class = input_format.classes.get(&(class_name.to_string(), mode))?;
-
-    let mut fields = class
-        .fields
-        .iter()
-        .take(STRUCT_PREVIEW_BREADTH_CAP)
-        .map(|(field_name, field_type, _, _)| {
-            format!(
-                "{}: {}",
-                field_name.real_name(),
-                field_type.diagnostic_repr()
-            )
-        })
-        .collect::<Vec<_>>();
-
-    if class.fields.len() > STRUCT_PREVIEW_BREADTH_CAP {
-        fields.push(format!(
-            "... (+{} fields)",
-            class.fields.len() - STRUCT_PREVIEW_BREADTH_CAP
-        ));
-    }
-
-    Some(format!("{{ {} }}", fields.join(", ")))
-}
-
-fn fallback_schema(fields: &[(String, StructFieldValue<'_, '_>)]) -> String {
-    let mut keys = fields
-        .iter()
-        .map(|(key, _)| key.as_str())
-        .collect::<Vec<_>>();
-    keys.sort_unstable();
-    let mut parts = keys
-        .iter()
-        .take(STRUCT_PREVIEW_BREADTH_CAP)
-        .filter_map(|key| {
-            fields
-                .iter()
-                .find(|(name, _)| name == key)
-                .map(|(_, value)| value)
-                .map(|value| format!("{key}: {}", primitive_type_name(value)))
-        })
-        .collect::<Vec<_>>();
-
-    if keys.len() > STRUCT_PREVIEW_BREADTH_CAP {
-        parts.push(format!(
-            "... (+{} fields)",
-            keys.len() - STRUCT_PREVIEW_BREADTH_CAP
-        ));
-    }
-
-    format!("{{ {} }}", parts.join(", "))
-}
-
-fn primitive_type_name(value: &StructFieldValue<'_, '_>) -> &'static str {
-    match value {
-        StructFieldValue::String(_) => "string",
-        StructFieldValue::Peek(value) => primitive_type_name_peek(*value),
-    }
-}
-
-fn sample_indices(len: usize, depth: usize, include_middle: bool) -> Vec<usize> {
-    if len == 0 || depth >= STRUCT_PREVIEW_DEPTH_CAP {
-        return Vec::new();
-    }
-
-    if depth == 1 {
-        return vec![0];
-    }
-
-    if len <= 3 {
-        return (0..len).collect();
-    }
-
-    let mut indices = vec![0, len - 1];
-    if include_middle {
-        indices.push(len / 2);
-    }
-    indices.sort_unstable();
-    indices.dedup();
-    indices
-}
-
-fn optional_inner(type_ir: Option<&TypeIR>) -> Option<&TypeIR> {
     match type_ir {
-        Some(TypeGeneric::Union(union, _)) => match union.view() {
+        TypeGeneric::List(inner, _) => {
+            render_list_node(inner, output_format, indent, depth + 1, max_depth, visited)
+        }
+        TypeGeneric::Map(key, value, _) => {
+            let key_name = type_label(key, output_format);
+            if is_simple_type(value) {
+                return vec![format!(
+                    "{}map<{}, {}>",
+                    spaces(indent),
+                    key_name,
+                    type_label(value, output_format)
+                )];
+            }
+
+            let mut lines = vec![format!("{}map<{},", spaces(indent), key_name)];
+            lines.extend(render_type_node(
+                value,
+                output_format,
+                indent + 2,
+                depth + 1,
+                max_depth,
+                visited,
+            ));
+            lines.push(format!("{}>", spaces(indent)));
+            lines
+        }
+        TypeGeneric::Class { name, mode, .. } => {
+            if let Some(class) = output_format.classes.get(&(name.to_string(), *mode)) {
+                render_class_block(
+                    class,
+                    output_format,
+                    None,
+                    indent,
+                    depth,
+                    RenderBudget::relaxed(),
+                    visited,
+                )
+            } else {
+                vec![format!("{}{}", spaces(indent), short_name(name))]
+            }
+        }
+        TypeGeneric::Enum { name, .. } => vec![format!(
+            "{}{}",
+            spaces(indent),
+            enum_name(name, output_format)
+        )],
+        TypeGeneric::Union(union, _) => {
+            render_union_node(union, output_format, indent, depth, max_depth, visited)
+        }
+        TypeGeneric::RecursiveTypeAlias { name, .. } => {
+            if let Some(alias) = output_format.structural_recursive_aliases.get(name) {
+                render_type_node(alias, output_format, indent, depth + 1, max_depth, visited)
+            } else {
+                vec![format!("{}{}", spaces(indent), short_name(name))]
+            }
+        }
+        TypeGeneric::Primitive(value, _) => {
+            vec![format!("{}{}", spaces(indent), primitive_name(*value))]
+        }
+        TypeGeneric::Literal(literal, _) => {
+            vec![format!("{}{:?}", spaces(indent), literal)]
+        }
+        _ => vec![format!(
+            "{}{}",
+            spaces(indent),
+            clean_diagnostic_repr(type_ir)
+        )],
+    }
+}
+
+fn render_list_node(
+    inner: &TypeIR,
+    output_format: &OutputFormatContent,
+    indent: usize,
+    depth: usize,
+    max_depth: usize,
+    visited: &mut BTreeSet<String>,
+) -> Vec<String> {
+    if is_simple_type(inner) {
+        return vec![format!(
+            "{}list[{}]",
+            spaces(indent),
+            type_label(inner, output_format)
+        )];
+    }
+
+    let mut lines = vec![format!("{}list[", spaces(indent))];
+    lines.extend(render_type_node(
+        inner,
+        output_format,
+        indent + 2,
+        depth,
+        max_depth,
+        visited,
+    ));
+    lines.push(format!("{}]", spaces(indent)));
+    lines
+}
+
+fn render_union_node(
+    union: &bamltype::baml_types::ir_type::UnionTypeGeneric<TypeMeta>,
+    output_format: &OutputFormatContent,
+    indent: usize,
+    depth: usize,
+    max_depth: usize,
+    visited: &mut BTreeSet<String>,
+) -> Vec<String> {
+    if let UnionTypeViewGeneric::Optional(inner) = union.view() {
+        if is_simple_type(inner) {
+            return vec![format!(
+                "{}{} | null",
+                spaces(indent),
+                type_label(inner, output_format)
+            )];
+        }
+    }
+
+    let mut lines = vec![format!("{}one of:", spaces(indent))];
+    for option in union.iter_include_null() {
+        let rendered = render_type_node(
+            option,
+            output_format,
+            indent + 4,
+            depth + 1,
+            max_depth,
+            visited,
+        );
+        if rendered.is_empty() {
+            continue;
+        }
+
+        lines.push(format!(
+            "{}- {}",
+            spaces(indent + 2),
+            rendered[0].trim_start()
+        ));
+        for extra in rendered.iter().skip(1) {
+            lines.push(format!("{}{}", spaces(indent + 4), extra.trim_start()));
+        }
+    }
+
+    lines
+}
+
+fn render_method_line(method: &MethodSignature) -> String {
+    let mut line = format!(".{}{}", method.name, method.signature);
+    let doc = normalize_doc_text(&method.doc);
+    if !doc.is_empty() {
+        line.push_str(" // ");
+        line.push_str(&doc);
+    }
+    line
+}
+
+fn is_simple_type(type_ir: &TypeIR) -> bool {
+    if let Some(inner) = strip_optional(type_ir) {
+        return matches!(
+            inner,
+            TypeGeneric::Primitive(..)
+                | TypeGeneric::Enum { .. }
+                | TypeGeneric::Literal(..)
+                | TypeGeneric::Top(..)
+        );
+    }
+
+    matches!(
+        type_ir,
+        TypeGeneric::Primitive(..)
+            | TypeGeneric::Enum { .. }
+            | TypeGeneric::Literal(..)
+            | TypeGeneric::Top(..)
+    )
+}
+
+fn strip_optional(type_ir: &TypeIR) -> Option<&TypeIR> {
+    match type_ir {
+        TypeGeneric::Union(union, _) => match union.view() {
+            UnionTypeViewGeneric::Optional(inner) => Some(inner),
+            _ => None,
+        },
+        _ => Some(type_ir),
+    }
+}
+
+fn optional_inner(type_ir: &TypeIR) -> Option<&TypeIR> {
+    match type_ir {
+        TypeGeneric::Union(union, _) => match union.view() {
             UnionTypeViewGeneric::Optional(inner) => Some(inner),
             _ => None,
         },
@@ -746,1028 +527,263 @@ fn optional_inner(type_ir: Option<&TypeIR>) -> Option<&TypeIR> {
     }
 }
 
-fn item_type(type_ir: Option<&TypeIR>) -> Option<&TypeIR> {
+fn class_type_ref(type_ir: &TypeIR) -> Option<(&str, StreamingMode)> {
     match type_ir {
-        Some(TypeGeneric::List(inner, _)) => Some(inner),
-        Some(TypeGeneric::Union(union, _)) => match union.view() {
-            UnionTypeViewGeneric::Optional(inner) => item_type(Some(inner)),
+        TypeGeneric::Class { name, mode, .. } => Some((name.as_str(), *mode)),
+        TypeGeneric::Union(union, _) => match union.view() {
+            UnionTypeViewGeneric::Optional(inner) => class_type_ref(inner),
             _ => None,
         },
         _ => None,
     }
 }
 
-fn map_value_type(type_ir: Option<&TypeIR>) -> Option<&TypeIR> {
+fn clean_type_expr(type_ir: &TypeIR, output_format: &OutputFormatContent) -> String {
     match type_ir {
-        Some(TypeGeneric::Map(_, value, _)) => Some(value),
-        Some(TypeGeneric::Union(union, _)) => match union.view() {
-            UnionTypeViewGeneric::Optional(inner) => map_value_type(Some(inner)),
-            _ => None,
-        },
-        _ => None,
-    }
-}
-
-fn class_type_ref(type_ir: Option<&TypeIR>) -> Option<(&str, bamltype::baml_types::StreamingMode)> {
-    match type_ir {
-        Some(TypeGeneric::Class { name, mode, .. }) => Some((name.as_str(), *mode)),
-        Some(TypeGeneric::Union(union, _)) => match union.view() {
-            UnionTypeViewGeneric::Optional(inner) => class_type_ref(Some(inner)),
-            _ => None,
-        },
-        _ => None,
-    }
-}
-
-fn truncate_string(text: &str, limit: usize) -> String {
-    let total = text.chars().count();
-    if total <= limit {
-        return format!("{:?}", text);
-    }
-
-    let head_len = limit / 2;
-    let tail_len = limit.saturating_sub(head_len);
-    let head = text.chars().take(head_len).collect::<String>();
-    let tail = text
-        .chars()
-        .rev()
-        .take(tail_len)
-        .collect::<String>()
-        .chars()
-        .rev()
-        .collect::<String>();
-
-    format!(
-        "{:?} ... ({} chars omitted) ... {:?}",
-        head,
-        total.saturating_sub(head_len + tail_len),
-        tail
-    )
-}
-
-fn summarize_json_string(text: &str) -> Option<String> {
-    let value = serde_json::from_str::<serde_json::Value>(text).ok()?;
-
-    match value {
-        serde_json::Value::Object(map) => {
-            let mut keys = map.keys().cloned().collect::<Vec<_>>();
-            keys.sort_unstable();
-            let mut summary = keys.iter().take(8).cloned().collect::<Vec<_>>().join(", ");
-            if keys.len() > 8 {
-                summary.push_str(&format!(", ... (+{} keys)", keys.len() - 8));
+        TypeGeneric::Primitive(value, _) => primitive_name(*value).to_string(),
+        TypeGeneric::Class { name, mode, .. } => output_format
+            .classes
+            .get(&(name.to_string(), *mode))
+            .map(|class| class.name.rendered_name().to_string())
+            .unwrap_or_else(|| short_name(name)),
+        TypeGeneric::Enum { name, .. } => enum_name(name, output_format),
+        TypeGeneric::List(inner, _) => {
+            format!("list[{}]", clean_type_expr(inner, output_format))
+        }
+        TypeGeneric::Map(key, value, _) => format!(
+            "map<{}, {}>",
+            clean_type_expr(key, output_format),
+            clean_type_expr(value, output_format)
+        ),
+        TypeGeneric::Union(union, _) => {
+            if let UnionTypeViewGeneric::Optional(inner) = union.view() {
+                return format!("{} | null", clean_type_expr(inner, output_format));
             }
-            Some(format!("object keys: {summary}"))
-        }
-        serde_json::Value::Array(items) => {
-            let first = items.first().map(json_value_name).unwrap_or("empty");
-            Some(format!(
-                "array with {} items (first item type: {first})",
-                items.len()
-            ))
-        }
-        _ => None,
-    }
-}
 
-fn json_value_name(value: &serde_json::Value) -> &'static str {
-    match value {
-        serde_json::Value::Null => "null",
-        serde_json::Value::Bool(_) => "bool",
-        serde_json::Value::Number(_) => "number",
-        serde_json::Value::String(_) => "string",
-        serde_json::Value::Array(_) => "array",
-        serde_json::Value::Object(_) => "object",
-    }
-}
-
-fn scalar_distribution(items: &[Peek<'_, '_>]) -> Option<String> {
-    if items.is_empty() {
-        return None;
-    }
-
-    let mut numeric = Vec::new();
-    let mut t = 0usize;
-    let mut f = 0usize;
-    let mut variants: BTreeMap<String, usize> = BTreeMap::new();
-
-    for item in items {
-        match summarize_peek(*item) {
-            PeekSummary::SignedInt(v) => numeric.push(v as f64),
-            PeekSummary::UnsignedInt(v) => numeric.push(v as f64),
-            PeekSummary::Float(v) => numeric.push(v),
-            PeekSummary::Bool(true) => t += 1,
-            PeekSummary::Bool(false) => f += 1,
-            PeekSummary::UnitEnum(variant) => *variants.entry(variant).or_insert(0) += 1,
-            _ => return None,
-        }
-    }
-
-    if !numeric.is_empty() {
-        let min = numeric.iter().fold(f64::INFINITY, |acc, v| acc.min(*v));
-        let max = numeric.iter().fold(f64::NEG_INFINITY, |acc, v| acc.max(*v));
-        let mean = numeric.iter().sum::<f64>() / numeric.len() as f64;
-        return Some(format!(
-            "min={}; max={}; mean={}",
-            number(min),
-            number(max),
-            number(mean)
-        ));
-    }
-
-    if t + f == items.len() {
-        return Some(format!("true={t}, false={f}"));
-    }
-
-    if !variants.is_empty() {
-        return Some(
-            variants
+            let variants = union
+                .iter_include_null()
                 .into_iter()
-                .map(|(variant, count)| format!("{variant}: {count}"))
-                .collect::<Vec<_>>()
-                .join(", "),
-        );
-    }
-
-    None
-}
-
-struct FieldStats {
-    summary: String,
-    sampling_note: Option<String>,
-}
-
-#[derive(Default)]
-struct FieldAgg {
-    present: usize,
-    missing: usize,
-    strings: Vec<usize>,
-    unique_values: BTreeSet<String>,
-    numbers: Vec<f64>,
-    bool_true: usize,
-    bool_false: usize,
-}
-
-fn compute_field_stats(items: &[Peek<'_, '_>]) -> Option<FieldStats> {
-    if items.is_empty() {
-        return None;
-    }
-
-    let rows = items
-        .iter()
-        .map(|item| row_for_field_stats(*item))
-        .collect::<Option<Vec<_>>>()?;
-
-    let sample_indices = if rows.len() <= FIELD_STATS_FULL_SCAN {
-        (0..rows.len()).collect::<Vec<_>>()
-    } else {
-        stride_sample(rows.len(), FIELD_STATS_SAMPLE)
-    };
-
-    let sampled_rows = sample_indices
-        .iter()
-        .map(|idx| &rows[*idx])
-        .collect::<Vec<_>>();
-
-    let mut field_names = BTreeSet::new();
-    for row in &sampled_rows {
-        for key in row.keys() {
-            field_names.insert(key.clone());
+                .map(|variant| clean_type_expr(variant, output_format))
+                .collect::<Vec<_>>();
+            variants.join(" | ")
         }
+        TypeGeneric::RecursiveTypeAlias { name, .. } => short_name(name),
+        _ => clean_diagnostic_repr(type_ir),
     }
+}
 
-    let mut parts = Vec::new();
+fn clean_diagnostic_repr(type_ir: &TypeIR) -> String {
+    let mut out = type_ir.diagnostic_repr().to_string();
+    out = out.replace("class `", "");
+    out = out.replace("enum `", "");
+    out = out.replace('`', "");
+    for token in ["class ", "enum "] {
+        out = out.replace(token, "");
+    }
+    short_path_tokens(&out)
+}
 
-    for field_name in field_names {
-        let mut agg = FieldAgg::default();
-        for row in &sampled_rows {
-            match row.get(&field_name) {
-                None => agg.missing += 1,
-                Some(StructFieldValue::String(v)) => {
-                    agg.present += 1;
-                    agg.strings.push(v.chars().count());
-                    if agg.unique_values.len() <= 4096 {
-                        agg.unique_values.insert(v.clone());
-                    }
-                }
-                Some(StructFieldValue::Peek(value)) => match summarize_peek(*value) {
-                    PeekSummary::None => agg.missing += 1,
-                    PeekSummary::String(v) => {
-                        agg.present += 1;
-                        agg.strings.push(v.chars().count());
-                        if agg.unique_values.len() <= 4096 {
-                            agg.unique_values.insert(v.to_string());
-                        }
-                    }
-                    PeekSummary::SignedInt(v) => {
-                        agg.present += 1;
-                        agg.numbers.push(v as f64);
-                    }
-                    PeekSummary::UnsignedInt(v) => {
-                        agg.present += 1;
-                        agg.numbers.push(v as f64);
-                    }
-                    PeekSummary::Float(v) => {
-                        agg.present += 1;
-                        agg.numbers.push(v);
-                    }
-                    PeekSummary::Bool(true) => {
-                        agg.present += 1;
-                        agg.bool_true += 1;
-                    }
-                    PeekSummary::Bool(false) => {
-                        agg.present += 1;
-                        agg.bool_false += 1;
-                    }
-                    PeekSummary::UnitEnum(variant) => {
-                        agg.present += 1;
-                        if agg.unique_values.len() <= 4096 {
-                            agg.unique_values.insert(variant);
-                        }
-                    }
-                    _ => agg.present += 1,
-                },
-            }
+fn short_path_tokens(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len());
+    let mut token = String::new();
+
+    let flush = |out: &mut String, token: &mut String| {
+        if token.is_empty() {
+            return;
         }
-
-        let mut rendered = if !agg.numbers.is_empty() && agg.numbers.len() == agg.present {
-            let min = agg.numbers.iter().fold(f64::INFINITY, |acc, v| acc.min(*v));
-            let max = agg
-                .numbers
-                .iter()
-                .fold(f64::NEG_INFINITY, |acc, v| acc.max(*v));
-            let mean = agg.numbers.iter().sum::<f64>() / agg.numbers.len() as f64;
-            format!(
-                "min={}; max={}; mean={}",
-                number(min),
-                number(max),
-                number(mean)
-            )
-        } else if !agg.strings.is_empty() && agg.strings.len() == agg.present {
-            let min = agg.strings.iter().min().copied().unwrap_or(0);
-            let max = agg.strings.iter().max().copied().unwrap_or(0);
-            if is_categorical_field(&field_name, agg.unique_values.len(), agg.present) {
-                format!("{} unique values", agg.unique_values.len())
-            } else {
-                format!("{min}-{max} chars")
+        if token.contains("::") {
+            if let Some(last) = token.rsplit("::").next() {
+                out.push_str(last);
             }
-        } else if agg.bool_true + agg.bool_false == agg.present {
-            format!("true={}, false={}", agg.bool_true, agg.bool_false)
         } else {
-            continue;
-        };
-
-        if agg.missing > 0 {
-            let pct = ((agg.missing as f64 / sampled_rows.len() as f64) * 100.0).round() as usize;
-            rendered.push_str(&format!(", {pct}% null"));
+            out.push_str(token);
         }
-
-        parts.push(format!("{field_name}: {rendered}"));
-    }
-
-    if parts.is_empty() {
-        return None;
-    }
-
-    Some(FieldStats {
-        summary: parts.join("; "),
-        sampling_note: (rows.len() > FIELD_STATS_FULL_SCAN)
-            .then(|| format!("(sampled {} of {})", sampled_rows.len(), rows.len())),
-    })
-}
-
-fn render_inline_field_value(value: &StructFieldValue<'_, '_>, budget: RenderBudget) -> String {
-    match value {
-        StructFieldValue::String(text) => truncate_string(text, budget.nested_limit),
-        StructFieldValue::Peek(value) => match summarize_peek(*value) {
-            PeekSummary::None => "None".to_string(),
-            PeekSummary::Media => "Media".to_string(),
-            PeekSummary::String(text) => truncate_string(text, budget.nested_limit),
-            PeekSummary::Bool(v) => v.to_string(),
-            PeekSummary::SignedInt(v) => v.to_string(),
-            PeekSummary::UnsignedInt(v) => v.to_string(),
-            PeekSummary::Float(v) => v.to_string(),
-            PeekSummary::UnitEnum(variant) => variant,
-            PeekSummary::List(list) => format!("Count: {} items", list.len()),
-            PeekSummary::Map(entries) => format!("Keys: {} items", entries.len()),
-            PeekSummary::StructLike { class_name, fields } => {
-                format!("{class_name} ({} fields)", fields.len())
-            }
-            PeekSummary::Unknown(value) => format!("{}", value),
-        },
-    }
-}
-
-fn primitive_type_name_peek(value: Peek<'_, '_>) -> &'static str {
-    match summarize_peek(value) {
-        PeekSummary::None => "null",
-        PeekSummary::Media => "media",
-        PeekSummary::String(_) => "string",
-        PeekSummary::Bool(_) => "bool",
-        PeekSummary::SignedInt(_) | PeekSummary::UnsignedInt(_) => "int",
-        PeekSummary::Float(_) => "float",
-        PeekSummary::UnitEnum(_) => "enum",
-        PeekSummary::List(_) => "list",
-        PeekSummary::Map(_) => "map",
-        PeekSummary::StructLike { .. } => "class",
-        PeekSummary::Unknown(_) => "object",
-    }
-}
-
-fn peek_at_field_path<'mem, 'facet>(
-    root: Peek<'mem, 'facet>,
-    path: &FieldPath,
-) -> Option<Peek<'mem, 'facet>> {
-    let parts = path.iter().collect::<Vec<_>>();
-    let mut current = root.innermost_peek();
-    for (idx, part) in parts.iter().enumerate() {
-        let struct_peek = current.into_struct().ok()?;
-        let mut next = struct_peek.field_by_name(part).ok()?.innermost_peek();
-        if idx + 1 < parts.len()
-            && let Ok(opt) = next.into_option()
-        {
-            next = opt.value()?.innermost_peek();
-        }
-        current = next;
-    }
-    Some(current)
-}
-
-fn map_entries_for_preview<'mem, 'facet>(
-    map: bamltype::facet_reflect::PeekMap<'mem, 'facet>,
-) -> Vec<(String, Peek<'mem, 'facet>)> {
-    let mut entries = BTreeMap::new();
-    for (key, value) in map.iter() {
-        entries.insert(key_to_string(key), value);
-    }
-    entries.into_iter().collect()
-}
-
-fn struct_like_fields<'mem, 'facet>(
-    value: Peek<'mem, 'facet>,
-) -> Option<(String, Vec<(String, StructFieldValue<'mem, 'facet>)>)> {
-    let value = value.innermost_peek();
-
-    if let Ok(struct_peek) = value.into_struct() {
-        let class_name = bamltype::internal_name_for_shape(value.shape());
-        let fields = struct_peek
-            .fields_for_serialize()
-            .map(|(field_item, field_value)| {
-                (
-                    field_item.effective_name().to_string(),
-                    StructFieldValue::Peek(field_value),
-                )
-            })
-            .collect::<Vec<_>>();
-        return Some((class_name, fields));
-    }
-
-    if let Ok(enum_peek) = value.into_enum() {
-        if !enum_has_data_variants(value.shape()) {
-            return None;
-        }
-
-        let class_name = bamltype::internal_name_for_shape(value.shape());
-        let variant = enum_peek.active_variant().ok()?;
-        let mut fields = Vec::new();
-        let tag_name = value.shape().get_tag_attr().unwrap_or("type");
-        fields.push((
-            tag_name.to_string(),
-            StructFieldValue::String(variant.effective_name().to_string()),
-        ));
-        fields.extend(
-            enum_peek
-                .fields_for_serialize()
-                .map(|(field_item, field_value)| {
-                    (
-                        field_item.effective_name().to_string(),
-                        StructFieldValue::Peek(field_value),
-                    )
-                }),
-        );
-        return Some((class_name, fields));
-    }
-
-    None
-}
-
-fn row_for_field_stats<'mem, 'facet>(
-    value: Peek<'mem, 'facet>,
-) -> Option<BTreeMap<String, StructFieldValue<'mem, 'facet>>> {
-    if let Some((_, fields)) = struct_like_fields(value) {
-        let mut row = BTreeMap::new();
-        for (name, field_value) in fields {
-            row.insert(name, field_value);
-        }
-        return Some(row);
-    }
-
-    let map = value.innermost_peek().into_map().ok()?;
-    let mut row = BTreeMap::new();
-    for (key, value) in map.iter() {
-        row.insert(key_to_string(key), StructFieldValue::Peek(value));
-    }
-    Some(row)
-}
-
-fn unit_enum_variant(value: Peek<'_, '_>) -> Option<String> {
-    let value = value.innermost_peek();
-    let enum_peek = value.into_enum().ok()?;
-    if enum_has_data_variants(value.shape()) {
-        return None;
-    }
-    Some(
-        enum_peek
-            .active_variant()
-            .ok()?
-            .effective_name()
-            .to_string(),
-    )
-}
-
-fn is_media_shape(shape: &'static bamltype::facet::Shape) -> bool {
-    // TODO: Brittle - relies on type-name string matching. Replace with
-    // structural Facet type identity when available.
-    shape.type_identifier.ends_with("BamlMedia")
-        || shape.type_identifier.contains("::media::BamlMedia")
-}
-
-fn enum_has_data_variants(shape: &'static bamltype::facet::Shape) -> bool {
-    let Type::User(UserType::Enum(enum_type)) = &shape.ty else {
-        return false;
+        token.clear();
     };
-    enum_type
-        .variants
-        .iter()
-        .any(|variant| !variant.data.fields.is_empty())
-}
 
-fn key_to_string(key: Peek<'_, '_>) -> String {
-    if let Some(s) = key.as_str() {
-        return s.to_string();
-    }
-    if let Some(value) = peek_signed_i128(key) {
-        return value.to_string();
-    }
-    if let Some(value) = peek_unsigned_u128(key) {
-        return value.to_string();
-    }
-    if let Ok(value) = key.get::<bool>() {
-        return value.to_string();
-    }
-    format!("{key}")
-}
-
-fn peek_signed_i128(value: Peek<'_, '_>) -> Option<i128> {
-    if let Ok(v) = value.get::<i128>() {
-        return Some(*v);
-    }
-    if let Ok(v) = value.get::<i64>() {
-        return Some(*v as i128);
-    }
-    if let Ok(v) = value.get::<i32>() {
-        return Some(*v as i128);
-    }
-    if let Ok(v) = value.get::<i16>() {
-        return Some(*v as i128);
-    }
-    if let Ok(v) = value.get::<i8>() {
-        return Some(*v as i128);
-    }
-    if let Ok(v) = value.get::<isize>() {
-        return Some(*v as i128);
-    }
-    None
-}
-
-fn peek_unsigned_u128(value: Peek<'_, '_>) -> Option<u128> {
-    if let Ok(v) = value.get::<u128>() {
-        return Some(*v);
-    }
-    if let Ok(v) = value.get::<u64>() {
-        return Some(*v as u128);
-    }
-    if let Ok(v) = value.get::<u32>() {
-        return Some(*v as u128);
-    }
-    if let Ok(v) = value.get::<u16>() {
-        return Some(*v as u128);
-    }
-    if let Ok(v) = value.get::<u8>() {
-        return Some(*v as u128);
-    }
-    if let Ok(v) = value.get::<usize>() {
-        return Some(*v as u128);
-    }
-    None
-}
-
-fn collapse_option_chain<'mem, 'facet>(value: Peek<'mem, 'facet>) -> Option<Peek<'mem, 'facet>> {
-    let mut current = value.innermost_peek();
-    loop {
-        match current.into_option() {
-            Ok(option) => match option.value() {
-                Some(inner) => current = inner.innermost_peek(),
-                None => return None,
-            },
-            Err(_) => return Some(current),
+    for ch in raw.chars() {
+        if ch.is_ascii_alphanumeric() || ch == '_' || ch == ':' {
+            token.push(ch);
+        } else {
+            flush(&mut out, &mut token);
+            out.push(ch);
         }
     }
-}
-
-fn stride_sample(total: usize, target: usize) -> Vec<usize> {
-    if total <= target {
-        return (0..total).collect();
-    }
-
-    let step = total as f64 / target as f64;
-    let mut out = (0..target)
-        .map(|i| ((i as f64) * step).floor() as usize)
-        .collect::<Vec<_>>();
-
-    if let Some(last) = out.last_mut() {
-        *last = total - 1;
-    }
-
-    out.sort_unstable();
-    out.dedup();
+    flush(&mut out, &mut token);
     out
 }
 
-fn is_categorical_field(name: &str, unique: usize, present: usize) -> bool {
-    let lowered = name.to_ascii_lowercase();
-    if ["id", "type", "category", "status", "label"]
-        .iter()
-        .any(|token| lowered.contains(token))
-    {
-        return true;
-    }
-
-    unique <= 32 || (unique as f64 / present.max(1) as f64) <= 0.2
+fn enum_name(internal: &str, output_format: &OutputFormatContent) -> String {
+    output_format
+        .enums
+        .get(internal)
+        .map(|enm| enm.name.rendered_name().to_string())
+        .unwrap_or_else(|| short_name(internal))
 }
 
-fn number(value: f64) -> String {
-    if (value.fract()).abs() < f64::EPSILON {
-        format!("{value:.0}")
-    } else {
-        format!("{value:.3}")
+fn primitive_name(value: TypeValue) -> &'static str {
+    match value {
+        TypeValue::String => "string",
+        TypeValue::Int => "int",
+        TypeValue::Float => "float",
+        TypeValue::Bool => "bool",
+        TypeValue::Null => "null",
+        _ => "value",
     }
+}
+
+fn short_name(path: &str) -> String {
+    path.rsplit("::").next().unwrap_or(path).to_string()
+}
+
+fn normalize_doc_text(text: &str) -> String {
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn spaces(count: usize) -> String {
+    " ".repeat(count)
 }
 
 #[cfg(test)]
 mod tests {
-    use std::collections::{BTreeMap, HashMap};
+    use super::*;
+    use crate::BamlType;
+    use crate::Signature;
 
-    use crate::{BamlType, Signature};
-
-    use super::super::runtime::{MethodSignature, MethodSource};
-    use super::render_previews as render_previews_with_methods;
-
-    fn render_previews<S: Signature>(input: &S::Input) -> String
-    where
-        S::Input: BamlType + for<'a> crate::Facet<'a>,
-    {
-        render_previews_with_methods::<S>(input, &BTreeMap::new())
+    #[derive(Clone, Debug)]
+    #[BamlType]
+    struct PreviewAction {
+        /// Tool name.
+        name: String,
+        /// JSON arguments.
+        arguments: String,
+        /// Tool output.
+        result: Option<String>,
+        /// True if the tool errored.
+        is_error: bool,
     }
 
     #[derive(Clone, Debug)]
     #[BamlType]
-    struct Paper {
+    struct PreviewTurn {
+        /// User message that started this turn.
+        trigger: Option<String>,
+        /// Tool actions in this turn.
+        actions: Vec<PreviewAction>,
+    }
+
+    #[derive(Clone, Debug)]
+    #[BamlType]
+    struct PreviewSession {
+        /// First user message, truncated.
+        brief: Option<String>,
+        /// Turn sequence.
+        turns: Vec<PreviewTurn>,
+    }
+
+    #[derive(Clone, Debug)]
+    #[BamlType]
+    struct PreviewSessions {
+        /// Stored sessions.
+        items: Vec<PreviewSession>,
+    }
+
+    #[derive(Signature, Clone, Debug)]
+    struct PreviewSig {
+        #[input]
         title: String,
-        abstract_text: String,
-        year: i32,
-        category: String,
-        email: Option<String>,
-    }
-
-    #[derive(Clone, Debug)]
-    #[BamlType]
-    enum State {
-        Ready,
-        Failed,
-    }
-
-    #[derive(Clone, Debug)]
-    #[BamlType]
-    #[allow(
-        dead_code,
-        reason = "Payload fields are exercised via reflection in preview tests."
-    )]
-    enum ActionState {
-        Final { answer: String, confidence: i32 },
-        Retry { reason: String },
-    }
-
-    #[derive(Clone, Debug)]
-    #[BamlType]
-    struct RowWithNestedOptionals {
-        id: String,
-        attrs: Option<HashMap<String, Option<i32>>>,
-    }
-
-    #[derive(Clone, Debug)]
-    #[BamlType]
-    struct RowWithDoubleOptional {
-        id: String,
-        maybe_note: Option<Option<String>>,
-    }
-
-    #[derive(Clone, Debug)]
-    #[BamlType]
-    struct FlattenedNote {
-        reason: String,
-    }
-
-    #[derive(Signature, Clone, Debug)]
-    /// Scalar preview test.
-    struct ScalarSig {
-        #[input]
-        #[check("this != ''", label = "non_empty")]
-        text: String,
 
         #[input]
-        payload: String,
+        count: i64,
 
         #[output]
-        ok: bool,
-    }
-
-    #[derive(Signature, Clone, Debug)]
-    /// Collection preview test.
-    struct CollectionSig {
-        #[input]
-        papers: Vec<Paper>,
-
-        #[output]
-        ok: bool,
-    }
-
-    #[derive(Signature, Clone, Debug)]
-    /// Mixed preview test.
-    struct MixedSig {
-        #[input]
-        maybe_note: Option<String>,
-
-        #[input]
-        scores: HashMap<String, i32>,
-
-        #[input]
-        states: Vec<State>,
-
-        #[input]
-        nested: Vec<Vec<String>>,
-
-        #[output]
-        ok: bool,
-    }
-
-    #[derive(Signature, Clone, Debug)]
-    struct EnumPayloadSig {
-        #[input]
-        action: ActionState,
-
-        #[output]
-        ok: bool,
-    }
-
-    #[derive(Signature, Clone, Debug)]
-    struct NestedOptionalStatsSig {
-        #[input]
-        rows: Vec<RowWithNestedOptionals>,
-
-        #[output]
-        ok: bool,
-    }
-
-    #[derive(Signature, Clone, Debug)]
-    struct EmptyCollectionsSig {
-        #[input]
-        empty_list: Vec<String>,
-
-        #[input]
-        empty_map: HashMap<String, i32>,
-
-        #[input]
-        nested_empty: Vec<Vec<String>>,
-
-        #[output]
-        ok: bool,
-    }
-
-    #[derive(Signature, Clone, Debug)]
-    struct FlattenAliasSig {
-        #[input]
-        #[flatten]
-        inner: FlattenedNote,
-
-        #[input]
-        #[alias("topic_alias")]
-        topic: String,
-
-        #[output]
-        ok: bool,
-    }
-
-    #[derive(Signature, Clone, Debug)]
-    struct NestedOptionalSig {
-        #[input]
-        maybe_note: Option<Option<String>>,
-
-        #[output]
-        ok: bool,
-    }
-
-    #[derive(Signature, Clone, Debug)]
-    struct NestedOptionalStatsParitySig {
-        #[input]
-        rows: Vec<RowWithDoubleOptional>,
-
-        #[output]
-        ok: bool,
+        answer: String,
     }
 
     #[test]
-    fn scalar_preview_shows_truncation_json_and_constraints() {
-        let rendered = render_previews::<ScalarSig>(&ScalarSigInput {
-            text: "x".repeat(620),
-            payload: serde_json::json!({
-                "a": 1,
-                "b": [1, 2, 3],
-                "longer_payload_to_force_json_detection": "abcdefghijklmnopqrstuvwxyz"
-            })
-            .to_string(),
-        });
+    fn primitive_inputs_are_skipped() {
+        let input = PreviewSigInput {
+            title: "x".to_string(),
+            count: 3,
+        };
+        let rendered = render_previews::<PreviewSig>(&input, &BTreeMap::new());
+        assert!(rendered.contains("(No complex input variables.)"));
+    }
 
-        assert!(rendered.contains("Constraint: soft non_empty"));
-        assert!(rendered.contains("Length: 620 chars"));
-        assert!(rendered.contains("chars omitted"));
-        assert!(
-            rendered.contains("(JSON String) object keys")
-                || rendered.contains("(JSON String)")
-                || rendered.contains("object keys")
-        );
-        assert!(rendered.contains("## Expected Output"));
+    #[derive(Signature, Clone, Debug)]
+    struct RichPreviewSig {
+        #[input]
+        /// Turn-level trajectories for each development session.
+        sessions: PreviewSessions,
+
+        #[output]
+        answer: String,
     }
 
     #[test]
-    fn collection_preview_shows_samples_and_field_stats() {
-        let papers = (0..2_101)
-            .map(|idx| Paper {
-                title: format!("paper-{idx}"),
-                abstract_text: "z".repeat(180 + (idx % 20) as usize),
-                year: 2020 + (idx % 5),
-                category: format!("cat-{}", idx % 7),
-                email: (idx % 3 == 0).then(|| format!("author{idx}@example.com")),
-            })
-            .collect::<Vec<_>>();
-
-        let rendered = render_previews::<CollectionSig>(&CollectionSigInput { papers });
-
-        assert!(rendered.contains("Count: 2101 items"));
-        assert!(rendered.contains("Field stats:"));
-        assert!(rendered.contains("(sampled"));
-        assert!(rendered.contains("Sample [0]:"));
-        assert!(rendered.contains("Sample [1050]:"));
-        assert!(rendered.contains("Sample [2100]:"));
-    }
-
-    #[test]
-    fn mixed_preview_shows_optional_map_enum_and_nested_depth_rules() {
-        let mut scores = HashMap::new();
-        scores.insert("zeta".to_string(), 9);
-        scores.insert("alpha".to_string(), 1);
-        scores.insert("middle".to_string(), 5);
-        scores.insert("omega".to_string(), 7);
-
-        let rendered = render_previews::<MixedSig>(&MixedSigInput {
-            maybe_note: None,
-            scores,
-            states: vec![State::Ready, State::Failed, State::Ready],
-            nested: vec![
-                vec!["a".to_string(), "b".to_string()],
-                vec!["c".to_string(), "d".to_string()],
-                vec!["e".to_string(), "f".to_string()],
+    fn schema_rendering_has_methods_shape_comments_and_nested_lists() {
+        let input = RichPreviewSigInput {
+            sessions: PreviewSessions {
+                items: vec![PreviewSession {
+                    brief: Some("Investigate signal drop".to_string()),
+                    turns: vec![PreviewTurn {
+                        trigger: Some("start".to_string()),
+                        actions: vec![PreviewAction {
+                            name: "search".to_string(),
+                            arguments: "{\"q\":\"start\"}".to_string(),
+                            result: Some("ok".to_string()),
+                            is_error: false,
+                        }],
+                    }],
+                }],
+            },
+        };
+        let methods = BTreeMap::from([(
+            "sessions".to_string(),
+            vec![
+                MethodSignature {
+                    name: "search".to_string(),
+                    signature: "(query)".to_string(),
+                    doc: "Find matching sessions.".to_string(),
+                    source: super::super::runtime::MethodSource::Custom,
+                    is_dunder: false,
+                },
+                MethodSignature {
+                    name: "hidden".to_string(),
+                    signature: "()".to_string(),
+                    doc: "".to_string(),
+                    source: super::super::runtime::MethodSource::Custom,
+                    is_dunder: false,
+                },
             ],
-        });
+        )]);
 
-        assert!(rendered.contains("maybe_note"));
-        assert!(rendered.contains("None"));
-        assert!(rendered.contains("Keys: 4 items"));
-        assert!(rendered.contains("Sample [\"alpha\"]"));
-        assert!(rendered.contains("Sample [\"omega\"]"));
-        assert!(rendered.contains("Distribution:"));
-        assert!(rendered.contains("Ready: 2"));
-        assert!(rendered.contains("Count: 3 items"));
-    }
-
-    #[test]
-    fn method_preview_renders_custom_methods_before_dunders() {
-        let rendered = render_previews_with_methods::<ScalarSig>(
-            &ScalarSigInput {
-                text: "hello".to_string(),
-                payload: "{}".to_string(),
-            },
-            &BTreeMap::from([(
-                "text".to_string(),
-                vec![
-                    MethodSignature {
-                        name: "__len__".to_string(),
-                        signature: "()".to_string(),
-                        doc: "Length of this value.".to_string(),
-                        source: MethodSource::Generated,
-                        is_dunder: true,
-                    },
-                    MethodSignature {
-                        name: "search".to_string(),
-                        signature: "(query: str) -> list[Step]".to_string(),
-                        doc: "Search matching entries.".to_string(),
-                        source: MethodSource::Custom,
-                        is_dunder: false,
-                    },
-                ],
-            )]),
-        );
-
-        let search = rendered.find(".search(").expect("search should be visible");
-        let dunder_len = rendered
-            .find(".__len__()")
-            .expect("__len__ should be visible");
-        assert!(search < dunder_len);
-        assert!(rendered.contains("Methods:"));
-    }
-
-    #[test]
-    fn method_preview_truncates_and_reports_remaining_methods() {
-        let methods = (0..7)
-            .rev()
-            .map(|idx| MethodSignature {
-                name: format!("m{idx}"),
-                signature: "()".to_string(),
-                doc: format!(
-                    "Long description for method {idx}. This should truncate to keep preview compact."
-                ),
-                source: MethodSource::Custom,
-                is_dunder: false,
-            })
-            .collect::<Vec<_>>();
-
-        let rendered = render_previews_with_methods::<ScalarSig>(
-            &ScalarSigInput {
-                text: "hello".to_string(),
-                payload: "{}".to_string(),
-            },
-            &BTreeMap::from([("text".to_string(), methods)]),
-        );
-
-        assert!(rendered.contains(".m0()"));
-        assert!(rendered.contains(".m4()"));
-        assert!(!rendered.contains(".m5()"));
-        assert!(rendered.contains("... (2 more methods; use help(text) for full list)"));
-    }
-
-    #[test]
-    fn enum_payload_variant_renders_as_struct_like_preview() {
-        let rendered = render_previews::<EnumPayloadSig>(&EnumPayloadSigInput {
-            action: ActionState::Final {
-                answer: "ship it".to_string(),
-                confidence: 9,
-            },
-        });
-
-        assert!(rendered.contains("action:"));
-        assert!(rendered.contains("Preview:"));
-        assert!(rendered.contains("type: \"Final\""));
-        assert!(rendered.contains("answer: \"ship it\""));
-        assert!(rendered.contains("confidence: 9"));
-    }
-
-    #[test]
-    fn vec_struct_field_stats_handles_nested_optional_map_values() {
-        let rows = vec![
-            RowWithNestedOptionals {
-                id: "row-a".to_string(),
-                attrs: Some(HashMap::from([
-                    ("x".to_string(), Some(1)),
-                    ("y".to_string(), None),
-                ])),
-            },
-            RowWithNestedOptionals {
-                id: "row-b".to_string(),
-                attrs: None,
-            },
-            RowWithNestedOptionals {
-                id: "row-c".to_string(),
-                attrs: Some(HashMap::from([("z".to_string(), Some(3))])),
-            },
-        ];
-
-        let rendered =
-            render_previews::<NestedOptionalStatsSig>(&NestedOptionalStatsSigInput { rows });
-
-        assert!(rendered.contains("Count: 3 items"));
-        assert!(rendered.contains("Field stats:"));
-        assert!(rendered.contains("id:"));
-        assert!(rendered.contains("Sample [0]:"));
-    }
-
-    #[test]
-    fn empty_collections_keep_counts_without_samples() {
-        let rendered = render_previews::<EmptyCollectionsSig>(&EmptyCollectionsSigInput {
-            empty_list: Vec::new(),
-            empty_map: HashMap::new(),
-            nested_empty: vec![Vec::new()],
-        });
-
-        assert!(rendered.contains("empty_list"));
-        assert!(rendered.contains("Count: 0 items"));
-        assert!(rendered.contains("empty_map"));
-        assert!(rendered.contains("Keys: 0 items"));
-        assert!(rendered.contains("nested_empty"));
-        assert!(rendered.contains("Sample [0]: Count: 0 items"));
-        assert!(!rendered.contains("Sample [\""));
-    }
-
-    #[test]
-    fn map_samples_are_deterministically_sorted_under_peek() {
-        let mut scores = HashMap::new();
-        scores.insert("zeta".to_string(), 9);
-        scores.insert("alpha".to_string(), 1);
-        scores.insert("middle".to_string(), 5);
-        scores.insert("omega".to_string(), 7);
-
-        let rendered = render_previews::<MixedSig>(&MixedSigInput {
-            maybe_note: Some("note".to_string()),
-            scores,
-            states: vec![State::Ready],
-            nested: vec![vec!["a".to_string()]],
-        });
-
-        let alpha = rendered
-            .find("Sample [\"alpha\"]")
-            .expect("alpha sample must be present");
-        let omega = rendered
-            .find("Sample [\"omega\"]")
-            .expect("omega sample must be present");
-        let zeta = rendered
-            .find("Sample [\"zeta\"]")
-            .expect("zeta sample must be present");
-
+        let rendered = render_previews::<RichPreviewSig>(&input, &methods);
+        assert!(rendered.contains("Variable: `sessions` (access it in your code)"));
+        assert!(rendered.contains("Type: PreviewSessions"));
         assert!(
-            alpha < omega && omega < zeta,
-            "map key order is not deterministic:\n{rendered}"
+            rendered.contains("Description: Turn-level trajectories for each development session.")
         );
-    }
-
-    #[test]
-    fn flattened_alias_field_path_resolves_value_under_peek() {
-        let rendered = render_previews::<FlattenAliasSig>(&FlattenAliasSigInput {
-            inner: FlattenedNote {
-                reason: "because evidence".to_string(),
-            },
-            topic: "biology".to_string(),
-        });
-
-        assert!(rendered.contains("reason: string"));
-        assert!(rendered.contains("Value: \"because evidence\""));
-        assert!(rendered.contains("topic_alias: string"));
-        assert!(rendered.contains("Value: \"biology\""));
-        assert!(!rendered.contains("<missing>"));
-    }
-
-    #[test]
-    fn nested_optional_some_none_renders_none_without_present_prefix() {
-        let rendered = render_previews::<NestedOptionalSig>(&NestedOptionalSigInput {
-            maybe_note: Some(None),
-        });
-
-        assert!(rendered.contains("maybe_note"));
-        assert!(rendered.contains("None"));
-        assert!(!rendered.contains("(Present) None"));
-    }
-
-    #[test]
-    fn nested_optional_some_none_counts_as_null_in_field_stats() {
-        let rows = vec![
-            RowWithDoubleOptional {
-                id: "r1".to_string(),
-                maybe_note: Some(None),
-            },
-            RowWithDoubleOptional {
-                id: "r2".to_string(),
-                maybe_note: None,
-            },
-            RowWithDoubleOptional {
-                id: "r3".to_string(),
-                maybe_note: Some(Some("x".to_string())),
-            },
-        ];
-
-        let rendered =
-            render_previews::<NestedOptionalStatsParitySig>(&NestedOptionalStatsParitySigInput {
-                rows,
-            });
-
-        assert!(rendered.contains("Field stats:"));
-        assert!(rendered.contains("maybe_note:"));
-        assert!(rendered.contains("67% null"));
+        assert!(rendered.contains("// methods"));
+        assert!(rendered.contains(".search(query) // Find matching sessions."));
+        assert!(!rendered.contains(".hidden()"));
+        assert!(rendered.contains("// shape"));
+        assert!(rendered.contains("items: list[ // Stored sessions."));
+        assert!(rendered.contains("brief: string | null // First user message, truncated."));
+        assert!(rendered.contains("turns: list[ // Turn sequence."));
+        assert!(rendered.contains("PreviewTurn {"));
+        assert!(rendered.contains("actions: list[ // Tool actions in this turn."));
+        assert!(rendered.contains("PreviewAction {"));
+        assert!(rendered.contains("name: string // Tool name."));
+        assert!(rendered.contains("arguments: string // JSON arguments."));
+        assert!(rendered.contains("result: string | null // Tool output."));
+        assert!(rendered.contains("is_error: bool // True if the tool errored."));
+        assert!(
+            rendered.contains("trigger: string | null // User message that started this turn.")
+        );
+        assert!(!rendered.contains("Vec<"));
+        assert!(!rendered.contains("String"));
+        assert!(!rendered.contains("i64"));
+        assert!(!rendered.contains("$self"));
     }
 }

--- a/crates/dspy-rs/src/modules/rlm/previews.rs
+++ b/crates/dspy-rs/src/modules/rlm/previews.rs
@@ -1,11 +1,12 @@
 use std::collections::{BTreeMap, BTreeSet};
 
+use bamltype::baml_types::TypeIR;
 use bamltype::baml_types::ir_type::{TypeGeneric, UnionTypeViewGeneric};
-use bamltype::baml_types::{BamlMap, TypeIR};
+use bamltype::facet::{Type, UserType};
+use bamltype::facet_reflect::{HasFields, Peek};
 
 use crate::{
-    BamlType, BamlValue, ConstraintKind, Facet, FieldSchema, OutputFormatContent, Signature,
-    SignatureSchema,
+    BamlType, ConstraintKind, Facet, FieldPath, OutputFormatContent, Signature, SignatureSchema,
 };
 
 const TOP_LEVEL_STRING_LIMIT: usize = 500;
@@ -54,7 +55,7 @@ where
     S::Input: BamlType + for<'a> Facet<'a>,
 {
     let schema = SignatureSchema::of::<S>();
-    let root = input.to_baml_value();
+    let root = Peek::new(input);
     let input_format = <S::Input as BamlType>::baml_output_format();
 
     let budgets = [
@@ -64,7 +65,7 @@ where
     ];
 
     for budget in budgets {
-        let rendered = render_with_budget(schema, &root, input_format, budget);
+        let rendered = render_with_budget(schema, root, input_format, budget);
         if rendered.chars().count() <= SOFT_PREVIEW_BUDGET || !budget.include_middle_samples {
             return rendered;
         }
@@ -75,7 +76,7 @@ where
 
 fn render_with_budget(
     schema: &SignatureSchema,
-    root: &BamlValue,
+    root: Peek<'_, '_>,
     input_format: &OutputFormatContent,
     budget: RenderBudget,
 ) -> String {
@@ -103,10 +104,8 @@ fn render_with_budget(
             ));
         }
 
-        if let Some(value) = schema.navigate_field(field.path(), root) {
-            for line in
-                render_value_block(value, Some(&field.type_ir), field, input_format, 0, budget)
-            {
+        if let Some(value) = peek_at_field_path(root, field.path()) {
+            for line in render_value_block(value, Some(&field.type_ir), input_format, 0, budget) {
                 lines.push(format!("  {line}"));
             }
         } else {
@@ -133,46 +132,121 @@ fn render_with_budget(
 }
 
 fn render_value_block(
-    value: &BamlValue,
+    value: Peek<'_, '_>,
     type_ir: Option<&TypeIR>,
-    field: &FieldSchema,
     input_format: &OutputFormatContent,
     depth: usize,
     budget: RenderBudget,
 ) -> Vec<String> {
     if let Some(inner) = optional_inner(type_ir) {
-        if matches!(value, BamlValue::Null) {
-            return vec!["None".to_string()];
+        return match summarize_peek(value) {
+            PeekSummary::None => vec!["None".to_string()],
+            summary => {
+                let mut lines = vec!["(Present)".to_string()];
+                lines.extend(render_value_block_from_summary(
+                    summary,
+                    Some(inner),
+                    input_format,
+                    depth,
+                    budget,
+                ));
+                lines
+            }
+        };
+    }
+    render_value_block_from_summary(summarize_peek(value), type_ir, input_format, depth, budget)
+}
+
+#[derive(Clone)]
+enum StructFieldValue<'mem, 'facet> {
+    Peek(Peek<'mem, 'facet>),
+    String(String),
+}
+
+enum PeekSummary<'mem, 'facet> {
+    None,
+    String(&'mem str),
+    Bool(bool),
+    SignedInt(i128),
+    UnsignedInt(u128),
+    Float(f64),
+    UnitEnum(String),
+    List(bamltype::facet_reflect::PeekListLike<'mem, 'facet>),
+    Map(Vec<(String, Peek<'mem, 'facet>)>),
+    StructLike {
+        class_name: String,
+        fields: Vec<(String, StructFieldValue<'mem, 'facet>)>,
+    },
+    Unknown(Peek<'mem, 'facet>),
+}
+
+fn summarize_peek<'mem, 'facet>(value: Peek<'mem, 'facet>) -> PeekSummary<'mem, 'facet> {
+    let Some(value) = collapse_option_chain(value) else {
+        return PeekSummary::None;
+    };
+
+    if let Some(text) = value.as_str() {
+        return PeekSummary::String(text);
+    }
+    if let Ok(v) = value.get::<bool>() {
+        return PeekSummary::Bool(*v);
+    }
+    if let Some(v) = peek_signed_i128(value) {
+        return PeekSummary::SignedInt(v);
+    }
+    if let Some(v) = peek_unsigned_u128(value) {
+        return PeekSummary::UnsignedInt(v);
+    }
+    if let Ok(v) = value.get::<f64>() {
+        return PeekSummary::Float(*v);
+    }
+    if let Ok(v) = value.get::<f32>() {
+        return PeekSummary::Float(*v as f64);
+    }
+    if let Some(v) = unit_enum_variant(value) {
+        return PeekSummary::UnitEnum(v);
+    }
+    if let Ok(list) = value.into_list_like() {
+        return PeekSummary::List(list);
+    }
+    if let Ok(map) = value.into_map() {
+        return PeekSummary::Map(map_entries_for_preview(map));
+    }
+    if let Some((class_name, fields)) = struct_like_fields(value) {
+        return PeekSummary::StructLike { class_name, fields };
+    }
+    PeekSummary::Unknown(value)
+}
+
+fn render_value_block_from_summary(
+    summary: PeekSummary<'_, '_>,
+    type_ir: Option<&TypeIR>,
+    input_format: &OutputFormatContent,
+    depth: usize,
+    budget: RenderBudget,
+) -> Vec<String> {
+    match summary {
+        PeekSummary::None => vec!["None".to_string()],
+        PeekSummary::String(text) => render_string_block(text, depth > 0, budget),
+        PeekSummary::Bool(v) => vec![format!("Value: {v}")],
+        PeekSummary::SignedInt(v) => vec![format!("Value: {v}")],
+        PeekSummary::UnsignedInt(v) => vec![format!("Value: {v}")],
+        PeekSummary::Float(v) => vec![format!("Value: {v}")],
+        PeekSummary::UnitEnum(variant) => vec![format!("Variant: {variant}")],
+        PeekSummary::List(list) => {
+            render_list_block(&list, item_type(type_ir), input_format, depth, budget)
         }
-        let mut lines = vec!["(Present)".to_string()];
-        lines.extend(render_value_block(
-            value,
-            Some(inner),
-            field,
+        PeekSummary::Map(entries) => render_map_block(
+            &entries,
+            map_value_type(type_ir),
             input_format,
             depth,
             budget,
-        ));
-        return lines;
-    }
-
-    match value {
-        BamlValue::String(text) => render_string_block(text, depth > 0, budget),
-        BamlValue::Int(v) => vec![format!("Value: {v}")],
-        BamlValue::Float(v) => vec![format!("Value: {v}")],
-        BamlValue::Bool(v) => vec![format!("Value: {v}")],
-        BamlValue::Null => vec!["None".to_string()],
-        BamlValue::Enum(_, variant) => vec![format!("Variant: {variant}")],
-        BamlValue::Media(_) => vec!["Media (preview omitted)".to_string()],
-        BamlValue::List(items) => {
-            render_list_block(items, item_type(type_ir), input_format, depth, budget)
+        ),
+        PeekSummary::StructLike { class_name, fields } => {
+            render_struct_block(&class_name, &fields, type_ir, input_format, depth, budget)
         }
-        BamlValue::Map(map) => {
-            render_map_block(map, map_value_type(type_ir), input_format, depth, budget)
-        }
-        BamlValue::Class(class_name, fields) => {
-            render_struct_block(class_name, fields, type_ir, input_format, depth, budget)
-        }
+        PeekSummary::Unknown(value) => vec![format!("Value: {}", value)],
     }
 }
 
@@ -185,10 +259,10 @@ fn render_string_block(text: &str, nested: bool, budget: RenderBudget) -> Vec<St
     let lines = text.lines().count().max(1);
     let mut out = vec![format!("Length: {len} chars, Lines: {lines}")];
 
-    if len > 50 {
-        if let Some(summary) = summarize_json_string(text) {
-            out.push(format!("(JSON String) {summary}"));
-        }
+    if len > 50
+        && let Some(summary) = summarize_json_string(text)
+    {
+        out.push(format!("(JSON String) {summary}"));
     }
 
     out.push(format!(
@@ -199,7 +273,7 @@ fn render_string_block(text: &str, nested: bool, budget: RenderBudget) -> Vec<St
 }
 
 fn render_list_block(
-    items: &[BamlValue],
+    items: &bamltype::facet_reflect::PeekListLike<'_, '_>,
     item_type: Option<&TypeIR>,
     input_format: &OutputFormatContent,
     depth: usize,
@@ -211,11 +285,13 @@ fn render_list_block(
         lines.push(format!("Schema: {schema_line}"));
     }
 
-    if let Some(distribution) = scalar_distribution(items) {
+    let sample = items.iter().collect::<Vec<_>>();
+
+    if let Some(distribution) = scalar_distribution(&sample) {
         lines.push(format!("Distribution: {distribution}"));
     }
 
-    if let Some(stats) = compute_field_stats(items) {
+    if let Some(stats) = compute_field_stats(&sample) {
         lines.push(format!("Field stats: {}", stats.summary));
         if let Some(note) = stats.sampling_note {
             lines.push(note);
@@ -227,34 +303,31 @@ fn render_list_block(
     }
 
     for idx in sample_indices(items.len(), depth, budget.include_middle_samples) {
-        let rendered = render_inline_value(&items[idx], item_type, input_format, depth + 1, budget);
-        lines.push(format!("Sample [{idx}]: {rendered}"));
+        if let Some(item) = items.get(idx) {
+            let rendered = render_inline_value(item, item_type, input_format, depth + 1, budget);
+            lines.push(format!("Sample [{idx}]: {rendered}"));
+        }
     }
 
     lines
 }
 
 fn render_map_block(
-    map: &BamlMap<String, BamlValue>,
+    entries: &[(String, Peek<'_, '_>)],
     value_type: Option<&TypeIR>,
     input_format: &OutputFormatContent,
     depth: usize,
     budget: RenderBudget,
 ) -> Vec<String> {
-    let mut lines = vec![format!("Keys: {} items", map.len())];
-    if map.is_empty() || depth >= STRUCT_PREVIEW_DEPTH_CAP {
+    let mut lines = vec![format!("Keys: {} items", entries.len())];
+    if entries.is_empty() || depth >= STRUCT_PREVIEW_DEPTH_CAP {
         return lines;
     }
 
-    let mut keys = map.keys().collect::<Vec<_>>();
-    keys.sort_unstable();
-
-    for idx in sample_indices(keys.len(), depth, budget.include_middle_samples) {
-        let key = keys[idx];
-        if let Some(value) = map.get(key) {
-            let rendered = render_inline_value(value, value_type, input_format, depth + 1, budget);
-            lines.push(format!("Sample [{key:?}]: {rendered}"));
-        }
+    for idx in sample_indices(entries.len(), depth, budget.include_middle_samples) {
+        let (key, value) = &entries[idx];
+        let rendered = render_inline_value(*value, value_type, input_format, depth + 1, budget);
+        lines.push(format!("Sample [{key:?}]: {rendered}"));
     }
 
     lines
@@ -262,7 +335,7 @@ fn render_map_block(
 
 fn render_struct_block(
     class_name: &str,
-    fields: &BamlMap<String, BamlValue>,
+    fields: &[(String, StructFieldValue<'_, '_>)],
     type_ir: Option<&TypeIR>,
     input_format: &OutputFormatContent,
     depth: usize,
@@ -287,86 +360,93 @@ fn render_struct_block(
 }
 
 fn render_inline_value(
-    value: &BamlValue,
+    value: Peek<'_, '_>,
     type_ir: Option<&TypeIR>,
     input_format: &OutputFormatContent,
     depth: usize,
     budget: RenderBudget,
 ) -> String {
     if let Some(inner) = optional_inner(type_ir) {
-        return if matches!(value, BamlValue::Null) {
-            "None".to_string()
-        } else {
-            format!(
+        return match summarize_peek(value) {
+            PeekSummary::None => "None".to_string(),
+            summary => format!(
                 "(Present) {}",
-                render_inline_value(value, Some(inner), input_format, depth, budget)
-            )
+                render_inline_value_from_summary(summary, Some(inner), input_format, depth, budget)
+            ),
         };
     }
+    render_inline_value_from_summary(summarize_peek(value), type_ir, input_format, depth, budget)
+}
 
-    match value {
-        BamlValue::String(text) => truncate_string(text, budget.nested_limit),
-        BamlValue::Int(v) => v.to_string(),
-        BamlValue::Float(v) => v.to_string(),
-        BamlValue::Bool(v) => v.to_string(),
-        BamlValue::Null => "None".to_string(),
-        BamlValue::Enum(_, variant) => variant.to_string(),
-        BamlValue::Media(_) => "Media".to_string(),
-        BamlValue::List(items) => {
+fn render_inline_value_from_summary(
+    summary: PeekSummary<'_, '_>,
+    type_ir: Option<&TypeIR>,
+    input_format: &OutputFormatContent,
+    depth: usize,
+    budget: RenderBudget,
+) -> String {
+    match summary {
+        PeekSummary::None => "None".to_string(),
+        PeekSummary::String(text) => truncate_string(text, budget.nested_limit),
+        PeekSummary::Bool(v) => v.to_string(),
+        PeekSummary::SignedInt(v) => v.to_string(),
+        PeekSummary::UnsignedInt(v) => v.to_string(),
+        PeekSummary::Float(v) => v.to_string(),
+        PeekSummary::UnitEnum(variant) => variant,
+        PeekSummary::List(list) => {
             if depth >= STRUCT_PREVIEW_DEPTH_CAP {
-                return format!("Count: {} items", items.len());
+                return format!("Count: {} items", list.len());
             }
-            let idxs = sample_indices(items.len(), depth, budget.include_middle_samples);
+            let idxs = sample_indices(list.len(), depth, budget.include_middle_samples);
             let inner = item_type(type_ir);
             if idxs.is_empty() {
                 return "Count: 0 items".to_string();
             }
             let samples = idxs
                 .iter()
-                .map(|idx| {
-                    format!(
-                        "sample[{idx}]={}",
-                        render_inline_value(&items[*idx], inner, input_format, depth + 1, budget,)
-                    )
-                })
-                .collect::<Vec<_>>()
-                .join(", ");
-            format!("Count: {} items; {samples}", items.len())
-        }
-        BamlValue::Map(map) => {
-            if depth >= STRUCT_PREVIEW_DEPTH_CAP {
-                return format!("Keys: {} items", map.len());
-            }
-            let mut keys = map.keys().collect::<Vec<_>>();
-            keys.sort_unstable();
-            let value_type = map_value_type(type_ir);
-            let pairs = sample_indices(keys.len(), depth, budget.include_middle_samples)
-                .into_iter()
                 .filter_map(|idx| {
-                    let key = keys[idx];
-                    map.get(key).map(|entry| {
+                    list.get(*idx).map(|item| {
                         format!(
-                            "{key:?}: {}",
-                            render_inline_value(entry, value_type, input_format, depth + 1, budget,)
+                            "sample[{idx}]={}",
+                            render_inline_value(item, inner, input_format, depth + 1, budget)
                         )
                     })
                 })
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("Count: {} items; {samples}", list.len())
+        }
+        PeekSummary::Map(entries) => {
+            if depth >= STRUCT_PREVIEW_DEPTH_CAP {
+                return format!("Keys: {} items", entries.len());
+            }
+            let value_type = map_value_type(type_ir);
+            let pairs = sample_indices(entries.len(), depth, budget.include_middle_samples)
+                .into_iter()
+                .map(|idx| {
+                    let (key, entry) = &entries[idx];
+                    format!(
+                        "{key:?}: {}",
+                        render_inline_value(*entry, value_type, input_format, depth + 1, budget)
+                    )
+                })
                 .collect::<Vec<_>>();
             if pairs.is_empty() {
-                format!("Keys: {} items", map.len())
+                format!("Keys: {} items", entries.len())
             } else {
-                format!("Keys: {} items; {}", map.len(), pairs.join(", "))
+                format!("Keys: {} items; {}", entries.len(), pairs.join(", "))
             }
         }
-        BamlValue::Class(class_name, fields) => {
-            render_inline_struct(class_name, fields, type_ir, input_format, depth, budget)
+        PeekSummary::StructLike { class_name, fields } => {
+            render_inline_struct(&class_name, &fields, type_ir, input_format, depth, budget)
         }
+        PeekSummary::Unknown(value) => format!("{}", value),
     }
 }
 
 fn render_inline_struct(
     class_name: &str,
-    fields: &BamlMap<String, BamlValue>,
+    fields: &[(String, StructFieldValue<'_, '_>)],
     type_ir: Option<&TypeIR>,
     input_format: &OutputFormatContent,
     depth: usize,
@@ -379,27 +459,11 @@ fn render_inline_struct(
     let ordered = ordered_struct_fields(fields, type_ir, input_format);
     let mut parts = Vec::new();
 
-    for (idx, (name, value, child_ty)) in ordered.into_iter().enumerate() {
+    for (idx, (name, value, _child_ty)) in ordered.into_iter().enumerate() {
         if idx >= STRUCT_PREVIEW_BREADTH_CAP {
             break;
         }
-        let rendered = match value {
-            BamlValue::String(text) => truncate_string(text, budget.nested_limit),
-            BamlValue::Int(v) => v.to_string(),
-            BamlValue::Float(v) => v.to_string(),
-            BamlValue::Bool(v) => v.to_string(),
-            BamlValue::Null => "None".to_string(),
-            BamlValue::Enum(_, variant) => variant.to_string(),
-            BamlValue::Media(_) => "Media".to_string(),
-            BamlValue::List(items) => format!("Count: {} items", items.len()),
-            BamlValue::Map(map) => format!("Keys: {} items", map.len()),
-            BamlValue::Class(inner_name, inner_fields) => {
-                let _ = child_ty;
-                let _ = input_format;
-                let _ = budget;
-                format!("{inner_name} ({} fields)", inner_fields.len())
-            }
-        };
+        let rendered = render_inline_field_value(value, budget);
         parts.push(format!("{name}: {rendered}"));
     }
 
@@ -413,31 +477,35 @@ fn render_inline_struct(
     format!("{class_name} {{ {} }}", parts.join(", "))
 }
 
-fn ordered_struct_fields<'a>(
-    fields: &'a BamlMap<String, BamlValue>,
+fn ordered_struct_fields<'a, 'mem, 'facet>(
+    fields: &'a [(String, StructFieldValue<'mem, 'facet>)],
     type_ir: Option<&'a TypeIR>,
     input_format: &'a OutputFormatContent,
-) -> Vec<(&'a str, &'a BamlValue, Option<&'a TypeIR>)> {
-    if let Some((class_name, mode)) = class_type_ref(type_ir) {
-        if let Some(class) = input_format.classes.get(&(class_name.to_string(), mode)) {
-            let mut ordered = Vec::new();
-            for (field_name, field_ty, _, _) in &class.fields {
-                let key = field_name.real_name();
-                if let Some(value) = fields.get(key) {
-                    ordered.push((key, value, Some(field_ty)));
-                }
+) -> Vec<(
+    &'a str,
+    &'a StructFieldValue<'mem, 'facet>,
+    Option<&'a TypeIR>,
+)> {
+    if let Some((class_name, mode)) = class_type_ref(type_ir)
+        && let Some(class) = input_format.classes.get(&(class_name.to_string(), mode))
+    {
+        let mut ordered = Vec::new();
+        for (field_name, field_ty, _, _) in &class.fields {
+            let key = field_name.real_name();
+            if let Some((_, value)) = fields.iter().find(|(name, _)| name == key) {
+                ordered.push((key, value, Some(field_ty)));
             }
-
-            for (key, value) in fields {
-                if !ordered
-                    .iter()
-                    .any(|(existing, _, _)| *existing == key.as_str())
-                {
-                    ordered.push((key.as_str(), value, None));
-                }
-            }
-            return ordered;
         }
+
+        for (key, value) in fields {
+            if !ordered
+                .iter()
+                .any(|(existing, _, _)| *existing == key.as_str())
+            {
+                ordered.push((key.as_str(), value, None));
+            }
+        }
+        return ordered;
     }
 
     let mut fallback = fields
@@ -478,41 +546,38 @@ fn class_schema_line(
     Some(format!("{{ {} }}", fields.join(", ")))
 }
 
-fn fallback_schema(fields: &BamlMap<String, BamlValue>) -> String {
-    let mut keys = fields.keys().collect::<Vec<_>>();
+fn fallback_schema(fields: &[(String, StructFieldValue<'_, '_>)]) -> String {
+    let mut keys = fields
+        .iter()
+        .map(|(key, _)| key.as_str())
+        .collect::<Vec<_>>();
     keys.sort_unstable();
     let mut parts = keys
         .iter()
         .take(STRUCT_PREVIEW_BREADTH_CAP)
         .filter_map(|key| {
             fields
-                .get(*key)
+                .iter()
+                .find(|(name, _)| name == key)
+                .map(|(_, value)| value)
                 .map(|value| format!("{key}: {}", primitive_type_name(value)))
         })
         .collect::<Vec<_>>();
 
-    if fields.len() > STRUCT_PREVIEW_BREADTH_CAP {
+    if keys.len() > STRUCT_PREVIEW_BREADTH_CAP {
         parts.push(format!(
             "... (+{} fields)",
-            fields.len() - STRUCT_PREVIEW_BREADTH_CAP
+            keys.len() - STRUCT_PREVIEW_BREADTH_CAP
         ));
     }
 
     format!("{{ {} }}", parts.join(", "))
 }
 
-fn primitive_type_name(value: &BamlValue) -> &'static str {
+fn primitive_type_name(value: &StructFieldValue<'_, '_>) -> &'static str {
     match value {
-        BamlValue::String(_) => "string",
-        BamlValue::Int(_) => "int",
-        BamlValue::Float(_) => "float",
-        BamlValue::Bool(_) => "bool",
-        BamlValue::Map(_) => "map",
-        BamlValue::List(_) => "list",
-        BamlValue::Media(_) => "media",
-        BamlValue::Enum(_, _) => "enum",
-        BamlValue::Class(_, _) => "class",
-        BamlValue::Null => "null",
+        StructFieldValue::String(_) => "string",
+        StructFieldValue::Peek(value) => primitive_type_name_peek(*value),
     }
 }
 
@@ -642,7 +707,7 @@ fn json_value_name(value: &serde_json::Value) -> &'static str {
     }
 }
 
-fn scalar_distribution(items: &[BamlValue]) -> Option<String> {
+fn scalar_distribution(items: &[Peek<'_, '_>]) -> Option<String> {
     if items.is_empty() {
         return None;
     }
@@ -653,12 +718,13 @@ fn scalar_distribution(items: &[BamlValue]) -> Option<String> {
     let mut variants: BTreeMap<String, usize> = BTreeMap::new();
 
     for item in items {
-        match item {
-            BamlValue::Int(v) => numeric.push(*v as f64),
-            BamlValue::Float(v) => numeric.push(*v),
-            BamlValue::Bool(true) => t += 1,
-            BamlValue::Bool(false) => f += 1,
-            BamlValue::Enum(_, variant) => *variants.entry(variant.clone()).or_insert(0) += 1,
+        match summarize_peek(*item) {
+            PeekSummary::SignedInt(v) => numeric.push(v as f64),
+            PeekSummary::UnsignedInt(v) => numeric.push(v as f64),
+            PeekSummary::Float(v) => numeric.push(v),
+            PeekSummary::Bool(true) => t += 1,
+            PeekSummary::Bool(false) => f += 1,
+            PeekSummary::UnitEnum(variant) => *variants.entry(variant).or_insert(0) += 1,
             _ => return None,
         }
     }
@@ -708,17 +774,14 @@ struct FieldAgg {
     bool_false: usize,
 }
 
-fn compute_field_stats(items: &[BamlValue]) -> Option<FieldStats> {
+fn compute_field_stats(items: &[Peek<'_, '_>]) -> Option<FieldStats> {
     if items.is_empty() {
         return None;
     }
 
     let rows = items
         .iter()
-        .map(|item| match item {
-            BamlValue::Class(_, fields) | BamlValue::Map(fields) => Some(fields),
-            _ => None,
-        })
+        .map(|item| row_for_field_stats(*item))
         .collect::<Option<Vec<_>>>()?;
 
     let sample_indices = if rows.len() <= FIELD_STATS_FULL_SCAN {
@@ -729,7 +792,7 @@ fn compute_field_stats(items: &[BamlValue]) -> Option<FieldStats> {
 
     let sampled_rows = sample_indices
         .iter()
-        .map(|idx| rows[*idx])
+        .map(|idx| &rows[*idx])
         .collect::<Vec<_>>();
 
     let mut field_names = BTreeSet::new();
@@ -745,38 +808,51 @@ fn compute_field_stats(items: &[BamlValue]) -> Option<FieldStats> {
         let mut agg = FieldAgg::default();
         for row in &sampled_rows {
             match row.get(&field_name) {
-                None | Some(BamlValue::Null) => agg.missing += 1,
-                Some(BamlValue::String(v)) => {
+                None => agg.missing += 1,
+                Some(StructFieldValue::String(v)) => {
                     agg.present += 1;
                     agg.strings.push(v.chars().count());
                     if agg.unique_values.len() <= 4096 {
                         agg.unique_values.insert(v.clone());
                     }
                 }
-                Some(BamlValue::Int(v)) => {
-                    agg.present += 1;
-                    agg.numbers.push(*v as f64);
-                }
-                Some(BamlValue::Float(v)) => {
-                    agg.present += 1;
-                    agg.numbers.push(*v);
-                }
-                Some(BamlValue::Bool(true)) => {
-                    agg.present += 1;
-                    agg.bool_true += 1;
-                }
-                Some(BamlValue::Bool(false)) => {
-                    agg.present += 1;
-                    agg.bool_false += 1;
-                }
-                Some(v) => {
-                    agg.present += 1;
-                    if let BamlValue::Enum(_, variant) = v {
+                Some(StructFieldValue::Peek(value)) => match summarize_peek(*value) {
+                    PeekSummary::None => agg.missing += 1,
+                    PeekSummary::String(v) => {
+                        agg.present += 1;
+                        agg.strings.push(v.chars().count());
                         if agg.unique_values.len() <= 4096 {
-                            agg.unique_values.insert(variant.clone());
+                            agg.unique_values.insert(v.to_string());
                         }
                     }
-                }
+                    PeekSummary::SignedInt(v) => {
+                        agg.present += 1;
+                        agg.numbers.push(v as f64);
+                    }
+                    PeekSummary::UnsignedInt(v) => {
+                        agg.present += 1;
+                        agg.numbers.push(v as f64);
+                    }
+                    PeekSummary::Float(v) => {
+                        agg.present += 1;
+                        agg.numbers.push(v);
+                    }
+                    PeekSummary::Bool(true) => {
+                        agg.present += 1;
+                        agg.bool_true += 1;
+                    }
+                    PeekSummary::Bool(false) => {
+                        agg.present += 1;
+                        agg.bool_false += 1;
+                    }
+                    PeekSummary::UnitEnum(variant) => {
+                        agg.present += 1;
+                        if agg.unique_values.len() <= 4096 {
+                            agg.unique_values.insert(variant);
+                        }
+                    }
+                    _ => agg.present += 1,
+                },
             }
         }
 
@@ -824,6 +900,236 @@ fn compute_field_stats(items: &[BamlValue]) -> Option<FieldStats> {
         sampling_note: (rows.len() > FIELD_STATS_FULL_SCAN)
             .then(|| format!("(sampled {} of {})", sampled_rows.len(), rows.len())),
     })
+}
+
+fn render_inline_field_value(value: &StructFieldValue<'_, '_>, budget: RenderBudget) -> String {
+    match value {
+        StructFieldValue::String(text) => truncate_string(text, budget.nested_limit),
+        StructFieldValue::Peek(value) => match summarize_peek(*value) {
+            PeekSummary::None => "None".to_string(),
+            PeekSummary::String(text) => truncate_string(text, budget.nested_limit),
+            PeekSummary::Bool(v) => v.to_string(),
+            PeekSummary::SignedInt(v) => v.to_string(),
+            PeekSummary::UnsignedInt(v) => v.to_string(),
+            PeekSummary::Float(v) => v.to_string(),
+            PeekSummary::UnitEnum(variant) => variant,
+            PeekSummary::List(list) => format!("Count: {} items", list.len()),
+            PeekSummary::Map(entries) => format!("Keys: {} items", entries.len()),
+            PeekSummary::StructLike { class_name, fields } => {
+                format!("{class_name} ({} fields)", fields.len())
+            }
+            PeekSummary::Unknown(value) => format!("{}", value),
+        },
+    }
+}
+
+fn primitive_type_name_peek(value: Peek<'_, '_>) -> &'static str {
+    match summarize_peek(value) {
+        PeekSummary::None => "null",
+        PeekSummary::String(_) => "string",
+        PeekSummary::Bool(_) => "bool",
+        PeekSummary::SignedInt(_) | PeekSummary::UnsignedInt(_) => "int",
+        PeekSummary::Float(_) => "float",
+        PeekSummary::UnitEnum(_) => "enum",
+        PeekSummary::List(_) => "list",
+        PeekSummary::Map(_) => "map",
+        PeekSummary::StructLike { .. } => "class",
+        PeekSummary::Unknown(_) => "object",
+    }
+}
+
+fn peek_at_field_path<'mem, 'facet>(
+    root: Peek<'mem, 'facet>,
+    path: &FieldPath,
+) -> Option<Peek<'mem, 'facet>> {
+    let parts = path.iter().collect::<Vec<_>>();
+    let mut current = root.innermost_peek();
+    for (idx, part) in parts.iter().enumerate() {
+        let struct_peek = current.into_struct().ok()?;
+        let mut next = struct_peek.field_by_name(part).ok()?.innermost_peek();
+        if idx + 1 < parts.len()
+            && let Ok(opt) = next.into_option()
+        {
+            next = opt.value()?.innermost_peek();
+        }
+        current = next;
+    }
+    Some(current)
+}
+
+fn map_entries_for_preview<'mem, 'facet>(
+    map: bamltype::facet_reflect::PeekMap<'mem, 'facet>,
+) -> Vec<(String, Peek<'mem, 'facet>)> {
+    let mut entries = BTreeMap::new();
+    for (key, value) in map.iter() {
+        entries.insert(key_to_string(key), value);
+    }
+    entries.into_iter().collect()
+}
+
+fn struct_like_fields<'mem, 'facet>(
+    value: Peek<'mem, 'facet>,
+) -> Option<(String, Vec<(String, StructFieldValue<'mem, 'facet>)>)> {
+    let value = value.innermost_peek();
+
+    if let Ok(struct_peek) = value.into_struct() {
+        let class_name = bamltype::internal_name_for_shape(value.shape());
+        let fields = struct_peek
+            .fields_for_serialize()
+            .map(|(field_item, field_value)| {
+                (
+                    field_item.effective_name().to_string(),
+                    StructFieldValue::Peek(field_value),
+                )
+            })
+            .collect::<Vec<_>>();
+        return Some((class_name, fields));
+    }
+
+    if let Ok(enum_peek) = value.into_enum() {
+        if !enum_has_data_variants(value.shape()) {
+            return None;
+        }
+
+        let class_name = bamltype::internal_name_for_shape(value.shape());
+        let variant = enum_peek.active_variant().ok()?;
+        let mut fields = Vec::new();
+        let tag_name = value.shape().get_tag_attr().unwrap_or("type");
+        fields.push((
+            tag_name.to_string(),
+            StructFieldValue::String(variant.effective_name().to_string()),
+        ));
+        fields.extend(
+            enum_peek
+                .fields_for_serialize()
+                .map(|(field_item, field_value)| {
+                    (
+                        field_item.effective_name().to_string(),
+                        StructFieldValue::Peek(field_value),
+                    )
+                }),
+        );
+        return Some((class_name, fields));
+    }
+
+    None
+}
+
+fn row_for_field_stats<'mem, 'facet>(
+    value: Peek<'mem, 'facet>,
+) -> Option<BTreeMap<String, StructFieldValue<'mem, 'facet>>> {
+    if let Some((_, fields)) = struct_like_fields(value) {
+        let mut row = BTreeMap::new();
+        for (name, field_value) in fields {
+            row.insert(name, field_value);
+        }
+        return Some(row);
+    }
+
+    let map = value.innermost_peek().into_map().ok()?;
+    let mut row = BTreeMap::new();
+    for (key, value) in map.iter() {
+        row.insert(key_to_string(key), StructFieldValue::Peek(value));
+    }
+    Some(row)
+}
+
+fn unit_enum_variant(value: Peek<'_, '_>) -> Option<String> {
+    let value = value.innermost_peek();
+    let enum_peek = value.into_enum().ok()?;
+    if enum_has_data_variants(value.shape()) {
+        return None;
+    }
+    Some(
+        enum_peek
+            .active_variant()
+            .ok()?
+            .effective_name()
+            .to_string(),
+    )
+}
+
+fn enum_has_data_variants(shape: &'static bamltype::facet::Shape) -> bool {
+    let Type::User(UserType::Enum(enum_type)) = &shape.ty else {
+        return false;
+    };
+    enum_type
+        .variants
+        .iter()
+        .any(|variant| !variant.data.fields.is_empty())
+}
+
+fn key_to_string(key: Peek<'_, '_>) -> String {
+    if let Some(s) = key.as_str() {
+        return s.to_string();
+    }
+    if let Some(value) = peek_signed_i128(key) {
+        return value.to_string();
+    }
+    if let Some(value) = peek_unsigned_u128(key) {
+        return value.to_string();
+    }
+    if let Ok(value) = key.get::<bool>() {
+        return value.to_string();
+    }
+    format!("{key}")
+}
+
+fn peek_signed_i128(value: Peek<'_, '_>) -> Option<i128> {
+    if let Ok(v) = value.get::<i128>() {
+        return Some(*v);
+    }
+    if let Ok(v) = value.get::<i64>() {
+        return Some(*v as i128);
+    }
+    if let Ok(v) = value.get::<i32>() {
+        return Some(*v as i128);
+    }
+    if let Ok(v) = value.get::<i16>() {
+        return Some(*v as i128);
+    }
+    if let Ok(v) = value.get::<i8>() {
+        return Some(*v as i128);
+    }
+    if let Ok(v) = value.get::<isize>() {
+        return Some(*v as i128);
+    }
+    None
+}
+
+fn peek_unsigned_u128(value: Peek<'_, '_>) -> Option<u128> {
+    if let Ok(v) = value.get::<u128>() {
+        return Some(*v);
+    }
+    if let Ok(v) = value.get::<u64>() {
+        return Some(*v as u128);
+    }
+    if let Ok(v) = value.get::<u32>() {
+        return Some(*v as u128);
+    }
+    if let Ok(v) = value.get::<u16>() {
+        return Some(*v as u128);
+    }
+    if let Ok(v) = value.get::<u8>() {
+        return Some(*v as u128);
+    }
+    if let Ok(v) = value.get::<usize>() {
+        return Some(*v as u128);
+    }
+    None
+}
+
+fn collapse_option_chain<'mem, 'facet>(value: Peek<'mem, 'facet>) -> Option<Peek<'mem, 'facet>> {
+    let mut current = value.innermost_peek();
+    loop {
+        match current.into_option() {
+            Ok(option) => match option.value() {
+                Some(inner) => current = inner.innermost_peek(),
+                None => return None,
+            },
+            Err(_) => return Some(current),
+        }
+    }
 }
 
 fn stride_sample(total: usize, target: usize) -> Vec<usize> {
@@ -890,6 +1196,37 @@ mod tests {
         Failed,
     }
 
+    #[derive(Clone, Debug)]
+    #[BamlType]
+    #[allow(
+        dead_code,
+        reason = "Payload fields are exercised via reflection in preview tests."
+    )]
+    enum ActionState {
+        Final { answer: String, confidence: i32 },
+        Retry { reason: String },
+    }
+
+    #[derive(Clone, Debug)]
+    #[BamlType]
+    struct RowWithNestedOptionals {
+        id: String,
+        attrs: Option<HashMap<String, Option<i32>>>,
+    }
+
+    #[derive(Clone, Debug)]
+    #[BamlType]
+    struct RowWithDoubleOptional {
+        id: String,
+        maybe_note: Option<Option<String>>,
+    }
+
+    #[derive(Clone, Debug)]
+    #[BamlType]
+    struct FlattenedNote {
+        reason: String,
+    }
+
     #[derive(Signature, Clone, Debug)]
     /// Scalar preview test.
     struct ScalarSig {
@@ -928,6 +1265,71 @@ mod tests {
 
         #[input]
         nested: Vec<Vec<String>>,
+
+        #[output]
+        ok: bool,
+    }
+
+    #[derive(Signature, Clone, Debug)]
+    struct EnumPayloadSig {
+        #[input]
+        action: ActionState,
+
+        #[output]
+        ok: bool,
+    }
+
+    #[derive(Signature, Clone, Debug)]
+    struct NestedOptionalStatsSig {
+        #[input]
+        rows: Vec<RowWithNestedOptionals>,
+
+        #[output]
+        ok: bool,
+    }
+
+    #[derive(Signature, Clone, Debug)]
+    struct EmptyCollectionsSig {
+        #[input]
+        empty_list: Vec<String>,
+
+        #[input]
+        empty_map: HashMap<String, i32>,
+
+        #[input]
+        nested_empty: Vec<Vec<String>>,
+
+        #[output]
+        ok: bool,
+    }
+
+    #[derive(Signature, Clone, Debug)]
+    struct FlattenAliasSig {
+        #[input]
+        #[flatten]
+        inner: FlattenedNote,
+
+        #[input]
+        #[alias("topic_alias")]
+        topic: String,
+
+        #[output]
+        ok: bool,
+    }
+
+    #[derive(Signature, Clone, Debug)]
+    struct NestedOptionalSig {
+        #[input]
+        maybe_note: Option<Option<String>>,
+
+        #[output]
+        ok: bool,
+    }
+
+    #[derive(Signature, Clone, Debug)]
+    struct NestedOptionalStatsParitySig {
+        #[input]
+        rows: Vec<RowWithDoubleOptional>,
 
         #[output]
         ok: bool,
@@ -1005,5 +1407,152 @@ mod tests {
         assert!(rendered.contains("Distribution:"));
         assert!(rendered.contains("Ready: 2"));
         assert!(rendered.contains("Count: 3 items"));
+    }
+
+    #[test]
+    fn enum_payload_variant_renders_as_struct_like_preview() {
+        let rendered = render_previews::<EnumPayloadSig>(&EnumPayloadSigInput {
+            action: ActionState::Final {
+                answer: "ship it".to_string(),
+                confidence: 9,
+            },
+        });
+
+        assert!(rendered.contains("action:"));
+        assert!(rendered.contains("Preview:"));
+        assert!(rendered.contains("type: \"Final\""));
+        assert!(rendered.contains("answer: \"ship it\""));
+        assert!(rendered.contains("confidence: 9"));
+    }
+
+    #[test]
+    fn vec_struct_field_stats_handles_nested_optional_map_values() {
+        let rows = vec![
+            RowWithNestedOptionals {
+                id: "row-a".to_string(),
+                attrs: Some(HashMap::from([
+                    ("x".to_string(), Some(1)),
+                    ("y".to_string(), None),
+                ])),
+            },
+            RowWithNestedOptionals {
+                id: "row-b".to_string(),
+                attrs: None,
+            },
+            RowWithNestedOptionals {
+                id: "row-c".to_string(),
+                attrs: Some(HashMap::from([("z".to_string(), Some(3))])),
+            },
+        ];
+
+        let rendered =
+            render_previews::<NestedOptionalStatsSig>(&NestedOptionalStatsSigInput { rows });
+
+        assert!(rendered.contains("Count: 3 items"));
+        assert!(rendered.contains("Field stats:"));
+        assert!(rendered.contains("id:"));
+        assert!(rendered.contains("Sample [0]:"));
+    }
+
+    #[test]
+    fn empty_collections_keep_counts_without_samples() {
+        let rendered = render_previews::<EmptyCollectionsSig>(&EmptyCollectionsSigInput {
+            empty_list: Vec::new(),
+            empty_map: HashMap::new(),
+            nested_empty: vec![Vec::new()],
+        });
+
+        assert!(rendered.contains("empty_list"));
+        assert!(rendered.contains("Count: 0 items"));
+        assert!(rendered.contains("empty_map"));
+        assert!(rendered.contains("Keys: 0 items"));
+        assert!(rendered.contains("nested_empty"));
+        assert!(rendered.contains("Sample [0]: Count: 0 items"));
+        assert!(!rendered.contains("Sample [\""));
+    }
+
+    #[test]
+    fn map_samples_are_deterministically_sorted_under_peek() {
+        let mut scores = HashMap::new();
+        scores.insert("zeta".to_string(), 9);
+        scores.insert("alpha".to_string(), 1);
+        scores.insert("middle".to_string(), 5);
+        scores.insert("omega".to_string(), 7);
+
+        let rendered = render_previews::<MixedSig>(&MixedSigInput {
+            maybe_note: Some("note".to_string()),
+            scores,
+            states: vec![State::Ready],
+            nested: vec![vec!["a".to_string()]],
+        });
+
+        let alpha = rendered
+            .find("Sample [\"alpha\"]")
+            .expect("alpha sample must be present");
+        let omega = rendered
+            .find("Sample [\"omega\"]")
+            .expect("omega sample must be present");
+        let zeta = rendered
+            .find("Sample [\"zeta\"]")
+            .expect("zeta sample must be present");
+
+        assert!(
+            alpha < omega && omega < zeta,
+            "map key order is not deterministic:\n{rendered}"
+        );
+    }
+
+    #[test]
+    fn flattened_alias_field_path_resolves_value_under_peek() {
+        let rendered = render_previews::<FlattenAliasSig>(&FlattenAliasSigInput {
+            inner: FlattenedNote {
+                reason: "because evidence".to_string(),
+            },
+            topic: "biology".to_string(),
+        });
+
+        assert!(rendered.contains("reason: string"));
+        assert!(rendered.contains("Value: \"because evidence\""));
+        assert!(rendered.contains("topic_alias: string"));
+        assert!(rendered.contains("Value: \"biology\""));
+        assert!(!rendered.contains("<missing>"));
+    }
+
+    #[test]
+    fn nested_optional_some_none_renders_none_without_present_prefix() {
+        let rendered = render_previews::<NestedOptionalSig>(&NestedOptionalSigInput {
+            maybe_note: Some(None),
+        });
+
+        assert!(rendered.contains("maybe_note"));
+        assert!(rendered.contains("None"));
+        assert!(!rendered.contains("(Present) None"));
+    }
+
+    #[test]
+    fn nested_optional_some_none_counts_as_null_in_field_stats() {
+        let rows = vec![
+            RowWithDoubleOptional {
+                id: "r1".to_string(),
+                maybe_note: Some(None),
+            },
+            RowWithDoubleOptional {
+                id: "r2".to_string(),
+                maybe_note: None,
+            },
+            RowWithDoubleOptional {
+                id: "r3".to_string(),
+                maybe_note: Some(Some("x".to_string())),
+            },
+        ];
+
+        let rendered =
+            render_previews::<NestedOptionalStatsParitySig>(&NestedOptionalStatsParitySigInput {
+                rows,
+            });
+
+        assert!(rendered.contains("Field stats:"));
+        assert!(rendered.contains("maybe_note:"));
+        assert!(rendered.contains("67% null"));
     }
 }

--- a/crates/dspy-rs/src/modules/rlm/previews.rs
+++ b/crates/dspy-rs/src/modules/rlm/previews.rs
@@ -71,7 +71,7 @@ where
         }
     }
 
-    String::new()
+    unreachable!("preview budget cascade must return on final pass")
 }
 
 fn render_with_budget(
@@ -1060,6 +1060,8 @@ fn unit_enum_variant(value: Peek<'_, '_>) -> Option<String> {
 }
 
 fn is_media_shape(shape: &'static bamltype::facet::Shape) -> bool {
+    // TODO: Brittle - relies on type-name string matching. Replace with
+    // structural Facet type identity when available.
     shape.type_identifier.ends_with("BamlMedia")
         || shape.type_identifier.contains("::media::BamlMedia")
 }

--- a/crates/dspy-rs/src/modules/rlm/previews.rs
+++ b/crates/dspy-rs/src/modules/rlm/previews.rs
@@ -1,0 +1,1009 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use bamltype::baml_types::ir_type::{TypeGeneric, UnionTypeViewGeneric};
+use bamltype::baml_types::{BamlMap, TypeIR};
+
+use crate::{
+    BamlType, BamlValue, ConstraintKind, Facet, FieldSchema, OutputFormatContent, Signature,
+    SignatureSchema,
+};
+
+const TOP_LEVEL_STRING_LIMIT: usize = 500;
+const NESTED_STRING_LIMIT: usize = 100;
+const STRUCT_PREVIEW_DEPTH_CAP: usize = 2;
+const STRUCT_PREVIEW_BREADTH_CAP: usize = 8;
+const SOFT_PREVIEW_BUDGET: usize = 4 * 1024;
+const FIELD_STATS_FULL_SCAN: usize = 2_000;
+const FIELD_STATS_SAMPLE: usize = 512;
+
+#[derive(Clone, Copy)]
+struct RenderBudget {
+    top_level_limit: usize,
+    nested_limit: usize,
+    include_middle_samples: bool,
+}
+
+impl RenderBudget {
+    const fn default() -> Self {
+        Self {
+            top_level_limit: TOP_LEVEL_STRING_LIMIT,
+            nested_limit: NESTED_STRING_LIMIT,
+            include_middle_samples: true,
+        }
+    }
+
+    const fn shorter_strings() -> Self {
+        Self {
+            top_level_limit: 320,
+            nested_limit: 64,
+            include_middle_samples: true,
+        }
+    }
+
+    const fn no_middle_samples() -> Self {
+        Self {
+            top_level_limit: 200,
+            nested_limit: 48,
+            include_middle_samples: false,
+        }
+    }
+}
+
+pub(super) fn render_previews<S: Signature>(input: &S::Input) -> String
+where
+    S::Input: BamlType + for<'a> Facet<'a>,
+{
+    let schema = SignatureSchema::of::<S>();
+    let root = input.to_baml_value();
+    let input_format = <S::Input as BamlType>::baml_output_format();
+
+    let budgets = [
+        RenderBudget::default(),
+        RenderBudget::shorter_strings(),
+        RenderBudget::no_middle_samples(),
+    ];
+
+    for budget in budgets {
+        let rendered = render_with_budget(schema, &root, input_format, budget);
+        if rendered.chars().count() <= SOFT_PREVIEW_BUDGET || !budget.include_middle_samples {
+            return rendered;
+        }
+    }
+
+    String::new()
+}
+
+fn render_with_budget(
+    schema: &SignatureSchema,
+    root: &BamlValue,
+    input_format: &OutputFormatContent,
+    budget: RenderBudget,
+) -> String {
+    let mut lines = vec!["## Variables".to_string(), String::new()];
+
+    for field in schema.input_fields() {
+        lines.push(format!(
+            "{}: {}",
+            field.lm_name,
+            field.type_ir.diagnostic_repr()
+        ));
+
+        if !field.docs.trim().is_empty() {
+            lines.push(format!("  {}", field.docs.trim()));
+        }
+
+        for constraint in field.constraints {
+            let marker = match constraint.kind {
+                ConstraintKind::Check => "soft",
+                ConstraintKind::Assert => "hard",
+            };
+            lines.push(format!(
+                "  Constraint: {marker} {} ({})",
+                constraint.label, constraint.expression
+            ));
+        }
+
+        if let Some(value) = schema.navigate_field(field.path(), root) {
+            for line in
+                render_value_block(value, Some(&field.type_ir), field, input_format, 0, budget)
+            {
+                lines.push(format!("  {line}"));
+            }
+        } else {
+            lines.push("  <missing>".to_string());
+        }
+
+        lines.push(String::new());
+    }
+
+    lines.push("## Expected Output".to_string());
+    for field in schema.output_fields() {
+        lines.push(format!(
+            "{}: {}",
+            field.lm_name,
+            field.type_ir.diagnostic_repr()
+        ));
+    }
+
+    while lines.last().is_some_and(String::is_empty) {
+        lines.pop();
+    }
+
+    lines.join("\n")
+}
+
+fn render_value_block(
+    value: &BamlValue,
+    type_ir: Option<&TypeIR>,
+    field: &FieldSchema,
+    input_format: &OutputFormatContent,
+    depth: usize,
+    budget: RenderBudget,
+) -> Vec<String> {
+    if let Some(inner) = optional_inner(type_ir) {
+        if matches!(value, BamlValue::Null) {
+            return vec!["None".to_string()];
+        }
+        let mut lines = vec!["(Present)".to_string()];
+        lines.extend(render_value_block(
+            value,
+            Some(inner),
+            field,
+            input_format,
+            depth,
+            budget,
+        ));
+        return lines;
+    }
+
+    match value {
+        BamlValue::String(text) => render_string_block(text, depth > 0, budget),
+        BamlValue::Int(v) => vec![format!("Value: {v}")],
+        BamlValue::Float(v) => vec![format!("Value: {v}")],
+        BamlValue::Bool(v) => vec![format!("Value: {v}")],
+        BamlValue::Null => vec!["None".to_string()],
+        BamlValue::Enum(_, variant) => vec![format!("Variant: {variant}")],
+        BamlValue::Media(_) => vec!["Media (preview omitted)".to_string()],
+        BamlValue::List(items) => {
+            render_list_block(items, item_type(type_ir), input_format, depth, budget)
+        }
+        BamlValue::Map(map) => {
+            render_map_block(map, map_value_type(type_ir), input_format, depth, budget)
+        }
+        BamlValue::Class(class_name, fields) => {
+            render_struct_block(class_name, fields, type_ir, input_format, depth, budget)
+        }
+    }
+}
+
+fn render_string_block(text: &str, nested: bool, budget: RenderBudget) -> Vec<String> {
+    if nested {
+        return vec![truncate_string(text, budget.nested_limit)];
+    }
+
+    let len = text.chars().count();
+    let lines = text.lines().count().max(1);
+    let mut out = vec![format!("Length: {len} chars, Lines: {lines}")];
+
+    if len > 50 {
+        if let Some(summary) = summarize_json_string(text) {
+            out.push(format!("(JSON String) {summary}"));
+        }
+    }
+
+    out.push(format!(
+        "Value: {}",
+        truncate_string(text, budget.top_level_limit)
+    ));
+    out
+}
+
+fn render_list_block(
+    items: &[BamlValue],
+    item_type: Option<&TypeIR>,
+    input_format: &OutputFormatContent,
+    depth: usize,
+    budget: RenderBudget,
+) -> Vec<String> {
+    let mut lines = vec![format!("Count: {} items", items.len())];
+
+    if let Some(schema_line) = class_schema_line(item_type, input_format) {
+        lines.push(format!("Schema: {schema_line}"));
+    }
+
+    if let Some(distribution) = scalar_distribution(items) {
+        lines.push(format!("Distribution: {distribution}"));
+    }
+
+    if let Some(stats) = compute_field_stats(items) {
+        lines.push(format!("Field stats: {}", stats.summary));
+        if let Some(note) = stats.sampling_note {
+            lines.push(note);
+        }
+    }
+
+    if depth >= STRUCT_PREVIEW_DEPTH_CAP {
+        return lines;
+    }
+
+    for idx in sample_indices(items.len(), depth, budget.include_middle_samples) {
+        let rendered = render_inline_value(&items[idx], item_type, input_format, depth + 1, budget);
+        lines.push(format!("Sample [{idx}]: {rendered}"));
+    }
+
+    lines
+}
+
+fn render_map_block(
+    map: &BamlMap<String, BamlValue>,
+    value_type: Option<&TypeIR>,
+    input_format: &OutputFormatContent,
+    depth: usize,
+    budget: RenderBudget,
+) -> Vec<String> {
+    let mut lines = vec![format!("Keys: {} items", map.len())];
+    if map.is_empty() || depth >= STRUCT_PREVIEW_DEPTH_CAP {
+        return lines;
+    }
+
+    let mut keys = map.keys().collect::<Vec<_>>();
+    keys.sort_unstable();
+
+    for idx in sample_indices(keys.len(), depth, budget.include_middle_samples) {
+        let key = keys[idx];
+        if let Some(value) = map.get(key) {
+            let rendered = render_inline_value(value, value_type, input_format, depth + 1, budget);
+            lines.push(format!("Sample [{key:?}]: {rendered}"));
+        }
+    }
+
+    lines
+}
+
+fn render_struct_block(
+    class_name: &str,
+    fields: &BamlMap<String, BamlValue>,
+    type_ir: Option<&TypeIR>,
+    input_format: &OutputFormatContent,
+    depth: usize,
+    budget: RenderBudget,
+) -> Vec<String> {
+    let mut lines = vec![];
+
+    if let Some(schema_line) = class_schema_line(type_ir, input_format) {
+        lines.push(format!("Schema: {schema_line}"));
+    } else {
+        lines.push(format!("Schema: {}", fallback_schema(fields)));
+    }
+
+    if depth >= STRUCT_PREVIEW_DEPTH_CAP {
+        lines.push(format!("Preview: {class_name} ({} fields)", fields.len()));
+        return lines;
+    }
+
+    let preview = render_inline_struct(class_name, fields, type_ir, input_format, depth, budget);
+    lines.push(format!("Preview: {preview}"));
+    lines
+}
+
+fn render_inline_value(
+    value: &BamlValue,
+    type_ir: Option<&TypeIR>,
+    input_format: &OutputFormatContent,
+    depth: usize,
+    budget: RenderBudget,
+) -> String {
+    if let Some(inner) = optional_inner(type_ir) {
+        return if matches!(value, BamlValue::Null) {
+            "None".to_string()
+        } else {
+            format!(
+                "(Present) {}",
+                render_inline_value(value, Some(inner), input_format, depth, budget)
+            )
+        };
+    }
+
+    match value {
+        BamlValue::String(text) => truncate_string(text, budget.nested_limit),
+        BamlValue::Int(v) => v.to_string(),
+        BamlValue::Float(v) => v.to_string(),
+        BamlValue::Bool(v) => v.to_string(),
+        BamlValue::Null => "None".to_string(),
+        BamlValue::Enum(_, variant) => variant.to_string(),
+        BamlValue::Media(_) => "Media".to_string(),
+        BamlValue::List(items) => {
+            if depth >= STRUCT_PREVIEW_DEPTH_CAP {
+                return format!("Count: {} items", items.len());
+            }
+            let idxs = sample_indices(items.len(), depth, budget.include_middle_samples);
+            let inner = item_type(type_ir);
+            if idxs.is_empty() {
+                return "Count: 0 items".to_string();
+            }
+            let samples = idxs
+                .iter()
+                .map(|idx| {
+                    format!(
+                        "sample[{idx}]={}",
+                        render_inline_value(&items[*idx], inner, input_format, depth + 1, budget,)
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("Count: {} items; {samples}", items.len())
+        }
+        BamlValue::Map(map) => {
+            if depth >= STRUCT_PREVIEW_DEPTH_CAP {
+                return format!("Keys: {} items", map.len());
+            }
+            let mut keys = map.keys().collect::<Vec<_>>();
+            keys.sort_unstable();
+            let value_type = map_value_type(type_ir);
+            let pairs = sample_indices(keys.len(), depth, budget.include_middle_samples)
+                .into_iter()
+                .filter_map(|idx| {
+                    let key = keys[idx];
+                    map.get(key).map(|entry| {
+                        format!(
+                            "{key:?}: {}",
+                            render_inline_value(entry, value_type, input_format, depth + 1, budget,)
+                        )
+                    })
+                })
+                .collect::<Vec<_>>();
+            if pairs.is_empty() {
+                format!("Keys: {} items", map.len())
+            } else {
+                format!("Keys: {} items; {}", map.len(), pairs.join(", "))
+            }
+        }
+        BamlValue::Class(class_name, fields) => {
+            render_inline_struct(class_name, fields, type_ir, input_format, depth, budget)
+        }
+    }
+}
+
+fn render_inline_struct(
+    class_name: &str,
+    fields: &BamlMap<String, BamlValue>,
+    type_ir: Option<&TypeIR>,
+    input_format: &OutputFormatContent,
+    depth: usize,
+    budget: RenderBudget,
+) -> String {
+    if depth >= STRUCT_PREVIEW_DEPTH_CAP {
+        return format!("{class_name} ({} fields)", fields.len());
+    }
+
+    let ordered = ordered_struct_fields(fields, type_ir, input_format);
+    let mut parts = Vec::new();
+
+    for (idx, (name, value, child_ty)) in ordered.into_iter().enumerate() {
+        if idx >= STRUCT_PREVIEW_BREADTH_CAP {
+            break;
+        }
+        let rendered = match value {
+            BamlValue::String(text) => truncate_string(text, budget.nested_limit),
+            BamlValue::Int(v) => v.to_string(),
+            BamlValue::Float(v) => v.to_string(),
+            BamlValue::Bool(v) => v.to_string(),
+            BamlValue::Null => "None".to_string(),
+            BamlValue::Enum(_, variant) => variant.to_string(),
+            BamlValue::Media(_) => "Media".to_string(),
+            BamlValue::List(items) => format!("Count: {} items", items.len()),
+            BamlValue::Map(map) => format!("Keys: {} items", map.len()),
+            BamlValue::Class(inner_name, inner_fields) => {
+                let _ = child_ty;
+                let _ = input_format;
+                let _ = budget;
+                format!("{inner_name} ({} fields)", inner_fields.len())
+            }
+        };
+        parts.push(format!("{name}: {rendered}"));
+    }
+
+    if fields.len() > STRUCT_PREVIEW_BREADTH_CAP {
+        parts.push(format!(
+            "... (+{} fields)",
+            fields.len() - STRUCT_PREVIEW_BREADTH_CAP
+        ));
+    }
+
+    format!("{class_name} {{ {} }}", parts.join(", "))
+}
+
+fn ordered_struct_fields<'a>(
+    fields: &'a BamlMap<String, BamlValue>,
+    type_ir: Option<&'a TypeIR>,
+    input_format: &'a OutputFormatContent,
+) -> Vec<(&'a str, &'a BamlValue, Option<&'a TypeIR>)> {
+    if let Some((class_name, mode)) = class_type_ref(type_ir) {
+        if let Some(class) = input_format.classes.get(&(class_name.to_string(), mode)) {
+            let mut ordered = Vec::new();
+            for (field_name, field_ty, _, _) in &class.fields {
+                let key = field_name.real_name();
+                if let Some(value) = fields.get(key) {
+                    ordered.push((key, value, Some(field_ty)));
+                }
+            }
+
+            for (key, value) in fields {
+                if !ordered
+                    .iter()
+                    .any(|(existing, _, _)| *existing == key.as_str())
+                {
+                    ordered.push((key.as_str(), value, None));
+                }
+            }
+            return ordered;
+        }
+    }
+
+    let mut fallback = fields
+        .iter()
+        .map(|(key, value)| (key.as_str(), value, None))
+        .collect::<Vec<_>>();
+    fallback.sort_by(|a, b| a.0.cmp(b.0));
+    fallback
+}
+
+fn class_schema_line(
+    type_ir: Option<&TypeIR>,
+    input_format: &OutputFormatContent,
+) -> Option<String> {
+    let (class_name, mode) = class_type_ref(type_ir)?;
+    let class = input_format.classes.get(&(class_name.to_string(), mode))?;
+
+    let mut fields = class
+        .fields
+        .iter()
+        .take(STRUCT_PREVIEW_BREADTH_CAP)
+        .map(|(field_name, field_type, _, _)| {
+            format!(
+                "{}: {}",
+                field_name.real_name(),
+                field_type.diagnostic_repr()
+            )
+        })
+        .collect::<Vec<_>>();
+
+    if class.fields.len() > STRUCT_PREVIEW_BREADTH_CAP {
+        fields.push(format!(
+            "... (+{} fields)",
+            class.fields.len() - STRUCT_PREVIEW_BREADTH_CAP
+        ));
+    }
+
+    Some(format!("{{ {} }}", fields.join(", ")))
+}
+
+fn fallback_schema(fields: &BamlMap<String, BamlValue>) -> String {
+    let mut keys = fields.keys().collect::<Vec<_>>();
+    keys.sort_unstable();
+    let mut parts = keys
+        .iter()
+        .take(STRUCT_PREVIEW_BREADTH_CAP)
+        .filter_map(|key| {
+            fields
+                .get(*key)
+                .map(|value| format!("{key}: {}", primitive_type_name(value)))
+        })
+        .collect::<Vec<_>>();
+
+    if fields.len() > STRUCT_PREVIEW_BREADTH_CAP {
+        parts.push(format!(
+            "... (+{} fields)",
+            fields.len() - STRUCT_PREVIEW_BREADTH_CAP
+        ));
+    }
+
+    format!("{{ {} }}", parts.join(", "))
+}
+
+fn primitive_type_name(value: &BamlValue) -> &'static str {
+    match value {
+        BamlValue::String(_) => "string",
+        BamlValue::Int(_) => "int",
+        BamlValue::Float(_) => "float",
+        BamlValue::Bool(_) => "bool",
+        BamlValue::Map(_) => "map",
+        BamlValue::List(_) => "list",
+        BamlValue::Media(_) => "media",
+        BamlValue::Enum(_, _) => "enum",
+        BamlValue::Class(_, _) => "class",
+        BamlValue::Null => "null",
+    }
+}
+
+fn sample_indices(len: usize, depth: usize, include_middle: bool) -> Vec<usize> {
+    if len == 0 || depth >= STRUCT_PREVIEW_DEPTH_CAP {
+        return Vec::new();
+    }
+
+    if depth == 1 {
+        return vec![0];
+    }
+
+    if len <= 3 {
+        return (0..len).collect();
+    }
+
+    let mut indices = vec![0, len - 1];
+    if include_middle {
+        indices.push(len / 2);
+    }
+    indices.sort_unstable();
+    indices.dedup();
+    indices
+}
+
+fn optional_inner(type_ir: Option<&TypeIR>) -> Option<&TypeIR> {
+    match type_ir {
+        Some(TypeGeneric::Union(union, _)) => match union.view() {
+            UnionTypeViewGeneric::Optional(inner) => Some(inner),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn item_type(type_ir: Option<&TypeIR>) -> Option<&TypeIR> {
+    match type_ir {
+        Some(TypeGeneric::List(inner, _)) => Some(inner),
+        Some(TypeGeneric::Union(union, _)) => match union.view() {
+            UnionTypeViewGeneric::Optional(inner) => item_type(Some(inner)),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn map_value_type(type_ir: Option<&TypeIR>) -> Option<&TypeIR> {
+    match type_ir {
+        Some(TypeGeneric::Map(_, value, _)) => Some(value),
+        Some(TypeGeneric::Union(union, _)) => match union.view() {
+            UnionTypeViewGeneric::Optional(inner) => map_value_type(Some(inner)),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn class_type_ref(type_ir: Option<&TypeIR>) -> Option<(&str, bamltype::baml_types::StreamingMode)> {
+    match type_ir {
+        Some(TypeGeneric::Class { name, mode, .. }) => Some((name.as_str(), *mode)),
+        Some(TypeGeneric::Union(union, _)) => match union.view() {
+            UnionTypeViewGeneric::Optional(inner) => class_type_ref(Some(inner)),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn truncate_string(text: &str, limit: usize) -> String {
+    let total = text.chars().count();
+    if total <= limit {
+        return format!("{:?}", text);
+    }
+
+    let head_len = limit / 2;
+    let tail_len = limit.saturating_sub(head_len);
+    let head = text.chars().take(head_len).collect::<String>();
+    let tail = text
+        .chars()
+        .rev()
+        .take(tail_len)
+        .collect::<String>()
+        .chars()
+        .rev()
+        .collect::<String>();
+
+    format!(
+        "{:?} ... ({} chars omitted) ... {:?}",
+        head,
+        total.saturating_sub(head_len + tail_len),
+        tail
+    )
+}
+
+fn summarize_json_string(text: &str) -> Option<String> {
+    let value = serde_json::from_str::<serde_json::Value>(text).ok()?;
+
+    match value {
+        serde_json::Value::Object(map) => {
+            let mut keys = map.keys().cloned().collect::<Vec<_>>();
+            keys.sort_unstable();
+            let mut summary = keys.iter().take(8).cloned().collect::<Vec<_>>().join(", ");
+            if keys.len() > 8 {
+                summary.push_str(&format!(", ... (+{} keys)", keys.len() - 8));
+            }
+            Some(format!("object keys: {summary}"))
+        }
+        serde_json::Value::Array(items) => {
+            let first = items.first().map(json_value_name).unwrap_or("empty");
+            Some(format!(
+                "array with {} items (first item type: {first})",
+                items.len()
+            ))
+        }
+        _ => None,
+    }
+}
+
+fn json_value_name(value: &serde_json::Value) -> &'static str {
+    match value {
+        serde_json::Value::Null => "null",
+        serde_json::Value::Bool(_) => "bool",
+        serde_json::Value::Number(_) => "number",
+        serde_json::Value::String(_) => "string",
+        serde_json::Value::Array(_) => "array",
+        serde_json::Value::Object(_) => "object",
+    }
+}
+
+fn scalar_distribution(items: &[BamlValue]) -> Option<String> {
+    if items.is_empty() {
+        return None;
+    }
+
+    let mut numeric = Vec::new();
+    let mut t = 0usize;
+    let mut f = 0usize;
+    let mut variants: BTreeMap<String, usize> = BTreeMap::new();
+
+    for item in items {
+        match item {
+            BamlValue::Int(v) => numeric.push(*v as f64),
+            BamlValue::Float(v) => numeric.push(*v),
+            BamlValue::Bool(true) => t += 1,
+            BamlValue::Bool(false) => f += 1,
+            BamlValue::Enum(_, variant) => *variants.entry(variant.clone()).or_insert(0) += 1,
+            _ => return None,
+        }
+    }
+
+    if !numeric.is_empty() {
+        let min = numeric.iter().fold(f64::INFINITY, |acc, v| acc.min(*v));
+        let max = numeric.iter().fold(f64::NEG_INFINITY, |acc, v| acc.max(*v));
+        let mean = numeric.iter().sum::<f64>() / numeric.len() as f64;
+        return Some(format!(
+            "min={}; max={}; mean={}",
+            number(min),
+            number(max),
+            number(mean)
+        ));
+    }
+
+    if t + f == items.len() {
+        return Some(format!("true={t}, false={f}"));
+    }
+
+    if !variants.is_empty() {
+        return Some(
+            variants
+                .into_iter()
+                .map(|(variant, count)| format!("{variant}: {count}"))
+                .collect::<Vec<_>>()
+                .join(", "),
+        );
+    }
+
+    None
+}
+
+struct FieldStats {
+    summary: String,
+    sampling_note: Option<String>,
+}
+
+#[derive(Default)]
+struct FieldAgg {
+    present: usize,
+    missing: usize,
+    strings: Vec<usize>,
+    unique_values: BTreeSet<String>,
+    numbers: Vec<f64>,
+    bool_true: usize,
+    bool_false: usize,
+}
+
+fn compute_field_stats(items: &[BamlValue]) -> Option<FieldStats> {
+    if items.is_empty() {
+        return None;
+    }
+
+    let rows = items
+        .iter()
+        .map(|item| match item {
+            BamlValue::Class(_, fields) | BamlValue::Map(fields) => Some(fields),
+            _ => None,
+        })
+        .collect::<Option<Vec<_>>>()?;
+
+    let sample_indices = if rows.len() <= FIELD_STATS_FULL_SCAN {
+        (0..rows.len()).collect::<Vec<_>>()
+    } else {
+        stride_sample(rows.len(), FIELD_STATS_SAMPLE)
+    };
+
+    let sampled_rows = sample_indices
+        .iter()
+        .map(|idx| rows[*idx])
+        .collect::<Vec<_>>();
+
+    let mut field_names = BTreeSet::new();
+    for row in &sampled_rows {
+        for key in row.keys() {
+            field_names.insert(key.clone());
+        }
+    }
+
+    let mut parts = Vec::new();
+
+    for field_name in field_names {
+        let mut agg = FieldAgg::default();
+        for row in &sampled_rows {
+            match row.get(&field_name) {
+                None | Some(BamlValue::Null) => agg.missing += 1,
+                Some(BamlValue::String(v)) => {
+                    agg.present += 1;
+                    agg.strings.push(v.chars().count());
+                    if agg.unique_values.len() <= 4096 {
+                        agg.unique_values.insert(v.clone());
+                    }
+                }
+                Some(BamlValue::Int(v)) => {
+                    agg.present += 1;
+                    agg.numbers.push(*v as f64);
+                }
+                Some(BamlValue::Float(v)) => {
+                    agg.present += 1;
+                    agg.numbers.push(*v);
+                }
+                Some(BamlValue::Bool(true)) => {
+                    agg.present += 1;
+                    agg.bool_true += 1;
+                }
+                Some(BamlValue::Bool(false)) => {
+                    agg.present += 1;
+                    agg.bool_false += 1;
+                }
+                Some(v) => {
+                    agg.present += 1;
+                    if let BamlValue::Enum(_, variant) = v {
+                        if agg.unique_values.len() <= 4096 {
+                            agg.unique_values.insert(variant.clone());
+                        }
+                    }
+                }
+            }
+        }
+
+        let mut rendered = if !agg.numbers.is_empty() && agg.numbers.len() == agg.present {
+            let min = agg.numbers.iter().fold(f64::INFINITY, |acc, v| acc.min(*v));
+            let max = agg
+                .numbers
+                .iter()
+                .fold(f64::NEG_INFINITY, |acc, v| acc.max(*v));
+            let mean = agg.numbers.iter().sum::<f64>() / agg.numbers.len() as f64;
+            format!(
+                "min={}; max={}; mean={}",
+                number(min),
+                number(max),
+                number(mean)
+            )
+        } else if !agg.strings.is_empty() && agg.strings.len() == agg.present {
+            let min = agg.strings.iter().min().copied().unwrap_or(0);
+            let max = agg.strings.iter().max().copied().unwrap_or(0);
+            if is_categorical_field(&field_name, agg.unique_values.len(), agg.present) {
+                format!("{} unique values", agg.unique_values.len())
+            } else {
+                format!("{min}-{max} chars")
+            }
+        } else if agg.bool_true + agg.bool_false == agg.present {
+            format!("true={}, false={}", agg.bool_true, agg.bool_false)
+        } else {
+            continue;
+        };
+
+        if agg.missing > 0 {
+            let pct = ((agg.missing as f64 / sampled_rows.len() as f64) * 100.0).round() as usize;
+            rendered.push_str(&format!(", {pct}% null"));
+        }
+
+        parts.push(format!("{field_name}: {rendered}"));
+    }
+
+    if parts.is_empty() {
+        return None;
+    }
+
+    Some(FieldStats {
+        summary: parts.join("; "),
+        sampling_note: (rows.len() > FIELD_STATS_FULL_SCAN)
+            .then(|| format!("(sampled {} of {})", sampled_rows.len(), rows.len())),
+    })
+}
+
+fn stride_sample(total: usize, target: usize) -> Vec<usize> {
+    if total <= target {
+        return (0..total).collect();
+    }
+
+    let step = total as f64 / target as f64;
+    let mut out = (0..target)
+        .map(|i| ((i as f64) * step).floor() as usize)
+        .collect::<Vec<_>>();
+
+    if let Some(last) = out.last_mut() {
+        *last = total - 1;
+    }
+
+    out.sort_unstable();
+    out.dedup();
+    out
+}
+
+fn is_categorical_field(name: &str, unique: usize, present: usize) -> bool {
+    let lowered = name.to_ascii_lowercase();
+    if ["id", "type", "category", "status", "label"]
+        .iter()
+        .any(|token| lowered.contains(token))
+    {
+        return true;
+    }
+
+    unique <= 32 || (unique as f64 / present.max(1) as f64) <= 0.2
+}
+
+fn number(value: f64) -> String {
+    if (value.fract()).abs() < f64::EPSILON {
+        format!("{value:.0}")
+    } else {
+        format!("{value:.3}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use crate::{BamlType, Signature};
+
+    use super::render_previews;
+
+    #[derive(Clone, Debug)]
+    #[BamlType]
+    struct Paper {
+        title: String,
+        abstract_text: String,
+        year: i32,
+        category: String,
+        email: Option<String>,
+    }
+
+    #[derive(Clone, Debug)]
+    #[BamlType]
+    enum State {
+        Ready,
+        Failed,
+    }
+
+    #[derive(Signature, Clone, Debug)]
+    /// Scalar preview test.
+    struct ScalarSig {
+        #[input]
+        #[check("this != ''", label = "non_empty")]
+        text: String,
+
+        #[input]
+        payload: String,
+
+        #[output]
+        ok: bool,
+    }
+
+    #[derive(Signature, Clone, Debug)]
+    /// Collection preview test.
+    struct CollectionSig {
+        #[input]
+        papers: Vec<Paper>,
+
+        #[output]
+        ok: bool,
+    }
+
+    #[derive(Signature, Clone, Debug)]
+    /// Mixed preview test.
+    struct MixedSig {
+        #[input]
+        maybe_note: Option<String>,
+
+        #[input]
+        scores: HashMap<String, i32>,
+
+        #[input]
+        states: Vec<State>,
+
+        #[input]
+        nested: Vec<Vec<String>>,
+
+        #[output]
+        ok: bool,
+    }
+
+    #[test]
+    fn scalar_preview_shows_truncation_json_and_constraints() {
+        let rendered = render_previews::<ScalarSig>(&ScalarSigInput {
+            text: "x".repeat(620),
+            payload: serde_json::json!({
+                "a": 1,
+                "b": [1, 2, 3],
+                "longer_payload_to_force_json_detection": "abcdefghijklmnopqrstuvwxyz"
+            })
+            .to_string(),
+        });
+
+        assert!(rendered.contains("Constraint: soft non_empty"));
+        assert!(rendered.contains("Length: 620 chars"));
+        assert!(rendered.contains("chars omitted"));
+        assert!(
+            rendered.contains("(JSON String) object keys")
+                || rendered.contains("(JSON String)")
+                || rendered.contains("object keys")
+        );
+        assert!(rendered.contains("## Expected Output"));
+    }
+
+    #[test]
+    fn collection_preview_shows_samples_and_field_stats() {
+        let papers = (0..2_101)
+            .map(|idx| Paper {
+                title: format!("paper-{idx}"),
+                abstract_text: "z".repeat(180 + (idx % 20) as usize),
+                year: 2020 + (idx % 5),
+                category: format!("cat-{}", idx % 7),
+                email: (idx % 3 == 0).then(|| format!("author{idx}@example.com")),
+            })
+            .collect::<Vec<_>>();
+
+        let rendered = render_previews::<CollectionSig>(&CollectionSigInput { papers });
+
+        assert!(rendered.contains("Count: 2101 items"));
+        assert!(rendered.contains("Field stats:"));
+        assert!(rendered.contains("(sampled"));
+        assert!(rendered.contains("Sample [0]:"));
+        assert!(rendered.contains("Sample [1050]:"));
+        assert!(rendered.contains("Sample [2100]:"));
+    }
+
+    #[test]
+    fn mixed_preview_shows_optional_map_enum_and_nested_depth_rules() {
+        let mut scores = HashMap::new();
+        scores.insert("zeta".to_string(), 9);
+        scores.insert("alpha".to_string(), 1);
+        scores.insert("middle".to_string(), 5);
+        scores.insert("omega".to_string(), 7);
+
+        let rendered = render_previews::<MixedSig>(&MixedSigInput {
+            maybe_note: None,
+            scores,
+            states: vec![State::Ready, State::Failed, State::Ready],
+            nested: vec![
+                vec!["a".to_string(), "b".to_string()],
+                vec!["c".to_string(), "d".to_string()],
+                vec!["e".to_string(), "f".to_string()],
+            ],
+        });
+
+        assert!(rendered.contains("maybe_note"));
+        assert!(rendered.contains("None"));
+        assert!(rendered.contains("Keys: 4 items"));
+        assert!(rendered.contains("Sample [\"alpha\"]"));
+        assert!(rendered.contains("Sample [\"omega\"]"));
+        assert!(rendered.contains("Distribution:"));
+        assert!(rendered.contains("Ready: 2"));
+        assert!(rendered.contains("Count: 3 items"));
+    }
+}

--- a/crates/dspy-rs/src/modules/rlm/previews.rs
+++ b/crates/dspy-rs/src/modules/rlm/previews.rs
@@ -5,10 +5,10 @@ use bamltype::baml_types::ir_type::{TypeGeneric, UnionTypeViewGeneric};
 use bamltype::facet::{Type, UserType};
 use bamltype::facet_reflect::{HasFields, Peek};
 
+use super::runtime::{MethodSignature, MethodSource};
 use crate::{
     BamlType, ConstraintKind, Facet, FieldPath, OutputFormatContent, Signature, SignatureSchema,
 };
-use super::runtime::MethodSignature;
 
 const TOP_LEVEL_STRING_LIMIT: usize = 500;
 const NESTED_STRING_LIMIT: usize = 100;
@@ -17,6 +17,9 @@ const STRUCT_PREVIEW_BREADTH_CAP: usize = 8;
 const SOFT_PREVIEW_BUDGET: usize = 4 * 1024;
 const FIELD_STATS_FULL_SCAN: usize = 2_000;
 const FIELD_STATS_SAMPLE: usize = 512;
+const MAX_METHODS_DEFAULT: usize = 5;
+const MAX_METHODS_SHORT: usize = 4;
+const MAX_METHODS_TIGHT: usize = 3;
 
 #[derive(Clone, Copy)]
 struct RenderBudget {
@@ -53,7 +56,7 @@ impl RenderBudget {
 
 pub(super) fn render_previews<S: Signature>(
     input: &S::Input,
-    _methods_by_var: &BTreeMap<String, Vec<MethodSignature>>,
+    methods_by_var: &BTreeMap<String, Vec<MethodSignature>>,
 ) -> String
 where
     S::Input: BamlType + for<'a> Facet<'a>,
@@ -69,7 +72,7 @@ where
     ];
 
     for budget in budgets {
-        let rendered = render_with_budget(schema, root, input_format, budget);
+        let rendered = render_with_budget(schema, root, input_format, methods_by_var, budget);
         if rendered.chars().count() <= SOFT_PREVIEW_BUDGET || !budget.include_middle_samples {
             return rendered;
         }
@@ -82,6 +85,7 @@ fn render_with_budget(
     schema: &SignatureSchema,
     root: Peek<'_, '_>,
     input_format: &OutputFormatContent,
+    methods_by_var: &BTreeMap<String, Vec<MethodSignature>>,
     budget: RenderBudget,
 ) -> String {
     let mut lines = vec!["## Variables".to_string(), String::new()];
@@ -115,6 +119,12 @@ fn render_with_budget(
         } else {
             lines.push("  <missing>".to_string());
         }
+        render_methods_section(
+            &mut lines,
+            &field.rust_name,
+            methods_by_var.get(&field.rust_name).map(Vec::as_slice),
+            budget,
+        );
 
         lines.push(String::new());
     }
@@ -133,6 +143,92 @@ fn render_with_budget(
     }
 
     lines.join("\n")
+}
+
+fn render_methods_section(
+    lines: &mut Vec<String>,
+    var_name: &str,
+    methods: Option<&[MethodSignature]>,
+    budget: RenderBudget,
+) {
+    let Some(methods) = methods else {
+        return;
+    };
+    if methods.is_empty() {
+        return;
+    }
+
+    let mut ordered = methods.iter().collect::<Vec<_>>();
+    ordered.sort_by_key(|method| {
+        (
+            method_source_rank(method.source),
+            method.is_dunder,
+            method.name.as_str(),
+        )
+    });
+
+    lines.push("  Methods:".to_string());
+    let max_methods = max_methods_for_budget(budget);
+    let doc_limit = budget.nested_limit.max(48);
+
+    for method in ordered.iter().take(max_methods) {
+        lines.push(format!(
+            "    .{}{}",
+            method.name,
+            normalized_signature(&method.signature)
+        ));
+        let doc = truncate_one_line(&method.doc, doc_limit);
+        if !doc.is_empty() {
+            lines.push(format!("      {doc}"));
+        }
+    }
+
+    if ordered.len() > max_methods {
+        lines.push(format!(
+            "    ... ({} more methods; use help({var_name}) for full list)",
+            ordered.len() - max_methods
+        ));
+    }
+}
+
+const fn max_methods_for_budget(budget: RenderBudget) -> usize {
+    if !budget.include_middle_samples {
+        MAX_METHODS_TIGHT
+    } else if budget.top_level_limit <= 320 {
+        MAX_METHODS_SHORT
+    } else {
+        MAX_METHODS_DEFAULT
+    }
+}
+
+const fn method_source_rank(source: MethodSource) -> u8 {
+    match source {
+        MethodSource::Custom => 0,
+        MethodSource::Generated => 1,
+    }
+}
+
+fn normalized_signature(signature: &str) -> String {
+    let sig = signature.trim();
+    if sig.is_empty() {
+        "()".to_string()
+    } else if sig.starts_with('(') {
+        sig.to_string()
+    } else {
+        format!("({sig})")
+    }
+}
+
+fn truncate_one_line(text: &str, limit: usize) -> String {
+    let collapsed = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    if collapsed.chars().count() <= limit {
+        return collapsed;
+    }
+    let head = collapsed
+        .chars()
+        .take(limit.saturating_sub(3))
+        .collect::<String>();
+    format!("{head}...")
 }
 
 fn render_value_block(
@@ -1194,11 +1290,19 @@ fn number(value: f64) -> String {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::collections::{BTreeMap, HashMap};
 
     use crate::{BamlType, Signature};
 
-    use super::render_previews;
+    use super::super::runtime::{MethodSignature, MethodSource};
+    use super::render_previews as render_previews_with_methods;
+
+    fn render_previews<S: Signature>(input: &S::Input) -> String
+    where
+        S::Input: BamlType + for<'a> crate::Facet<'a>,
+    {
+        render_previews_with_methods::<S>(input, &BTreeMap::new())
+    }
 
     #[derive(Clone, Debug)]
     #[BamlType]
@@ -1428,6 +1532,71 @@ mod tests {
         assert!(rendered.contains("Distribution:"));
         assert!(rendered.contains("Ready: 2"));
         assert!(rendered.contains("Count: 3 items"));
+    }
+
+    #[test]
+    fn method_preview_renders_custom_methods_before_dunders() {
+        let rendered = render_previews_with_methods::<ScalarSig>(
+            &ScalarSigInput {
+                text: "hello".to_string(),
+                payload: "{}".to_string(),
+            },
+            &BTreeMap::from([(
+                "text".to_string(),
+                vec![
+                    MethodSignature {
+                        name: "__len__".to_string(),
+                        signature: "()".to_string(),
+                        doc: "Length of this value.".to_string(),
+                        source: MethodSource::Generated,
+                        is_dunder: true,
+                    },
+                    MethodSignature {
+                        name: "search".to_string(),
+                        signature: "(query: str) -> list[Step]".to_string(),
+                        doc: "Search matching entries.".to_string(),
+                        source: MethodSource::Custom,
+                        is_dunder: false,
+                    },
+                ],
+            )]),
+        );
+
+        let search = rendered.find(".search(").expect("search should be visible");
+        let dunder_len = rendered
+            .find(".__len__()")
+            .expect("__len__ should be visible");
+        assert!(search < dunder_len);
+        assert!(rendered.contains("Methods:"));
+    }
+
+    #[test]
+    fn method_preview_truncates_and_reports_remaining_methods() {
+        let methods = (0..7)
+            .rev()
+            .map(|idx| MethodSignature {
+                name: format!("m{idx}"),
+                signature: "()".to_string(),
+                doc: format!(
+                    "Long description for method {idx}. This should truncate to keep preview compact."
+                ),
+                source: MethodSource::Custom,
+                is_dunder: false,
+            })
+            .collect::<Vec<_>>();
+
+        let rendered = render_previews_with_methods::<ScalarSig>(
+            &ScalarSigInput {
+                text: "hello".to_string(),
+                payload: "{}".to_string(),
+            },
+            &BTreeMap::from([("text".to_string(), methods)]),
+        );
+
+        assert!(rendered.contains(".m0()"));
+        assert!(rendered.contains(".m4()"));
+        assert!(!rendered.contains(".m5()"));
+        assert!(rendered.contains("... (2 more methods; use help(text) for full list)"));
     }
 
     #[test]

--- a/crates/dspy-rs/src/modules/rlm/previews.rs
+++ b/crates/dspy-rs/src/modules/rlm/previews.rs
@@ -4,6 +4,7 @@ use bamltype::baml_types::TypeIR;
 use bamltype::baml_types::ir_type::{TypeGeneric, UnionTypeViewGeneric};
 use bamltype::facet::{Type, UserType};
 use bamltype::facet_reflect::{HasFields, Peek};
+use tracing::{debug, info_span, trace};
 
 use super::runtime::{MethodSignature, MethodSource};
 use crate::{
@@ -62,6 +63,14 @@ where
     S::Input: BamlType + for<'a> Facet<'a>,
 {
     let schema = SignatureSchema::of::<S>();
+    let render_span = info_span!(
+        "rlm.preview.render",
+        input_fields = schema.input_fields().len(),
+        method_vars = methods_by_var.len(),
+        soft_budget = SOFT_PREVIEW_BUDGET,
+        output_len = tracing::field::Empty
+    );
+    let _render_guard = render_span.enter();
     let root = Peek::new(input);
     let input_format = <S::Input as BamlType>::baml_output_format();
 
@@ -71,9 +80,23 @@ where
         RenderBudget::no_middle_samples(),
     ];
 
-    for budget in budgets {
+    for (attempt, budget) in budgets.into_iter().enumerate() {
         let rendered = render_with_budget(schema, root, input_format, methods_by_var, budget);
-        if rendered.chars().count() <= SOFT_PREVIEW_BUDGET || !budget.include_middle_samples {
+        let output_len = rendered.chars().count();
+        let within_budget = output_len <= SOFT_PREVIEW_BUDGET;
+        debug!(
+            attempt = attempt + 1,
+            top_level_limit = budget.top_level_limit,
+            nested_limit = budget.nested_limit,
+            include_middle_samples = budget.include_middle_samples,
+            output_len,
+            budget_consumed = output_len,
+            budget_remaining = SOFT_PREVIEW_BUDGET.saturating_sub(output_len),
+            within_budget,
+            "preview budget pass rendered"
+        );
+        if within_budget || !budget.include_middle_samples {
+            render_span.record("output_len", output_len);
             return rendered;
         }
     }
@@ -386,6 +409,7 @@ fn render_list_block(
     depth: usize,
     budget: RenderBudget,
 ) -> Vec<String> {
+    trace!(depth, size = items.len(), "rendering list preview");
     let mut lines = vec![format!("Count: {} items", items.len())];
 
     if let Some(schema_line) = class_schema_line(item_type, input_format) {
@@ -426,6 +450,7 @@ fn render_map_block(
     depth: usize,
     budget: RenderBudget,
 ) -> Vec<String> {
+    trace!(depth, size = entries.len(), "rendering map preview");
     let mut lines = vec![format!("Keys: {} items", entries.len())];
     if entries.is_empty() || depth >= STRUCT_PREVIEW_DEPTH_CAP {
         return lines;

--- a/crates/dspy-rs/src/modules/rlm/previews.rs
+++ b/crates/dspy-rs/src/modules/rlm/previews.rs
@@ -637,7 +637,12 @@ fn short_name(path: &str) -> String {
 }
 
 fn normalize_doc_text(text: &str) -> String {
-    text.split_whitespace().collect::<Vec<_>>().join(" ")
+    text.lines()
+        .map(str::trim_end)
+        .collect::<Vec<_>>()
+        .join("\n")
+        .trim()
+        .to_string()
 }
 
 fn spaces(count: usize) -> String {

--- a/crates/dspy-rs/src/modules/rlm/prompt.rs
+++ b/crates/dspy-rs/src/modules/rlm/prompt.rs
@@ -25,7 +25,20 @@ parts = llm_query_batched([f"Summarize: {c}" for c in chunks])
 summary = llm_query(f"Combine:\n" + "\n".join(parts))
 
 # Direct
-quick_answer = llm_query(f"Answer directly: {question}")"#;
+quick_answer = llm_query(f"Answer directly: {question}")
+
+# SUBMIT safely for long answers
+# Build long strings via variables first to avoid unterminated triple-quote/parens errors.
+direct_answer = (
+    "Line 1...\n"
+    "Line 2..."
+)
+key_findings = (
+    "1. First finding...\n"
+    "2. Second finding..."
+)
+
+SUBMIT(direct_answer=direct_answer, key_findings=key_findings)"#;
 
 pub(super) fn render_action_instruction<S: Signature>(
     _config: &RlmConfig,
@@ -297,6 +310,7 @@ mod tests {
         assert!(rendered.contains("## Constraints"));
         assert!(rendered.contains("## Sub-LLM Patterns"));
         assert!(rendered.contains("No markdown fences"));
+        assert!(rendered.contains("SUBMIT safely for long answers"));
     }
 
     #[test]

--- a/crates/dspy-rs/src/modules/rlm/prompt.rs
+++ b/crates/dspy-rs/src/modules/rlm/prompt.rs
@@ -1,0 +1,191 @@
+use crate::{ConstraintKind, Signature, SignatureSchema};
+
+use super::RlmConfig;
+
+const PATTERNS_BLOCK: &str = r#"## Patterns
+
+Write programs that route data through llm_query:
+
+# Filter a collection
+relevant = [x for x, r in zip(items, llm_query_batched(
+    [f"Is {x.title} about {topic}? yes/no" for x in items]
+)) if 'yes' in r.lower()]
+
+# Extract details, then synthesize
+findings = llm_query_batched([f"Key finding: {x}" for x in relevant])
+answer = llm_query(f"Synthesize:\n" + "\n---\n".join(findings))
+
+# Handle large inputs by chunking
+chunks = [text[i:i+2000] for i in range(0, len(text), 2000)]
+parts = llm_query_batched([f"Summarize: {c}" for c in chunks])
+summary = llm_query(f"Combine:\n" + "\n".join(parts))"#;
+
+pub(super) fn render_action_instruction<S: Signature>(
+    config: &RlmConfig,
+    instruction_override: Option<&str>,
+) -> String {
+    let schema = SignatureSchema::of::<S>();
+    let task = instruction_override
+        .unwrap_or_else(|| schema.instruction())
+        .trim();
+
+    let input_names = if schema.input_fields().is_empty() {
+        "(none)".to_string()
+    } else {
+        schema
+            .input_fields()
+            .iter()
+            .map(|field| field.lm_name)
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
+
+    let output_assignments = if schema.output_fields().is_empty() {
+        "".to_string()
+    } else {
+        schema
+            .output_fields()
+            .iter()
+            .map(|field| format!("{}=...", field.lm_name))
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
+
+    let mut lines = vec![
+        format!("You work in a Python REPL. {task}"),
+        String::new(),
+        format!(
+            "Your inputs - {input_names} - are available as variables in memory."
+        ),
+        "You'll see metadata about each on your first turn. The full data is larger than your context window - interact with it by writing code.".to_string(),
+        format!("When done, call SUBMIT({output_assignments})."),
+        String::new(),
+        "Each turn: write code, see what happens, decide what's next. Don't try to solve everything at once.".to_string(),
+        "Variables persist - store your findings, build on them. Anything not in a variable is lost.".to_string(),
+        String::new(),
+        format!(
+            "All REPL output is limited to {} characters. Full content is always in the variable - pass it to llm_query() to analyze anything beyond what you can see directly.",
+            config.max_output_chars
+        ),
+        String::new(),
+        "## Tools".to_string(),
+        String::new(),
+        "llm_query(prompt)".to_string(),
+        "  Delegate analysis to a sub-model with ~500K character capacity.".to_string(),
+        "  This is your primary tool. Your context window is small; sub-models are large.".to_string(),
+        "  Code finds WHERE things are; llm_query understands WHAT they mean.".to_string(),
+        String::new(),
+        "llm_query_batched(prompts)".to_string(),
+        "  Concurrent batch queries. When analyzing a collection, process all items in parallel, not one at a time.".to_string(),
+        String::new(),
+        format!("SUBMIT({output_assignments})"),
+        "  Validates against the output schema below. If validation fails, you see detailed errors and can fix and retry.".to_string(),
+        "  - Print final values before calling SUBMIT".to_string(),
+        "  - Derive outputs from variables, don't retype literals".to_string(),
+        "  - If outputs look empty, zero, or too short: investigate first".to_string(),
+        String::new(),
+        "print()".to_string(),
+        "  You only see what you print. No output means no feedback.".to_string(),
+        String::new(),
+        "Standard Python: re, json, collections, math, itertools, etc.".to_string(),
+        String::new(),
+        "## Output Contract".to_string(),
+        String::new(),
+    ];
+
+    for field in schema.output_fields() {
+        lines.push(format!(
+            "{}: {}",
+            field.lm_name,
+            field.type_ir.diagnostic_repr()
+        ));
+        if !field.docs.trim().is_empty() {
+            lines.push(format!("  {}", field.docs.trim()));
+        }
+        for constraint in field.constraints {
+            let marker = match constraint.kind {
+                ConstraintKind::Check => "soft",
+                ConstraintKind::Assert => "hard",
+            };
+            lines.push(format!(
+                "  {marker}: {} ({})",
+                constraint.label, constraint.expression
+            ));
+        }
+        lines.push(String::new());
+    }
+
+    lines.push(PATTERNS_BLOCK.to_string());
+    lines.push(String::new());
+    lines.push("## Budget".to_string());
+    lines.push(String::new());
+    lines.push(format!(
+        "{} turns. {} sub-model calls.",
+        config.max_iterations, config.max_llm_calls
+    ));
+
+    while lines.last().is_some_and(String::is_empty) {
+        lines.pop();
+    }
+
+    lines.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Signature;
+
+    use super::*;
+
+    #[derive(Signature, Clone, Debug)]
+    /// Solve the query against the corpus.
+    struct PromptSig {
+        #[input]
+        papers: Vec<String>,
+
+        #[input]
+        question: String,
+
+        #[output]
+        #[assert("this.len() > 0", label = "non_empty")]
+        answer: String,
+    }
+
+    #[test]
+    fn includes_core_sections_and_schema_substitutions() {
+        let config = RlmConfig {
+            max_iterations: 7,
+            max_llm_calls: 11,
+            max_output_chars: 1234,
+            enable_extraction_fallback: true,
+        };
+
+        let rendered = render_action_instruction::<PromptSig>(&config, None);
+
+        assert!(
+            rendered.contains("You work in a Python REPL. Solve the query against the corpus.")
+        );
+        assert!(rendered.contains("Your inputs - papers, question -"));
+        assert!(rendered.contains("SUBMIT(answer=...)"));
+        assert!(rendered.contains("## Tools"));
+        assert!(rendered.contains("llm_query(prompt)"));
+        assert!(rendered.contains("llm_query_batched(prompts)"));
+        assert!(rendered.contains("## Output Contract"));
+        assert!(rendered.contains("answer: string"));
+        assert!(rendered.contains("hard: non_empty"));
+        assert!(rendered.contains("## Patterns"));
+        assert!(rendered.contains("## Budget"));
+        assert!(rendered.contains("7 turns. 11 sub-model calls."));
+    }
+
+    #[test]
+    fn instruction_override_replaces_task_sentence() {
+        let rendered = render_action_instruction::<PromptSig>(
+            &RlmConfig::default(),
+            Some("Custom task sentence."),
+        );
+
+        assert!(rendered.contains("You work in a Python REPL. Custom task sentence."));
+        assert!(!rendered.contains("Solve the query against the corpus."));
+    }
+}

--- a/crates/dspy-rs/src/modules/rlm/prompt.rs
+++ b/crates/dspy-rs/src/modules/rlm/prompt.rs
@@ -129,6 +129,9 @@ pub(super) fn render_action_instruction<S: Signature>(
     lines.push("- `llm_query(prompt)` — query a sub-LLM (~500K char capacity)".to_string());
     lines.push("- `llm_query_batched(prompts)` — batch query concurrently".to_string());
     lines.push("- `SUBMIT(field1=value1, ...)` — submit final answer".to_string());
+    lines.push(
+        "- `cleanup(*keep)` — clear scratch vars; optionally preserve named vars".to_string(),
+    );
     lines.push("- `print()` — ALWAYS print to see results".to_string());
     lines.push("- Standard libraries available (import as needed)".to_string());
     lines.push("Plus any user-provided tools with their descriptions.".to_string());
@@ -311,6 +314,7 @@ mod tests {
         assert!(rendered.contains("## Sub-LLM Patterns"));
         assert!(rendered.contains("No markdown fences"));
         assert!(rendered.contains("SUBMIT safely for long answers"));
+        assert!(rendered.contains("`cleanup(*keep)`"));
     }
 
     #[test]

--- a/crates/dspy-rs/src/modules/rlm/prompt.rs
+++ b/crates/dspy-rs/src/modules/rlm/prompt.rs
@@ -129,9 +129,6 @@ pub(super) fn render_action_instruction<S: Signature>(
     lines.push("- `llm_query(prompt)` — query a sub-LLM (~500K char capacity)".to_string());
     lines.push("- `llm_query_batched(prompts)` — batch query concurrently".to_string());
     lines.push("- `SUBMIT(field1=value1, ...)` — submit final answer".to_string());
-    lines.push(
-        "- `cleanup(*keep)` — clear scratch vars; optionally preserve named vars".to_string(),
-    );
     lines.push("- `print()` — ALWAYS print to see results".to_string());
     lines.push("- Standard libraries available (import as needed)".to_string());
     lines.push("Plus any user-provided tools with their descriptions.".to_string());
@@ -314,7 +311,6 @@ mod tests {
         assert!(rendered.contains("## Sub-LLM Patterns"));
         assert!(rendered.contains("No markdown fences"));
         assert!(rendered.contains("SUBMIT safely for long answers"));
-        assert!(rendered.contains("`cleanup(*keep)`"));
     }
 
     #[test]

--- a/crates/dspy-rs/src/modules/rlm/prompt.rs
+++ b/crates/dspy-rs/src/modules/rlm/prompt.rs
@@ -35,7 +35,7 @@ pub(super) fn render_action_instruction<S: Signature>(
         schema
             .input_fields()
             .iter()
-            .map(|field| field.lm_name)
+            .map(|field| field.rust_name.as_str())
             .collect::<Vec<_>>()
             .join(", ")
     };

--- a/crates/dspy-rs/src/modules/rlm/prompt.rs
+++ b/crates/dspy-rs/src/modules/rlm/prompt.rs
@@ -1,128 +1,171 @@
 use crate::{ConstraintKind, Signature, SignatureSchema};
+use bamltype::baml_types::ir_type::{TypeGeneric, UnionTypeViewGeneric};
+use bamltype::internal_baml_jinja::types::OutputFormatContent;
 
 use super::RlmConfig;
+use super::previews::{is_primitive_input_type, render_type_shape, type_label};
 
-const PATTERNS_BLOCK: &str = r#"## Patterns
+const PATTERNS_BLOCK: &str = r#"## Sub-LLM Patterns
 
-Write programs that route data through llm_query:
+Use these patterns when direct string operations are not enough.
 
-# Filter a collection
+# Semantic filter
+# Budget-aware: llm_query_batched uses 1 call per item. Slice first!
 relevant = [x for x, r in zip(items, llm_query_batched(
-    [f"Is {x.title} about {topic}? yes/no" for x in items]
+    [f"Is {x.label} about {topic}? yes/no" for x in items[:5]]
 )) if 'yes' in r.lower()]
 
-# Extract details, then synthesize
+# Chain
 findings = llm_query_batched([f"Key finding: {x}" for x in relevant])
 answer = llm_query(f"Synthesize:\n" + "\n---\n".join(findings))
 
-# Handle large inputs by chunking
+# Map-reduce
 chunks = [text[i:i+2000] for i in range(0, len(text), 2000)]
 parts = llm_query_batched([f"Summarize: {c}" for c in chunks])
-summary = llm_query(f"Combine:\n" + "\n".join(parts))"#;
+summary = llm_query(f"Combine:\n" + "\n".join(parts))
+
+# Direct
+quick_answer = llm_query(f"Answer directly: {question}")"#;
 
 pub(super) fn render_action_instruction<S: Signature>(
-    config: &RlmConfig,
+    _config: &RlmConfig,
     instruction_override: Option<&str>,
+    variable_schemas: &str,
 ) -> String {
     let schema = SignatureSchema::of::<S>();
     let task = instruction_override
         .unwrap_or_else(|| schema.instruction())
         .trim();
 
-    let input_names = if schema.input_fields().is_empty() {
-        "(none)".to_string()
-    } else {
-        schema
-            .input_fields()
-            .iter()
-            .map(|field| field.rust_name.as_str())
-            .collect::<Vec<_>>()
-            .join(", ")
-    };
-
-    let output_assignments = if schema.output_fields().is_empty() {
-        "".to_string()
-    } else {
-        schema
-            .output_fields()
-            .iter()
-            .map(|field| format!("{}=...", field.lm_name))
-            .collect::<Vec<_>>()
-            .join(", ")
-    };
-
     let mut lines = vec![
-        format!("You work in a Python REPL. {task}"),
+        "## Task".to_string(),
+        task.to_string(),
         String::new(),
-        format!(
-            "Your inputs - {input_names} - are available as variables in memory."
-        ),
-        "You'll see metadata about each on your first turn. The full data is larger than your context window - interact with it by writing code.".to_string(),
-        format!("When done, call SUBMIT({output_assignments})."),
-        String::new(),
-        "Each turn: write code, see what happens, decide what's next. Don't try to solve everything at once.".to_string(),
-        "Variables persist - store your findings, build on them. Anything not in a variable is lost.".to_string(),
-        String::new(),
-        format!(
-            "All REPL output is limited to {} characters. Full content is always in the variable - pass it to llm_query() to analyze anything beyond what you can see directly.",
-            config.max_output_chars
-        ),
-        String::new(),
-        "## Tools".to_string(),
-        String::new(),
-        "llm_query(prompt)".to_string(),
-        "  Delegate analysis to a sub-model with ~500K character capacity.".to_string(),
-        "  This is your primary tool. Your context window is small; sub-models are large.".to_string(),
-        "  Code finds WHERE things are; llm_query understands WHAT they mean.".to_string(),
-        String::new(),
-        "llm_query_batched(prompts)".to_string(),
-        "  Concurrent batch queries. When analyzing a collection, process all items in parallel, not one at a time.".to_string(),
-        String::new(),
-        format!("SUBMIT({output_assignments})"),
-        "  Validates against the output schema below. If validation fails, you see detailed errors and can fix and retry.".to_string(),
-        "  - Print final values before calling SUBMIT".to_string(),
-        "  - Derive outputs from variables, don't retype literals".to_string(),
-        "  - If outputs look empty, zero, or too short: investigate first".to_string(),
-        String::new(),
-        "print()".to_string(),
-        "  You only see what you print. No output means no feedback.".to_string(),
-        String::new(),
-        "Standard Python: re, json, collections, math, itertools, etc.".to_string(),
-        String::new(),
-        "## Output Contract".to_string(),
-        String::new(),
+        "## Input Variables".to_string(),
     ];
 
-    for field in schema.output_fields() {
-        lines.push(format!(
-            "{}: {}",
-            field.lm_name,
-            field.type_ir.diagnostic_repr()
-        ));
-        if !field.docs.trim().is_empty() {
-            lines.push(format!("  {}", field.docs.trim()));
+    if variable_schemas.trim().is_empty() {
+        lines.push("(No complex input variables.)".to_string());
+    } else {
+        lines.push(variable_schemas.trim().to_string());
+    }
+
+    lines.push(String::new());
+    lines.push("## Output Schema".to_string());
+    lines.push("Call SUBMIT() with the following fields when you have your answer:".to_string());
+    lines.push(String::new());
+    lines.push("Your output fields are:".to_string());
+
+    let output_format = schema.output_format();
+    for (index, field) in schema.output_fields().iter().enumerate() {
+        let type_name = type_label(&field.type_ir, output_format);
+        let mut doc_lines = field.docs.lines().map(str::trim_end).collect::<Vec<_>>();
+        while doc_lines.first().is_some_and(|line| line.trim().is_empty()) {
+            doc_lines.remove(0);
         }
-        for constraint in field.constraints {
-            let marker = match constraint.kind {
-                ConstraintKind::Check => "soft",
-                ConstraintKind::Assert => "hard",
-            };
+        while doc_lines.last().is_some_and(|line| line.trim().is_empty()) {
+            doc_lines.pop();
+        }
+
+        if let Some(first_doc) = doc_lines.first() {
             lines.push(format!(
-                "  {marker}: {} ({})",
-                constraint.label, constraint.expression
+                "{}. `{}` ({}): {}",
+                index + 1,
+                field.lm_name,
+                type_name,
+                first_doc
+            ));
+            for line in doc_lines.iter().skip(1) {
+                lines.push(format!("   {}", line));
+            }
+        } else {
+            lines.push(format!(
+                "{}. `{}` ({})",
+                index + 1,
+                field.lm_name,
+                type_name
             ));
         }
+
+        if let Some(variants) = enum_variants_line(&field.type_ir, output_format) {
+            lines.push(format!("   Valid values: {variants}"));
+        }
+
+        if !is_simple_output_type(&field.type_ir) {
+            lines.push("   Schema:".to_string());
+            for line in render_type_shape(&field.type_ir, output_format, 5) {
+                lines.push(line);
+            }
+        }
+
         lines.push(String::new());
     }
 
+    let submit_assignments = schema
+        .output_fields()
+        .iter()
+        .map(|field| format!("{}=...", field.lm_name))
+        .collect::<Vec<_>>()
+        .join(", ");
+    lines.push(format!("When final, call SUBMIT({submit_assignments})."));
+
+    lines.push(String::new());
+    lines.push("## Available Tools".to_string());
+    lines.push("Available in the REPL:".to_string());
+    lines.push("- Input variables accessible directly by name".to_string());
+    lines.push("- `llm_query(prompt)` — query a sub-LLM (~500K char capacity)".to_string());
+    lines.push("- `llm_query_batched(prompts)` — batch query concurrently".to_string());
+    lines.push("- `SUBMIT(field1=value1, ...)` — submit final answer".to_string());
+    lines.push("- `print()` — ALWAYS print to see results".to_string());
+    lines.push("- Standard libraries available (import as needed)".to_string());
+    lines.push("Plus any user-provided tools with their descriptions.".to_string());
+
+    lines.push(String::new());
+    lines.push("## Guidelines".to_string());
+    lines.push("Response format contract:".to_string());
+    lines.push("- Output code only.".to_string());
+    lines.push("- No prose.".to_string());
+    lines.push("- No markdown fences.".to_string());
+    lines.push("- If needed, put reasoning only in Python comments.".to_string());
+    lines.push(String::new());
+    lines.push("1. EXPLORE FIRST - Look at your data before processing it.".to_string());
+    lines.push("2. ITERATE - Write small code snippets, observe, decide next steps.".to_string());
+    lines.push("3. VERIFY BEFORE SUBMITTING - If results seem wrong, reconsider.".to_string());
+    lines.push(
+        "4. USE llm_query FOR SEMANTICS - String matching finds WHERE; llm_query understands WHAT."
+            .to_string(),
+    );
+    lines.push(
+        "5. MINIMIZE RETYPING — keep intermediate results in named variables for reuse."
+            .to_string(),
+    );
+    lines.push(
+        "6. SUBMIT ONLY AFTER SEEING OUTPUTS — verify your answer looks right before calling SUBMIT.".to_string(),
+    );
+
+    lines.push(String::new());
+    lines.push("## Constraints".to_string());
+    lines.push("- Soft checks use ⚠. Hard assertions use ❌.".to_string());
+    let mut any_constraints = false;
+    for field in schema.output_fields() {
+        for constraint in field.constraints {
+            any_constraints = true;
+            let marker = match constraint.kind {
+                ConstraintKind::Check => "⚠ soft",
+                ConstraintKind::Assert => "❌ hard",
+            };
+            lines.push(format!(
+                "- `{}`: {marker} - {} ({})",
+                field.lm_name, constraint.label, constraint.expression
+            ));
+        }
+    }
+    if !any_constraints {
+        lines.push("- No explicit soft checks or hard assertions for this signature.".to_string());
+    }
+
+    lines.push(String::new());
     lines.push(PATTERNS_BLOCK.to_string());
-    lines.push(String::new());
-    lines.push("## Budget".to_string());
-    lines.push(String::new());
-    lines.push(format!(
-        "{} turns. {} sub-model calls.",
-        config.max_iterations, config.max_llm_calls
-    ));
 
     while lines.last().is_some_and(String::is_empty) {
         lines.pop();
@@ -148,8 +191,53 @@ pub(super) fn render_extract_instruction<S: Signature>(
     .join("\n")
 }
 
+fn is_simple_output_type(type_ir: &crate::TypeIR) -> bool {
+    match type_ir {
+        TypeGeneric::Union(union, _) => match union.view() {
+            UnionTypeViewGeneric::Optional(inner) => is_simple_output_type(inner),
+            _ => false,
+        },
+        TypeGeneric::List(inner, _) => is_simple_output_type(inner),
+        TypeGeneric::Primitive(..)
+        | TypeGeneric::Enum { .. }
+        | TypeGeneric::Literal(..)
+        | TypeGeneric::Top(..) => true,
+        _ => is_primitive_input_type(type_ir),
+    }
+}
+
+fn enum_variants_line(
+    type_ir: &crate::TypeIR,
+    output_format: &OutputFormatContent,
+) -> Option<String> {
+    let enum_name = match type_ir {
+        TypeGeneric::Enum { name, .. } => Some(name.as_str()),
+        TypeGeneric::Union(union, _) => match union.view() {
+            UnionTypeViewGeneric::Optional(inner) => match inner {
+                TypeGeneric::Enum { name, .. } => Some(name.as_str()),
+                _ => None,
+            },
+            _ => None,
+        },
+        _ => None,
+    }?;
+
+    let enm = output_format.enums.get(enum_name)?;
+    let variants = enm
+        .values
+        .iter()
+        .map(|(name, _)| name.rendered_name().to_string())
+        .collect::<Vec<_>>();
+    if variants.is_empty() {
+        None
+    } else {
+        Some(variants.join(" | "))
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use crate::BamlType;
     use crate::Signature;
 
     use super::*;
@@ -168,42 +256,79 @@ mod tests {
         answer: String,
     }
 
-    #[test]
-    fn includes_core_sections_and_schema_substitutions() {
-        let config = RlmConfig {
-            max_iterations: 7,
-            max_llm_calls: 11,
-            max_output_chars: 1234,
-            enable_extraction_fallback: true,
-        };
+    #[derive(Clone, Debug)]
+    #[BamlType]
+    enum FailureMode {
+        Ignorance,
+        DiscoveryFailure,
+    }
 
-        let rendered = render_action_instruction::<PromptSig>(&config, None);
+    #[derive(Signature, Clone, Debug)]
+    struct OutputFormatSig {
+        #[input]
+        question: String,
 
-        assert!(
-            rendered.contains("You work in a Python REPL. Solve the query against the corpus.")
-        );
-        assert!(rendered.contains("Your inputs - papers, question -"));
-        assert!(rendered.contains("SUBMIT(answer=...)"));
-        assert!(rendered.contains("## Tools"));
-        assert!(rendered.contains("llm_query(prompt)"));
-        assert!(rendered.contains("llm_query_batched(prompts)"));
-        assert!(rendered.contains("## Output Contract"));
-        assert!(rendered.contains("answer: string"));
-        assert!(rendered.contains("hard: non_empty"));
-        assert!(rendered.contains("## Patterns"));
-        assert!(rendered.contains("## Budget"));
-        assert!(rendered.contains("7 turns. 11 sub-model calls."));
+        #[output]
+        tags: Vec<String>,
+
+        #[output]
+        mode: FailureMode,
+
+        #[output]
+        /// Line one.
+        /// - top bullet
+        ///   - nested bullet
+        notes: String,
     }
 
     #[test]
-    fn instruction_override_replaces_task_sentence() {
+    fn includes_new_core_sections() {
         let rendered = render_action_instruction::<PromptSig>(
             &RlmConfig::default(),
-            Some("Custom task sentence."),
+            None,
+            "Variable: `papers`",
         );
 
-        assert!(rendered.contains("You work in a Python REPL. Custom task sentence."));
-        assert!(!rendered.contains("Solve the query against the corpus."));
+        assert!(rendered.contains("## Task"));
+        assert!(rendered.contains("## Input Variables"));
+        assert!(rendered.contains("## Output Schema"));
+        assert!(rendered.contains("## Available Tools"));
+        assert!(rendered.contains("## Guidelines"));
+        assert!(rendered.contains("## Constraints"));
+        assert!(rendered.contains("## Sub-LLM Patterns"));
+        assert!(rendered.contains("No markdown fences"));
+    }
+
+    #[test]
+    fn system_message_sections_are_in_locked_order() {
+        let rendered = render_action_instruction::<PromptSig>(
+            &RlmConfig::default(),
+            None,
+            "Variable: `papers`",
+        );
+
+        let idx_task = rendered.find("## Task").expect("task section");
+        let idx_inputs = rendered
+            .find("## Input Variables")
+            .expect("input variables section");
+        let idx_output = rendered
+            .find("## Output Schema")
+            .expect("output schema section");
+        let idx_tools = rendered.find("## Available Tools").expect("tools section");
+        let idx_guidelines = rendered.find("## Guidelines").expect("guidelines section");
+        let idx_constraints = rendered
+            .find("## Constraints")
+            .expect("constraints section");
+        let idx_patterns = rendered
+            .find("## Sub-LLM Patterns")
+            .expect("patterns section");
+
+        assert!(idx_task < idx_inputs);
+        assert!(idx_inputs < idx_output);
+        assert!(idx_output < idx_tools);
+        assert!(idx_tools < idx_guidelines);
+        assert!(idx_guidelines < idx_constraints);
+        assert!(idx_constraints < idx_patterns);
     }
 
     #[test]
@@ -216,10 +341,31 @@ mod tests {
     }
 
     #[test]
-    fn extract_instruction_uses_override_when_present() {
-        let rendered = render_extract_instruction::<PromptSig>(Some("Custom extraction task."));
+    fn output_section_skips_schema_for_simple_list_and_enum_and_shows_enum_values() {
+        let rendered =
+            render_action_instruction::<OutputFormatSig>(&RlmConfig::default(), None, "");
 
-        assert!(rendered.contains("Custom extraction task."));
-        assert!(!rendered.contains("Solve the query against the corpus."));
+        let tags_block = rendered
+            .split("1. `tags` (list[string])")
+            .nth(1)
+            .and_then(|tail| tail.split("2. `mode` (FailureMode)").next())
+            .expect("tags block");
+        assert!(!tags_block.contains("Schema:"));
+
+        let mode_block = rendered
+            .split("2. `mode` (FailureMode)")
+            .nth(1)
+            .and_then(|tail| tail.split("3. `notes` (string)").next())
+            .expect("mode block");
+        assert!(!mode_block.contains("Schema:"));
+        assert!(mode_block.contains("Valid values: Ignorance | DiscoveryFailure"));
+    }
+
+    #[test]
+    fn output_docstrings_preserve_leading_whitespace() {
+        let rendered =
+            render_action_instruction::<OutputFormatSig>(&RlmConfig::default(), None, "");
+        assert!(rendered.contains("   - top bullet"));
+        assert!(rendered.contains("- nested bullet"));
     }
 }

--- a/crates/dspy-rs/src/modules/rlm/prompt.rs
+++ b/crates/dspy-rs/src/modules/rlm/prompt.rs
@@ -131,6 +131,23 @@ pub(super) fn render_action_instruction<S: Signature>(
     lines.join("\n")
 }
 
+pub(super) fn render_extract_instruction<S: Signature>(
+    instruction_override: Option<&str>,
+) -> String {
+    let schema = SignatureSchema::of::<S>();
+    let task = instruction_override
+        .unwrap_or_else(|| schema.instruction())
+        .trim();
+
+    [
+        "The following REPL session was generated for this task:",
+        task,
+        "",
+        "Based on the execution history, extract the final outputs. Review what was computed and provide the best answer from the trajectory.",
+    ]
+    .join("\n")
+}
+
 #[cfg(test)]
 mod tests {
     use crate::Signature;
@@ -186,6 +203,23 @@ mod tests {
         );
 
         assert!(rendered.contains("You work in a Python REPL. Custom task sentence."));
+        assert!(!rendered.contains("Solve the query against the corpus."));
+    }
+
+    #[test]
+    fn extract_instruction_includes_task_and_extraction_guidance() {
+        let rendered = render_extract_instruction::<PromptSig>(None);
+
+        assert!(rendered.contains("The following REPL session was generated for this task:"));
+        assert!(rendered.contains("Solve the query against the corpus."));
+        assert!(rendered.contains("Based on the execution history, extract the final outputs."));
+    }
+
+    #[test]
+    fn extract_instruction_uses_override_when_present() {
+        let rendered = render_extract_instruction::<PromptSig>(Some("Custom extraction task."));
+
+        assert!(rendered.contains("Custom extraction task."));
         assert!(!rendered.contains("Solve the query against the corpus."));
     }
 }

--- a/crates/dspy-rs/src/modules/rlm/py_bridge.rs
+++ b/crates/dspy-rs/src/modules/rlm/py_bridge.rs
@@ -453,9 +453,9 @@ fn py_to_class_value(
             }
         };
 
-        path.push(real.to_string());
-        let field_value = py_to_baml_value_inner(py, &value, field_type, output_format, path)?;
-        path.pop();
+        let field_value = with_path_segment(path, real.to_string(), |path| {
+            py_to_baml_value_inner(py, &value, field_type, output_format, path)
+        })?;
         fields.insert(real.to_string(), field_value);
     }
 
@@ -506,9 +506,9 @@ fn py_to_map_value(
         let key = key
             .extract::<String>()
             .map_err(|_| conversion_error(path, key_type, &key))?;
-        path.push(key.clone());
-        let value = py_to_baml_value_inner(py, &value, value_type, output_format, path)?;
-        path.pop();
+        let value = with_path_segment(path, key.clone(), |path| {
+            py_to_baml_value_inner(py, &value, value_type, output_format, path)
+        })?;
         map.insert(key, value);
     }
 
@@ -527,9 +527,9 @@ fn py_to_list_value(
     } else if let Ok(tuple) = obj.cast::<PyTuple>() {
         let mut items = Vec::with_capacity(tuple.len());
         for (idx, item) in tuple.iter().enumerate() {
-            path.push(idx.to_string());
-            let value = py_to_baml_value_inner(py, &item, item_type, output_format, path)?;
-            path.pop();
+            let value = with_path_segment(path, idx.to_string(), |path| {
+                py_to_baml_value_inner(py, &item, item_type, output_format, path)
+            })?;
             items.push(value);
         }
         return Ok(BamlValue::List(items));
@@ -548,9 +548,9 @@ fn py_to_list_value(
 
     let mut items = Vec::with_capacity(list.len());
     for (idx, item) in list.iter().enumerate() {
-        path.push(idx.to_string());
-        let value = py_to_baml_value_inner(py, &item, item_type, output_format, path)?;
-        path.pop();
+        let value = with_path_segment(path, idx.to_string(), |path| {
+            py_to_baml_value_inner(py, &item, item_type, output_format, path)
+        })?;
         items.push(value);
     }
 
@@ -570,9 +570,9 @@ fn py_to_tuple_value(
         }
         let mut values = Vec::with_capacity(items.len());
         for (idx, (item, item_type)) in tuple.iter().zip(items.iter()).enumerate() {
-            path.push(idx.to_string());
-            let value = py_to_baml_value_inner(py, &item, item_type, output_format, path)?;
-            path.pop();
+            let value = with_path_segment(path, idx.to_string(), |path| {
+                py_to_baml_value_inner(py, &item, item_type, output_format, path)
+            })?;
             values.push(value);
         }
         return Ok(BamlValue::List(values));
@@ -584,9 +584,9 @@ fn py_to_tuple_value(
         }
         let mut values = Vec::with_capacity(items.len());
         for (idx, (item, item_type)) in list.iter().zip(items.iter()).enumerate() {
-            path.push(idx.to_string());
-            let value = py_to_baml_value_inner(py, &item, item_type, output_format, path)?;
-            path.pop();
+            let value = with_path_segment(path, idx.to_string(), |path| {
+                py_to_baml_value_inner(py, &item, item_type, output_format, path)
+            })?;
             values.push(value);
         }
         return Ok(BamlValue::List(values));
@@ -780,6 +780,17 @@ fn conversion_error(path: &[String], expected: &TypeIR, got: &Bound<'_, PyAny>) 
     ))
 }
 
+fn with_path_segment<T>(
+    path: &mut Vec<String>,
+    segment: String,
+    convert: impl FnOnce(&mut Vec<String>) -> Result<T, BamlParseError>,
+) -> Result<T, BamlParseError> {
+    path.push(segment);
+    let result = convert(path);
+    path.pop();
+    result
+}
+
 fn schema_type_name(type_ir: &TypeIR) -> String {
     crate::core::render_type_name_for_prompt_with(type_ir, crate::core::simplify_type_token)
 }
@@ -823,6 +834,7 @@ fn orjson_fallback_to_baml(
 mod tests {
     use std::sync::Arc;
 
+    use bamltype::baml_types::ir_type::UnionConstructor;
     use pyo3::types::{PyDict, PyDictMethods};
     use tokio::runtime::Handle;
 
@@ -1020,6 +1032,33 @@ mod tests {
                     .expect("getitem")
                     .is_none()
             );
+        });
+    }
+
+    #[test]
+    fn union_attempts_do_not_leak_path_segments_between_branches() {
+        Python::attach(|py| {
+            let list = PyList::empty(py);
+            list.append(3).expect("append");
+
+            let union = TypeIR::union(vec![
+                TypeIR::list(TypeIR::literal_int(1)),
+                TypeIR::list(TypeIR::literal_int(2)),
+            ]);
+            let output_format = BridgeSig::schema().output_format();
+
+            let err = py_to_baml_value(py, list.as_any(), &union, output_format)
+                .expect_err("union should fail to parse mismatched literal");
+            match err {
+                BamlParseError::Convert(err) => {
+                    assert_eq!(
+                        err.path,
+                        vec!["0".to_string()],
+                        "path should represent one nesting level, not accumulate from prior union attempts"
+                    );
+                }
+                other => panic!("unexpected error: {other}"),
+            }
         });
     }
 }

--- a/crates/dspy-rs/src/modules/rlm/py_bridge.rs
+++ b/crates/dspy-rs/src/modules/rlm/py_bridge.rs
@@ -180,13 +180,23 @@ fn extract_signature(inspect: &Bound<'_, PyModule>, callable: &Bound<'_, PyAny>)
 fn sanitize_signature(raw_signature: &str) -> String {
     let mut signature = raw_signature.trim().to_string();
 
-    if signature.starts_with("(self, /, ") {
+    if signature == "($self)" || signature == "($self, /)" {
+        signature = "()".to_string();
+    } else if signature.starts_with("($self, /, ") {
+        signature = signature.replacen("($self, /, ", "(", 1);
+    } else if signature.starts_with("($self, ") {
+        signature = signature.replacen("($self, ", "(", 1);
+    }
+
+    if signature == "(self)" || signature == "(self, /)" {
+        signature = "()".to_string();
+    } else if signature.starts_with("(self, /, ") {
         signature = signature.replacen("(self, /, ", "(", 1);
     } else if signature.starts_with("(self, ") {
         signature = signature.replacen("(self, ", "(", 1);
-    } else if signature == "(self)" || signature == "(self, /)" {
-        signature = "()".to_string();
     }
+    signature = signature.replace("($self, /)", "()");
+    signature = signature.replace("($self,)", "()");
     signature = signature.replace(", /)", ")");
     signature = signature.replace(", /, ", ", ");
 
@@ -1020,6 +1030,7 @@ mod tests {
     use tokio::runtime::Handle;
 
     use super::*;
+    use crate::BamlType;
     use crate::Signature;
     use crate::modules::rlm::{LlmQuery, SubmitSlot};
 
@@ -1333,6 +1344,33 @@ mod tests {
             assert!(matches!(dunder_len.source, MethodSource::Generated));
             assert!(!dunder_len.doc.trim().is_empty());
         });
+    }
+
+    #[test]
+    fn sanitize_signature_removes_python_self_variants() {
+        assert_eq!(
+            sanitize_signature("($self, path_fragment)"),
+            "(path_fragment)"
+        );
+        assert_eq!(
+            sanitize_signature("($self, /, path_fragment)"),
+            "(path_fragment)"
+        );
+        assert_eq!(
+            sanitize_signature("(self, /, path_fragment)"),
+            "(path_fragment)"
+        );
+        assert_eq!(sanitize_signature("($self, /)"), "()");
+    }
+
+    #[test]
+    fn sanitize_signature_simplifies_qualified_type_paths() {
+        let raw = "(query: builtins.str, other: tanha.types.Sessions) -> tanha.types.Sessions";
+        let sanitized = sanitize_signature(raw);
+        assert!(!sanitized.contains("builtins."));
+        assert!(!sanitized.contains("tanha.types."));
+        assert!(sanitized.contains("str"));
+        assert!(sanitized.contains("Sessions"));
     }
 
     #[test]

--- a/crates/dspy-rs/src/modules/rlm/py_bridge.rs
+++ b/crates/dspy-rs/src/modules/rlm/py_bridge.rs
@@ -18,7 +18,7 @@ use super::submit::SubmitHandler;
 use super::tools::LlmTools;
 use crate::{BamlConvertError, ConstraintLevel, ResponseCheck, Signature};
 
-const RESERVED_GLOBAL_NAMES: [&str; 4] = ["llm_query", "llm_query_batched", "SUBMIT", "cleanup"];
+const RESERVED_GLOBAL_NAMES: [&str; 3] = ["llm_query", "llm_query_batched", "SUBMIT"];
 
 pub fn setup_interpreter_globals<S: Signature>(
     py: Python<'_>,
@@ -55,79 +55,11 @@ where
         )?;
     }
     globals.set_item("SUBMIT", Py::new(py, submit_handler.clone())?)?;
-    inject_cleanup_helper(py, &globals, input.rlm_field_names())?;
 
     Ok(InterpreterSetup {
         globals: globals.unbind(),
         methods_by_var,
     })
-}
-
-fn inject_cleanup_helper(
-    py: Python<'_>,
-    globals: &Bound<'_, PyDict>,
-    injected_roots: &[&str],
-) -> PyResult<()> {
-    let mut protected_names = injected_roots
-        .iter()
-        .map(|name| (*name).to_string())
-        .collect::<Vec<_>>();
-    protected_names.extend(RESERVED_GLOBAL_NAMES.iter().map(|name| (*name).to_string()));
-    protected_names.sort();
-    protected_names.dedup();
-
-    let protected_names_literal = protected_names
-        .iter()
-        .map(|name| format!("{name:?}"))
-        .collect::<Vec<_>>()
-        .join(", ");
-
-    let source = format!(
-        r#"def cleanup(*keep, _protected=frozenset([{protected_names_literal}])):
-    """Clear user-created globals while preserving injected/runtime bindings.
-
-    Usage:
-        cleanup()
-        cleanup("name_to_keep", "other_name")
-    """
-    namespace = globals()
-    keep_names = [str(name) for name in keep]
-    protected = set(_protected)
-    protected.update(keep_names)
-
-    cleared = []
-    for name in list(namespace.keys()):
-        if name in protected or name.startswith("__"):
-            continue
-        del namespace[name]
-        cleared.append(name)
-
-    cleared.sort()
-    kept_present = sorted(name for name in protected if name in namespace)
-    missing_requested = sorted(name for name in keep_names if name not in namespace)
-
-    def _fmt(names):
-        return ", ".join(f"`{{item}}`" for item in names) if names else "(none)"
-
-    message = (
-        f"cleanup(): cleared {{len(cleared)}} var(s): {{_fmt(cleared)}}\n"
-        f"kept: {{_fmt(kept_present)}}"
-    )
-    if missing_requested:
-        message += f"\nrequested but not found: {{_fmt(missing_requested)}}"
-    return message
-"#
-    );
-
-    let builtins = PyModule::import(py, "builtins")?;
-    builtins
-        .getattr("exec")?
-        .call1((source.as_str(), globals, globals))?;
-
-    if let Some(cleanup_fn) = globals.get_item("cleanup")? {
-        cleanup_fn.setattr("__source__", source.as_str())?;
-    }
-    Ok(())
 }
 
 fn collect_methods_by_var(
@@ -1310,7 +1242,6 @@ mod tests {
                         .is_some()
                 );
                 assert!(globals.get_item("SUBMIT").expect("getitem").is_some());
-                assert!(globals.get_item("cleanup").expect("getitem").is_some());
                 assert!(setup.methods_by_var.contains_key("question"));
                 assert!(setup.methods_by_var.contains_key("count"));
             });
@@ -1334,7 +1265,6 @@ mod tests {
             assert!(globals.get_item("question").expect("getitem").is_some());
             assert!(globals.get_item("count").expect("getitem").is_some());
             assert!(globals.get_item("SUBMIT").expect("getitem").is_some());
-            assert!(globals.get_item("cleanup").expect("getitem").is_some());
             assert!(globals.get_item("llm_query").expect("getitem").is_none());
             assert!(
                 globals
@@ -1344,59 +1274,6 @@ mod tests {
             );
             assert!(setup.methods_by_var.contains_key("question"));
             assert!(setup.methods_by_var.contains_key("count"));
-        });
-    }
-
-    #[test]
-    fn cleanup_helper_clears_scratch_variables_and_exposes_source() {
-        Python::attach(|py| {
-            let slot: SubmitSlot = Arc::new(std::sync::Mutex::new(None));
-            let submit = SubmitHandler::new::<BridgeSig>(Arc::clone(&slot));
-            let input = BridgeSigInput {
-                question: "what?".to_string(),
-                count: 3,
-            };
-
-            let setup = setup_interpreter_globals::<BridgeSig>(py, &input, &submit, None)
-                .expect("setup globals");
-            let globals = setup.globals.bind(py).clone();
-            globals
-                .set_item("retro_corrections", vec!["a", "b"])
-                .expect("set scratch");
-            globals
-                .set_item("themes", vec!["x"])
-                .expect("set keep target");
-
-            let cleanup_fn = globals
-                .get_item("cleanup")
-                .expect("getitem")
-                .expect("cleanup fn");
-            let message = cleanup_fn
-                .call1(("themes",))
-                .expect("call cleanup")
-                .extract::<String>()
-                .expect("cleanup message");
-
-            assert!(message.contains("cleared 1 var(s)"));
-            assert!(message.contains("`retro_corrections`"));
-            assert!(message.contains("`themes`"));
-            assert!(
-                globals
-                    .get_item("retro_corrections")
-                    .expect("getitem")
-                    .is_none()
-            );
-            assert!(globals.get_item("themes").expect("getitem").is_some());
-            assert!(globals.get_item("question").expect("getitem").is_some());
-            assert!(globals.get_item("SUBMIT").expect("getitem").is_some());
-
-            let source = cleanup_fn
-                .getattr("__source__")
-                .expect("cleanup source attr")
-                .extract::<String>()
-                .expect("cleanup source string");
-            assert!(source.contains("def cleanup("));
-            assert!(source.contains("Clear user-created globals"));
         });
     }
 

--- a/crates/dspy-rs/src/modules/rlm/py_bridge.rs
+++ b/crates/dspy-rs/src/modules/rlm/py_bridge.rs
@@ -1,10 +1,10 @@
 use anyhow::anyhow;
+use bamltype::BamlParseError;
 use bamltype::baml_types::ir_type::UnionTypeViewGeneric;
 use bamltype::baml_types::{BamlMap, BamlValue, LiteralValue, StreamingMode, TypeIR, TypeValue};
 use bamltype::internal_baml_jinja::types::{Class, OutputFormatContent};
 use bamltype::jsonish;
 use bamltype::jsonish::deserializer::coercer::run_user_checks;
-use bamltype::{BamlParseError, BamlType};
 use pyo3::IntoPyObjectExt;
 use pyo3::types::{
     PyAnyMethods, PyBool, PyDict, PyDictMethods, PyFloat, PyInt, PyList, PyListMethods, PyModule,
@@ -148,10 +148,7 @@ fn extract_trimmed_docstring(callable: &Bound<'_, PyAny>) -> PyResult<String> {
     Ok(raw_doc.trim().to_string())
 }
 
-fn extract_signature(
-    inspect: &Bound<'_, PyModule>,
-    callable: &Bound<'_, PyAny>,
-) -> Option<String> {
+fn extract_signature(inspect: &Bound<'_, PyModule>, callable: &Bound<'_, PyAny>) -> Option<String> {
     if let Ok(text_sig) = callable.getattr("__text_signature__")
         && let Ok(Some(text_sig)) = text_sig.extract::<Option<String>>()
     {
@@ -177,9 +174,7 @@ fn extract_signature(
                 .map(|sig| sig.trim().to_string())
                 .filter(|sig| !sig.is_empty())
         })
-        .or_else(|| {
-            None
-        })
+        .or_else(|| None)
 }
 
 fn sanitize_signature(raw_signature: &str) -> String {
@@ -234,9 +229,7 @@ fn simplify_qualified_type_paths(raw: &str) -> String {
 
 fn classify_method_source(name: &str) -> MethodSource {
     match name {
-        "__len__" | "__iter__" | "__getitem__" | "__repr__" | "__baml__" => {
-            MethodSource::Generated
-        }
+        "__len__" | "__iter__" | "__getitem__" | "__repr__" | "__baml__" => MethodSource::Generated,
         _ => MethodSource::Custom,
     }
 }
@@ -1022,6 +1015,7 @@ mod tests {
     use std::sync::Arc;
 
     use bamltype::baml_types::ir_type::UnionConstructor;
+    use pyo3::prelude::*;
     use pyo3::types::{PyDict, PyDictMethods};
     use tokio::runtime::Handle;
 
@@ -1059,6 +1053,45 @@ mod tests {
     struct ReservedNameSig {
         #[input]
         llm_query: String,
+
+        #[output]
+        answer: String,
+    }
+
+    #[pyclass]
+    #[BamlType]
+    #[derive(Clone, Debug)]
+    struct MethodFixture {
+        label: String,
+    }
+
+    #[pymethods]
+    impl MethodFixture {
+        #[new]
+        fn new(label: String) -> Self {
+            Self { label }
+        }
+
+        #[pyo3(text_signature = "(query)")]
+        /// Search entries by query text.
+        fn search(&self, query: String) -> String {
+            format!("{}:{query}", self.label)
+        }
+
+        /// Return the character count for this fixture label.
+        fn __len__(&self) -> usize {
+            self.label.chars().count()
+        }
+
+        fn undocumented(&self) -> String {
+            self.label.clone()
+        }
+    }
+
+    #[derive(Signature, Clone, Debug)]
+    struct MethodFixtureSig {
+        #[input]
+        trajectory: MethodFixture,
 
         #[output]
         answer: String,
@@ -1183,11 +1216,10 @@ mod tests {
                     count: 3,
                 };
 
-                let globals =
+                let setup =
                     setup_interpreter_globals::<BridgeSig>(py, &input, &submit, Some(&tools))
-                        .expect("setup globals")
-                        .bind(py)
-                        .clone();
+                        .expect("setup globals");
+                let globals = setup.globals.bind(py).clone();
 
                 assert!(globals.get_item("question").expect("getitem").is_some());
                 assert!(globals.get_item("count").expect("getitem").is_some());
@@ -1199,6 +1231,8 @@ mod tests {
                         .is_some()
                 );
                 assert!(globals.get_item("SUBMIT").expect("getitem").is_some());
+                assert!(setup.methods_by_var.contains_key("question"));
+                assert!(setup.methods_by_var.contains_key("count"));
             });
         });
     }
@@ -1213,10 +1247,9 @@ mod tests {
                 count: 3,
             };
 
-            let globals = setup_interpreter_globals::<BridgeSig>(py, &input, &submit, None)
-                .expect("setup globals")
-                .bind(py)
-                .clone();
+            let setup = setup_interpreter_globals::<BridgeSig>(py, &input, &submit, None)
+                .expect("setup globals");
+            let globals = setup.globals.bind(py).clone();
 
             assert!(globals.get_item("question").expect("getitem").is_some());
             assert!(globals.get_item("count").expect("getitem").is_some());
@@ -1228,6 +1261,8 @@ mod tests {
                     .expect("getitem")
                     .is_none()
             );
+            assert!(setup.methods_by_var.contains_key("question"));
+            assert!(setup.methods_by_var.contains_key("count"));
         });
     }
 
@@ -1245,6 +1280,58 @@ mod tests {
             let message = err.to_string();
             assert!(message.contains("llm_query"));
             assert!(message.contains("reserved runtime binding"));
+        });
+    }
+
+    #[test]
+    fn setup_interpreter_globals_collects_filtered_method_metadata() {
+        Python::attach(|py| {
+            let slot: SubmitSlot = Arc::new(std::sync::Mutex::new(None));
+            let submit = SubmitHandler::new::<MethodFixtureSig>(Arc::clone(&slot));
+            let input = MethodFixtureSigInput {
+                trajectory: MethodFixture {
+                    label: "root".to_string(),
+                },
+            };
+
+            let setup = setup_interpreter_globals::<MethodFixtureSig>(py, &input, &submit, None)
+                .expect("setup globals");
+            let methods = setup
+                .methods_by_var
+                .get("trajectory")
+                .expect("trajectory methods");
+
+            assert_eq!(
+                setup.methods_by_var.keys().collect::<Vec<_>>(),
+                vec![&"trajectory".to_string()],
+                "keys must match injected variable names"
+            );
+            assert!(
+                methods.windows(2).all(|w| w[0].name <= w[1].name),
+                "method list should be deterministic and sorted by name"
+            );
+            assert!(methods.iter().any(|m| m.name == "search"));
+            assert!(methods.iter().any(|m| m.name == "__len__"));
+            assert!(!methods.iter().any(|m| m.name == "undocumented"));
+            assert!(!methods.iter().any(|m| m.name == "__baml__"));
+
+            let search = methods
+                .iter()
+                .find(|m| m.name == "search")
+                .expect("search method metadata");
+            assert!(search.signature.contains("query"));
+            assert!(!search.signature.contains("self"));
+            assert!(search.doc.contains("Search entries"));
+            assert!(matches!(search.source, MethodSource::Custom));
+            assert!(!search.is_dunder);
+
+            let dunder_len = methods
+                .iter()
+                .find(|m| m.name == "__len__")
+                .expect("__len__ metadata");
+            assert!(dunder_len.is_dunder);
+            assert!(matches!(dunder_len.source, MethodSource::Generated));
+            assert!(!dunder_len.doc.trim().is_empty());
         });
     }
 

--- a/crates/dspy-rs/src/modules/rlm/py_bridge.rs
+++ b/crates/dspy-rs/src/modules/rlm/py_bridge.rs
@@ -1,3 +1,5 @@
+use std::collections::{BTreeMap, BTreeSet};
+
 use anyhow::anyhow;
 use bamltype::BamlParseError;
 use bamltype::baml_types::ir_type::UnionTypeViewGeneric;
@@ -16,9 +18,11 @@ use serde_json::Value as JsonValue;
 use super::runtime::{InterpreterSetup, MethodSignature, MethodSource, RlmInputFields};
 use super::submit::SubmitHandler;
 use super::tools::LlmTools;
-use crate::{BamlConvertError, ConstraintLevel, ResponseCheck, Signature};
+use crate::{BamlConvertError, BamlType, ConstraintLevel, ResponseCheck, Signature};
 
 const RESERVED_GLOBAL_NAMES: [&str; 3] = ["llm_query", "llm_query_batched", "SUBMIT"];
+const MAX_METHOD_COLLECTION_DEPTH: usize = 8;
+const MAX_METHOD_COLLECTION_ITEMS: usize = 12;
 
 pub fn setup_interpreter_globals<S: Signature>(
     py: Python<'_>,
@@ -43,7 +47,9 @@ where
         )));
     }
     input.inject_into_python(py, &globals)?;
-    let methods_by_var = collect_methods_by_var(py, &globals, input.rlm_field_names())?;
+    let input_format = <S::Input as BamlType>::baml_output_format();
+    let (methods_by_var, methods_by_type) =
+        collect_methods_by_var(py, &globals, input.rlm_field_names(), input_format)?;
 
     if let Some(llm_tools) = llm_tools {
         let tools_py = Py::new(py, llm_tools.clone())?;
@@ -59,6 +65,7 @@ where
     Ok(InterpreterSetup {
         globals: globals.unbind(),
         methods_by_var,
+        methods_by_type,
     })
 }
 
@@ -66,9 +73,16 @@ fn collect_methods_by_var(
     py: Python<'_>,
     globals: &Bound<'_, PyDict>,
     field_names: &[&str],
-) -> PyResult<std::collections::BTreeMap<String, Vec<MethodSignature>>> {
+    output_format: &OutputFormatContent,
+) -> PyResult<(BTreeMap<String, Vec<MethodSignature>>, BTreeMap<String, Vec<MethodSignature>>)> {
     let inspect = PyModule::import(py, "inspect")?;
-    let mut methods_by_var = std::collections::BTreeMap::new();
+    let mut methods_by_var = BTreeMap::new();
+    let mut methods_by_type = BTreeMap::new();
+    let mut observed_classes_by_name = BTreeMap::new();
+    let mut observed_instances_by_name = BTreeMap::new();
+    let mut candidate_modules = BTreeSet::new();
+    let mut visited_object_ids = BTreeSet::new();
+    let mut visited_type_names = BTreeSet::new();
 
     for field_name in field_names {
         let Some(value) = globals.get_item(field_name)? else {
@@ -76,9 +90,30 @@ fn collect_methods_by_var(
         };
         let methods = collect_visible_methods_for_object(&inspect, &value)?;
         methods_by_var.insert((*field_name).to_string(), methods);
+        collect_methods_for_reachable_types(
+            &inspect,
+            &value,
+            &mut methods_by_type,
+            &mut observed_classes_by_name,
+            &mut observed_instances_by_name,
+            &mut candidate_modules,
+            &mut visited_object_ids,
+            &mut visited_type_names,
+            0,
+        )?;
     }
 
-    Ok(methods_by_var)
+    collect_methods_for_schema_types(
+        py,
+        &inspect,
+        output_format,
+        &mut methods_by_type,
+        &observed_classes_by_name,
+        &observed_instances_by_name,
+        &candidate_modules,
+    )?;
+
+    Ok((methods_by_var, methods_by_type))
 }
 
 fn collect_visible_methods_for_object(
@@ -97,6 +132,13 @@ fn collect_visible_methods_for_object(
     }
 
     let class = value.get_type();
+    collect_visible_methods_for_class(inspect, class.as_any())
+}
+
+fn collect_visible_methods_for_class(
+    inspect: &Bound<'_, PyModule>,
+    class: &Bound<'_, PyAny>,
+) -> PyResult<Vec<MethodSignature>> {
     let members = inspect.call_method1("getmembers", (&class, inspect.getattr("isroutine")?))?;
     let members = members.cast::<PyList>()?;
     let mut methods = Vec::new();
@@ -116,9 +158,6 @@ fn collect_visible_methods_for_object(
 
         let callable = tuple.get_item(1)?;
         let doc = extract_trimmed_docstring(&callable)?;
-        if doc.is_empty() {
-            continue;
-        }
 
         methods.push(MethodSignature {
             signature: sanitize_signature(
@@ -139,6 +178,524 @@ fn collect_visible_methods_for_object(
     });
     methods.dedup_by(|a, b| a.name == b.name && a.signature == b.signature);
     Ok(methods)
+}
+
+fn collect_methods_for_reachable_types(
+    inspect: &Bound<'_, PyModule>,
+    value: &Bound<'_, PyAny>,
+    methods_by_type: &mut BTreeMap<String, Vec<MethodSignature>>,
+    observed_classes_by_name: &mut BTreeMap<String, Py<PyAny>>,
+    observed_instances_by_name: &mut BTreeMap<String, Py<PyAny>>,
+    candidate_modules: &mut BTreeSet<String>,
+    visited_object_ids: &mut BTreeSet<usize>,
+    visited_type_names: &mut BTreeSet<String>,
+    depth: usize,
+) -> PyResult<()> {
+    if depth > MAX_METHOD_COLLECTION_DEPTH {
+        return Ok(());
+    }
+
+    let object_id = value.as_ptr() as usize;
+    if !visited_object_ids.insert(object_id) {
+        return Ok(());
+    }
+
+    let class = value.get_type();
+    let class_name = class
+        .name()
+        .ok()
+        .and_then(|name| name.extract::<String>().ok())
+        .unwrap_or_else(|| "<unknown>".to_string());
+    if visited_type_names.insert(class_name.clone()) {
+        let methods = collect_visible_methods_for_class(inspect, class.as_any())?;
+        methods_by_type.insert(class_name.clone(), methods);
+    }
+    if let Ok(module_name) = class
+        .getattr("__module__")
+        .and_then(|name| name.extract::<String>())
+    {
+        candidate_modules.insert(module_name);
+    }
+    if let Ok(py_name) = class.name().and_then(|name| name.extract::<String>()) {
+        observed_classes_by_name
+            .entry(py_name)
+            .or_insert_with(|| class.as_any().clone().unbind());
+    }
+    observed_instances_by_name
+        .entry(class_name)
+        .or_insert_with(|| value.clone().unbind());
+
+    if value.is_instance_of::<PyString>()
+        || value.is_instance_of::<PyBool>()
+        || value.is_instance_of::<PyInt>()
+        || value.is_instance_of::<PyFloat>()
+    {
+        return Ok(());
+    }
+
+    if let Ok(list) = value.cast::<PyList>() {
+        for item in list.iter().take(MAX_METHOD_COLLECTION_ITEMS) {
+            collect_methods_for_reachable_types(
+                inspect,
+                &item,
+                methods_by_type,
+                observed_classes_by_name,
+                observed_instances_by_name,
+                candidate_modules,
+                visited_object_ids,
+                visited_type_names,
+                depth + 1,
+            )?;
+        }
+        return Ok(());
+    }
+
+    if let Ok(tuple) = value.cast::<PyTuple>() {
+        for item in tuple.iter().take(MAX_METHOD_COLLECTION_ITEMS) {
+            collect_methods_for_reachable_types(
+                inspect,
+                &item,
+                methods_by_type,
+                observed_classes_by_name,
+                observed_instances_by_name,
+                candidate_modules,
+                visited_object_ids,
+                visited_type_names,
+                depth + 1,
+            )?;
+        }
+        return Ok(());
+    }
+
+    if let Ok(dict) = value.cast::<PyDict>() {
+        for (key, item) in dict.iter().take(MAX_METHOD_COLLECTION_ITEMS) {
+            collect_methods_for_reachable_types(
+                inspect,
+                &key,
+                methods_by_type,
+                observed_classes_by_name,
+                observed_instances_by_name,
+                candidate_modules,
+                visited_object_ids,
+                visited_type_names,
+                depth + 1,
+            )?;
+            collect_methods_for_reachable_types(
+                inspect,
+                &item,
+                methods_by_type,
+                observed_classes_by_name,
+                observed_instances_by_name,
+                candidate_modules,
+                visited_object_ids,
+                visited_type_names,
+                depth + 1,
+            )?;
+        }
+        return Ok(());
+    }
+
+    if let Ok(object_dict) = value.getattr("__dict__")
+        && let Ok(object_dict) = object_dict.cast::<PyDict>()
+    {
+        for (_name, item) in object_dict.iter() {
+            collect_methods_for_reachable_types(
+                inspect,
+                &item,
+                methods_by_type,
+                observed_classes_by_name,
+                observed_instances_by_name,
+                candidate_modules,
+                visited_object_ids,
+                visited_type_names,
+                depth + 1,
+            )?;
+        }
+    }
+
+    if let Ok(class_dict_any) = class.getattr("__dict__")
+        && let Ok(class_dict) = class_dict_any.cast::<PyDict>()
+    {
+        for (name, _) in class_dict.iter() {
+            let Ok(name) = name.extract::<String>() else {
+                continue;
+            };
+            if name.starts_with("__") {
+                continue;
+            }
+            let Ok(item) = value.getattr(name.as_str()) else {
+                continue;
+            };
+            if item.is_callable() {
+                continue;
+            }
+            collect_methods_for_reachable_types(
+                inspect,
+                &item,
+                methods_by_type,
+                observed_classes_by_name,
+                observed_instances_by_name,
+                candidate_modules,
+                visited_object_ids,
+                visited_type_names,
+                depth + 1,
+            )?;
+        }
+    }
+
+    if let Ok(annotations_any) = class.getattr("__annotations__")
+        && let Ok(annotations) = annotations_any.cast::<PyDict>()
+    {
+        for (name, _) in annotations.iter() {
+            let Ok(name) = name.extract::<String>() else {
+                continue;
+            };
+            if name.starts_with("__") {
+                continue;
+            }
+            let Ok(item) = value.getattr(name.as_str()) else {
+                continue;
+            };
+            collect_methods_for_reachable_types(
+                inspect,
+                &item,
+                methods_by_type,
+                observed_classes_by_name,
+                observed_instances_by_name,
+                candidate_modules,
+                visited_object_ids,
+                visited_type_names,
+                depth + 1,
+            )?;
+        }
+    }
+
+    Ok(())
+}
+
+fn collect_methods_for_schema_types(
+    py: Python<'_>,
+    inspect: &Bound<'_, PyModule>,
+    output_format: &OutputFormatContent,
+    methods_by_type: &mut BTreeMap<String, Vec<MethodSignature>>,
+    observed_classes_by_name: &BTreeMap<String, Py<PyAny>>,
+    observed_instances_by_name: &BTreeMap<String, Py<PyAny>>,
+    candidate_modules: &BTreeSet<String>,
+) -> PyResult<()> {
+    let module_classes = collect_module_class_objects(py, inspect, candidate_modules)?;
+    let object_subclasses = collect_object_subclass_index(py)?;
+    let schema_type_names = collect_schema_type_names(output_format);
+    let runtime_type_names = observed_classes_by_name
+        .keys()
+        .cloned()
+        .collect::<BTreeSet<_>>();
+
+    let mut schema_class_names = BTreeMap::<String, BTreeSet<String>>::new();
+    let mut schema_fields = BTreeMap::<String, Vec<String>>::new();
+    for ((raw_name, _streaming), class) in output_format.classes.iter() {
+        let rendered_name = class.name.rendered_name().to_string();
+        let aliases = schema_class_names.entry(rendered_name.clone()).or_default();
+        aliases.insert(rendered_name);
+        aliases.insert(raw_name.clone());
+        schema_fields.entry(class.name.rendered_name().to_string()).or_insert_with(|| {
+            class
+                .fields
+                .iter()
+                .map(|(field_name, _, _, _)| field_name.real_name().to_string())
+                .collect()
+        });
+    }
+
+    let mut resolved_classes = BTreeMap::<String, Py<PyAny>>::new();
+    let mut resolved_instances = BTreeMap::<String, Py<PyAny>>::new();
+    for (rendered_name, aliases) in &schema_class_names {
+        if let Some(class_obj) = resolve_schema_class_object(
+            py,
+            aliases,
+            observed_classes_by_name,
+            &module_classes,
+            &object_subclasses,
+        ) {
+            resolved_classes.insert(rendered_name.clone(), class_obj);
+        }
+        if let Some(instance_obj) = resolve_schema_instance_object(py, aliases, observed_instances_by_name)
+        {
+            resolved_instances.insert(rendered_name.clone(), instance_obj);
+        }
+        if !resolved_classes.contains_key(rendered_name)
+            && let Some(instance) = resolved_instances.get(rendered_name)
+        {
+            resolved_classes.insert(
+                rendered_name.clone(),
+                instance.bind(py).get_type().as_any().clone().unbind(),
+            );
+        }
+    }
+
+    loop {
+        let unresolved = schema_class_names
+            .keys()
+            .filter(|name| !resolved_classes.contains_key(*name))
+            .cloned()
+            .collect::<Vec<_>>();
+        if unresolved.is_empty() {
+            break;
+        }
+        let progressed = project_unresolved_schema_classes_from_runtime_fields(
+            py,
+            &unresolved,
+            &schema_class_names,
+            &schema_fields,
+            &mut resolved_classes,
+            &mut resolved_instances,
+        )?;
+        if !progressed {
+            break;
+        }
+    }
+
+    for (rendered_name, aliases) in schema_class_names {
+        let synthetic_by_alias = rendered_name.contains('_') && aliases.iter().any(|a| a.contains("__"));
+        if synthetic_by_alias
+            || is_synthetic_variant_class_name(&rendered_name, &schema_type_names, &runtime_type_names)
+        {
+            methods_by_type.insert(rendered_name, Vec::new());
+            continue;
+        }
+        if methods_by_type.contains_key(&rendered_name) {
+            continue;
+        }
+        let methods = if let Some(class_obj) = resolved_classes.get(&rendered_name) {
+            let class_obj = class_obj.bind(py);
+            let resolved_name = class_obj
+                .getattr("__name__")
+                .ok()
+                .and_then(|name| name.extract::<String>().ok())
+                .unwrap_or_default();
+            if resolved_name == rendered_name {
+                collect_visible_methods_for_class(inspect, class_obj)?
+            } else {
+                Vec::new()
+            }
+        } else {
+            Vec::new()
+        };
+        let _ = aliases;
+        methods_by_type.insert(rendered_name, methods);
+    }
+
+    Ok(())
+}
+
+fn collect_module_class_objects(
+    py: Python<'_>,
+    inspect: &Bound<'_, PyModule>,
+    module_names: &BTreeSet<String>,
+) -> PyResult<BTreeMap<String, Py<PyAny>>> {
+    let is_class = inspect.getattr("isclass")?;
+    let mut classes = BTreeMap::new();
+    for module_name in module_names {
+        let Ok(module) = PyModule::import(py, module_name.as_str()) else {
+            continue;
+        };
+        let Ok(members_any) = inspect.call_method1("getmembers", (&module, &is_class)) else {
+            continue;
+        };
+        let Ok(members) = members_any.cast::<PyList>() else {
+            continue;
+        };
+        for member in members.iter() {
+            let Ok(tuple) = member.cast::<PyTuple>() else {
+                continue;
+            };
+            if tuple.len() != 2 {
+                continue;
+            }
+            let Ok(name) = tuple.get_item(0)?.extract::<String>() else {
+                continue;
+            };
+            let Ok(class_obj) = tuple.get_item(1) else {
+                continue;
+            };
+            classes
+                .entry(name)
+                .or_insert_with(|| class_obj.clone().unbind());
+        }
+    }
+    Ok(classes)
+}
+
+fn collect_object_subclass_index(py: Python<'_>) -> PyResult<BTreeMap<String, Py<PyAny>>> {
+    let builtins = PyModule::import(py, "builtins")?;
+    let object_type = builtins.getattr("object")?;
+    let subclasses_any = object_type.call_method0("__subclasses__")?;
+    let subclasses = subclasses_any.cast::<PyList>()?;
+    let mut classes = BTreeMap::new();
+    for subclass in subclasses.iter() {
+        let Ok(name) = subclass.getattr("__name__").and_then(|name| name.extract::<String>()) else {
+            continue;
+        };
+        classes.entry(name).or_insert_with(|| subclass.clone().unbind());
+    }
+    Ok(classes)
+}
+
+fn resolve_schema_class_object(
+    py: Python<'_>,
+    aliases: &BTreeSet<String>,
+    observed_classes_by_name: &BTreeMap<String, Py<PyAny>>,
+    module_classes: &BTreeMap<String, Py<PyAny>>,
+    object_subclasses: &BTreeMap<String, Py<PyAny>>,
+) -> Option<Py<PyAny>> {
+    for alias in aliases {
+        if let Some(class_obj) = observed_classes_by_name.get(alias) {
+            return Some(class_obj.clone_ref(py));
+        }
+    }
+    for alias in aliases {
+        if let Some(class_obj) = module_classes.get(alias) {
+            return Some(class_obj.clone_ref(py));
+        }
+    }
+    for alias in aliases {
+        if let Some(class_obj) = object_subclasses.get(alias) {
+            return Some(class_obj.clone_ref(py));
+        }
+    }
+    None
+}
+
+fn resolve_schema_instance_object(
+    py: Python<'_>,
+    aliases: &BTreeSet<String>,
+    observed_instances_by_name: &BTreeMap<String, Py<PyAny>>,
+) -> Option<Py<PyAny>> {
+    for alias in aliases {
+        if let Some(instance) = observed_instances_by_name.get(alias) {
+            return Some(instance.clone_ref(py));
+        }
+    }
+    None
+}
+
+fn collect_schema_type_names(output_format: &OutputFormatContent) -> BTreeSet<String> {
+    let mut names = BTreeSet::new();
+    for class in output_format.classes.values() {
+        names.insert(class.name.rendered_name().to_string());
+    }
+    for enm in output_format.enums.values() {
+        names.insert(enm.name.rendered_name().to_string());
+    }
+    names
+}
+
+fn is_synthetic_variant_class_name(
+    rendered_name: &str,
+    schema_type_names: &BTreeSet<String>,
+    runtime_type_names: &BTreeSet<String>,
+) -> bool {
+    let Some((prefix, suffix)) = rendered_name.split_once('_') else {
+        return false;
+    };
+    if prefix.is_empty() || suffix.is_empty() {
+        return false;
+    }
+    let Some(first) = suffix.chars().next() else {
+        return false;
+    };
+    first.is_ascii_uppercase()
+        && (schema_type_names.contains(prefix) || runtime_type_names.contains(prefix))
+}
+
+fn project_unresolved_schema_classes_from_runtime_fields(
+    py: Python<'_>,
+    unresolved: &[String],
+    schema_aliases: &BTreeMap<String, BTreeSet<String>>,
+    schema_fields: &BTreeMap<String, Vec<String>>,
+    resolved_classes: &mut BTreeMap<String, Py<PyAny>>,
+    resolved_instances: &mut BTreeMap<String, Py<PyAny>>,
+) -> PyResult<bool> {
+    let mut progressed = false;
+    let mut discovered = Vec::<(String, Py<PyAny>, Py<PyAny>)>::new();
+    let parents = resolved_instances
+        .keys()
+        .cloned()
+        .collect::<Vec<_>>();
+
+    for parent in parents {
+        let Some(instance) = resolved_instances.get(&parent) else {
+            continue;
+        };
+        let Some(field_names) = schema_fields.get(&parent) else {
+            continue;
+        };
+        let instance = instance.bind(py);
+        for field_name in field_names {
+            let Ok(field_value) = instance.getattr(field_name.as_str()) else {
+                continue;
+            };
+
+            let candidate = if let Ok(list) = field_value.cast::<PyList>() {
+                if list.is_empty() {
+                    None
+                } else {
+                    list.get_item(0).ok()
+                }
+            } else if let Ok(tuple) = field_value.cast::<PyTuple>() {
+                if tuple.is_empty() {
+                    None
+                } else {
+                    tuple.get_item(0).ok()
+                }
+            } else {
+                Some(field_value)
+            };
+
+            let Some(candidate) = candidate else {
+                continue;
+            };
+            if candidate.is_none() || candidate.is_callable() {
+                continue;
+            }
+
+            let candidate_class = candidate.get_type();
+            let Ok(candidate_name) = candidate_class
+                .name()
+                .and_then(|name| name.extract::<String>())
+            else {
+                continue;
+            };
+
+            for target in unresolved {
+                if resolved_classes.contains_key(target) {
+                    continue;
+                }
+                let Some(aliases) = schema_aliases.get(target) else {
+                    continue;
+                };
+                if !aliases.contains(&candidate_name) {
+                    continue;
+                }
+
+                discovered.push((
+                    target.clone(),
+                    candidate_class.as_any().clone().unbind(),
+                    candidate.clone().unbind(),
+                ));
+            }
+        }
+    }
+
+    for (target, class_obj, instance_obj) in discovered {
+        if resolved_classes.contains_key(&target) {
+            continue;
+        }
+        resolved_classes.insert(target.clone(), class_obj);
+        resolved_instances.entry(target).or_insert(instance_obj);
+        progressed = true;
+    }
+
+    Ok(progressed)
 }
 
 fn extract_trimmed_docstring(callable: &Bound<'_, PyAny>) -> PyResult<String> {
@@ -1108,6 +1665,51 @@ mod tests {
         answer: String,
     }
 
+    #[derive(Signature, Clone, Debug)]
+    struct MethodFixtureListSig {
+        #[input]
+        trajectories: Vec<MethodFixture>,
+
+        #[output]
+        answer: String,
+    }
+
+    #[pyclass]
+    #[BamlType]
+    #[derive(Clone, Debug)]
+    struct NoAnnotationsChild {
+        label: String,
+    }
+
+    #[pymethods]
+    impl NoAnnotationsChild {
+        #[new]
+        fn new(label: String) -> Self {
+            Self { label }
+        }
+
+        /// Thread view for this child fixture.
+        fn thread(&self, participants: Vec<String>) -> String {
+            format!("{}:{}", self.label, participants.join(","))
+        }
+    }
+
+    #[pyclass]
+    #[BamlType]
+    #[derive(Clone, Debug)]
+    struct NoAnnotationsContainer {
+        items: Vec<NoAnnotationsChild>,
+    }
+
+    #[derive(Signature, Clone, Debug)]
+    struct NoAnnotationsSig {
+        #[input]
+        container: NoAnnotationsContainer,
+
+        #[output]
+        answer: String,
+    }
+
     struct MockLm;
 
     #[async_trait::async_trait]
@@ -1244,6 +1846,8 @@ mod tests {
                 assert!(globals.get_item("SUBMIT").expect("getitem").is_some());
                 assert!(setup.methods_by_var.contains_key("question"));
                 assert!(setup.methods_by_var.contains_key("count"));
+                assert!(setup.methods_by_type.contains_key("str"));
+                assert!(setup.methods_by_type.contains_key("int"));
             });
         });
     }
@@ -1274,6 +1878,8 @@ mod tests {
             );
             assert!(setup.methods_by_var.contains_key("question"));
             assert!(setup.methods_by_var.contains_key("count"));
+            assert!(setup.methods_by_type.contains_key("str"));
+            assert!(setup.methods_by_type.contains_key("int"));
         });
     }
 
@@ -1311,6 +1917,10 @@ mod tests {
                 .methods_by_var
                 .get("trajectory")
                 .expect("trajectory methods");
+            let type_methods = setup
+                .methods_by_type
+                .get("MethodFixture")
+                .expect("MethodFixture methods");
 
             assert_eq!(
                 setup.methods_by_var.keys().collect::<Vec<_>>(),
@@ -1323,8 +1933,9 @@ mod tests {
             );
             assert!(methods.iter().any(|m| m.name == "search"));
             assert!(methods.iter().any(|m| m.name == "__len__"));
-            assert!(!methods.iter().any(|m| m.name == "undocumented"));
+            assert!(methods.iter().any(|m| m.name == "undocumented"));
             assert!(!methods.iter().any(|m| m.name == "__baml__"));
+            assert!(type_methods.iter().any(|m| m.name == "search"));
 
             let search = methods
                 .iter()
@@ -1336,6 +1947,14 @@ mod tests {
             assert!(matches!(search.source, MethodSource::Custom));
             assert!(!search.is_dunder);
 
+            let undocumented = methods
+                .iter()
+                .find(|m| m.name == "undocumented")
+                .expect("undocumented method metadata");
+            assert!(undocumented.doc.is_empty());
+            assert!(matches!(undocumented.source, MethodSource::Custom));
+            assert!(!undocumented.is_dunder);
+
             let dunder_len = methods
                 .iter()
                 .find(|m| m.name == "__len__")
@@ -1343,6 +1962,63 @@ mod tests {
             assert!(dunder_len.is_dunder);
             assert!(matches!(dunder_len.source, MethodSource::Generated));
             assert!(!dunder_len.doc.trim().is_empty());
+        });
+    }
+
+    #[test]
+    fn setup_interpreter_globals_collects_reachable_nested_type_methods() {
+        Python::attach(|py| {
+            let slot: SubmitSlot = Arc::new(std::sync::Mutex::new(None));
+            let submit = SubmitHandler::new::<MethodFixtureListSig>(Arc::clone(&slot));
+            let input = MethodFixtureListSigInput {
+                trajectories: vec![MethodFixture {
+                    label: "root".to_string(),
+                }],
+            };
+
+            let setup = setup_interpreter_globals::<MethodFixtureListSig>(py, &input, &submit, None)
+                .expect("setup globals");
+            let nested_type_methods = setup
+                .methods_by_type
+                .get("MethodFixture")
+                .expect("nested MethodFixture methods");
+
+            assert!(
+                nested_type_methods.iter().any(|m| m.name == "search"),
+                "nested type methods should include custom MethodFixture methods"
+            );
+        });
+    }
+
+    #[test]
+    fn setup_interpreter_globals_collects_schema_nested_type_methods_without_runtime_instance() {
+        Python::attach(|py| {
+            let _unused = Py::new(
+                py,
+                NoAnnotationsChild {
+                    label: "seed".to_string(),
+                },
+            )
+            .expect("seed nested class type object");
+
+            let slot: SubmitSlot = Arc::new(std::sync::Mutex::new(None));
+            let submit = SubmitHandler::new::<NoAnnotationsSig>(Arc::clone(&slot));
+            let input = NoAnnotationsSigInput {
+                container: NoAnnotationsContainer { items: Vec::new() },
+            };
+
+            let setup =
+                setup_interpreter_globals::<NoAnnotationsSig>(py, &input, &submit, None)
+                    .expect("setup globals");
+            let nested_methods = setup
+                .methods_by_type
+                .get("NoAnnotationsChild")
+                .expect("nested schema type methods");
+
+            assert!(
+                nested_methods.iter().any(|m| m.name == "thread"),
+                "schema-driven class lookup should collect nested type methods even when the input graph has no nested instances"
+            );
         });
     }
 

--- a/crates/dspy-rs/src/modules/rlm/py_bridge.rs
+++ b/crates/dspy-rs/src/modules/rlm/py_bridge.rs
@@ -21,7 +21,7 @@ pub fn setup_interpreter_globals<S: Signature>(
     py: Python<'_>,
     input: &S::Input,
     submit_handler: &SubmitHandler,
-    llm_tools: &LlmTools,
+    llm_tools: Option<&LlmTools>,
 ) -> PyResult<Py<PyDict>> {
     let globals = PyDict::new(py);
 
@@ -40,13 +40,15 @@ pub fn setup_interpreter_globals<S: Signature>(
         }
     }
 
-    let tools_py = Py::new(py, llm_tools.clone())?;
-    let tools_bound = tools_py.bind(py);
-    globals.set_item("llm_query", tools_bound.getattr("llm_query")?)?;
-    globals.set_item(
-        "llm_query_batched",
-        tools_bound.getattr("llm_query_batched")?,
-    )?;
+    if let Some(llm_tools) = llm_tools {
+        let tools_py = Py::new(py, llm_tools.clone())?;
+        let tools_bound = tools_py.bind(py);
+        globals.set_item("llm_query", tools_bound.getattr("llm_query")?)?;
+        globals.set_item(
+            "llm_query_batched",
+            tools_bound.getattr("llm_query_batched")?,
+        )?;
+    }
     globals.set_item("SUBMIT", Py::new(py, submit_handler.clone())?)?;
 
     Ok(globals.unbind())
@@ -969,10 +971,11 @@ mod tests {
                     count: 3,
                 };
 
-                let globals = setup_interpreter_globals::<BridgeSig>(py, &input, &submit, &tools)
-                    .expect("setup globals")
-                    .bind(py)
-                    .clone();
+                let globals =
+                    setup_interpreter_globals::<BridgeSig>(py, &input, &submit, Some(&tools))
+                        .expect("setup globals")
+                        .bind(py)
+                        .clone();
 
                 assert!(globals.get_item("question").expect("getitem").is_some());
                 assert!(globals.get_item("count").expect("getitem").is_some());
@@ -985,6 +988,34 @@ mod tests {
                 );
                 assert!(globals.get_item("SUBMIT").expect("getitem").is_some());
             });
+        });
+    }
+
+    #[test]
+    fn setup_interpreter_globals_without_sub_lm_tools_still_injects_submit_and_inputs() {
+        Python::attach(|py| {
+            let slot: SubmitSlot = Arc::new(std::sync::Mutex::new(None));
+            let submit = SubmitHandler::new::<BridgeSig>(Arc::clone(&slot));
+            let input = BridgeSigInput {
+                question: "what?".to_string(),
+                count: 3,
+            };
+
+            let globals = setup_interpreter_globals::<BridgeSig>(py, &input, &submit, None)
+                .expect("setup globals")
+                .bind(py)
+                .clone();
+
+            assert!(globals.get_item("question").expect("getitem").is_some());
+            assert!(globals.get_item("count").expect("getitem").is_some());
+            assert!(globals.get_item("SUBMIT").expect("getitem").is_some());
+            assert!(globals.get_item("llm_query").expect("getitem").is_none());
+            assert!(
+                globals
+                    .get_item("llm_query_batched")
+                    .expect("getitem")
+                    .is_none()
+            );
         });
     }
 }

--- a/crates/dspy-rs/src/modules/rlm/py_bridge.rs
+++ b/crates/dspy-rs/src/modules/rlm/py_bridge.rs
@@ -18,7 +18,7 @@ use super::submit::SubmitHandler;
 use super::tools::LlmTools;
 use crate::{BamlConvertError, ConstraintLevel, ResponseCheck, Signature};
 
-const RESERVED_GLOBAL_NAMES: [&str; 3] = ["llm_query", "llm_query_batched", "SUBMIT"];
+const RESERVED_GLOBAL_NAMES: [&str; 4] = ["llm_query", "llm_query_batched", "SUBMIT", "cleanup"];
 
 pub fn setup_interpreter_globals<S: Signature>(
     py: Python<'_>,
@@ -55,11 +55,79 @@ where
         )?;
     }
     globals.set_item("SUBMIT", Py::new(py, submit_handler.clone())?)?;
+    inject_cleanup_helper(py, &globals, input.rlm_field_names())?;
 
     Ok(InterpreterSetup {
         globals: globals.unbind(),
         methods_by_var,
     })
+}
+
+fn inject_cleanup_helper(
+    py: Python<'_>,
+    globals: &Bound<'_, PyDict>,
+    injected_roots: &[&str],
+) -> PyResult<()> {
+    let mut protected_names = injected_roots
+        .iter()
+        .map(|name| (*name).to_string())
+        .collect::<Vec<_>>();
+    protected_names.extend(RESERVED_GLOBAL_NAMES.iter().map(|name| (*name).to_string()));
+    protected_names.sort();
+    protected_names.dedup();
+
+    let protected_names_literal = protected_names
+        .iter()
+        .map(|name| format!("{name:?}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    let source = format!(
+        r#"def cleanup(*keep, _protected=frozenset([{protected_names_literal}])):
+    """Clear user-created globals while preserving injected/runtime bindings.
+
+    Usage:
+        cleanup()
+        cleanup("name_to_keep", "other_name")
+    """
+    namespace = globals()
+    keep_names = [str(name) for name in keep]
+    protected = set(_protected)
+    protected.update(keep_names)
+
+    cleared = []
+    for name in list(namespace.keys()):
+        if name in protected or name.startswith("__"):
+            continue
+        del namespace[name]
+        cleared.append(name)
+
+    cleared.sort()
+    kept_present = sorted(name for name in protected if name in namespace)
+    missing_requested = sorted(name for name in keep_names if name not in namespace)
+
+    def _fmt(names):
+        return ", ".join(f"`{{item}}`" for item in names) if names else "(none)"
+
+    message = (
+        f"cleanup(): cleared {{len(cleared)}} var(s): {{_fmt(cleared)}}\n"
+        f"kept: {{_fmt(kept_present)}}"
+    )
+    if missing_requested:
+        message += f"\nrequested but not found: {{_fmt(missing_requested)}}"
+    return message
+"#
+    );
+
+    let builtins = PyModule::import(py, "builtins")?;
+    builtins
+        .getattr("exec")?
+        .call1((source.as_str(), globals, globals))?;
+
+    if let Some(cleanup_fn) = globals.get_item("cleanup")? {
+        cleanup_fn.setattr("__source__", source.as_str())?;
+    }
+    Ok(())
 }
 
 fn collect_methods_by_var(
@@ -1242,6 +1310,7 @@ mod tests {
                         .is_some()
                 );
                 assert!(globals.get_item("SUBMIT").expect("getitem").is_some());
+                assert!(globals.get_item("cleanup").expect("getitem").is_some());
                 assert!(setup.methods_by_var.contains_key("question"));
                 assert!(setup.methods_by_var.contains_key("count"));
             });
@@ -1265,6 +1334,7 @@ mod tests {
             assert!(globals.get_item("question").expect("getitem").is_some());
             assert!(globals.get_item("count").expect("getitem").is_some());
             assert!(globals.get_item("SUBMIT").expect("getitem").is_some());
+            assert!(globals.get_item("cleanup").expect("getitem").is_some());
             assert!(globals.get_item("llm_query").expect("getitem").is_none());
             assert!(
                 globals
@@ -1274,6 +1344,59 @@ mod tests {
             );
             assert!(setup.methods_by_var.contains_key("question"));
             assert!(setup.methods_by_var.contains_key("count"));
+        });
+    }
+
+    #[test]
+    fn cleanup_helper_clears_scratch_variables_and_exposes_source() {
+        Python::attach(|py| {
+            let slot: SubmitSlot = Arc::new(std::sync::Mutex::new(None));
+            let submit = SubmitHandler::new::<BridgeSig>(Arc::clone(&slot));
+            let input = BridgeSigInput {
+                question: "what?".to_string(),
+                count: 3,
+            };
+
+            let setup = setup_interpreter_globals::<BridgeSig>(py, &input, &submit, None)
+                .expect("setup globals");
+            let globals = setup.globals.bind(py).clone();
+            globals
+                .set_item("retro_corrections", vec!["a", "b"])
+                .expect("set scratch");
+            globals
+                .set_item("themes", vec!["x"])
+                .expect("set keep target");
+
+            let cleanup_fn = globals
+                .get_item("cleanup")
+                .expect("getitem")
+                .expect("cleanup fn");
+            let message = cleanup_fn
+                .call1(("themes",))
+                .expect("call cleanup")
+                .extract::<String>()
+                .expect("cleanup message");
+
+            assert!(message.contains("cleared 1 var(s)"));
+            assert!(message.contains("`retro_corrections`"));
+            assert!(message.contains("`themes`"));
+            assert!(
+                globals
+                    .get_item("retro_corrections")
+                    .expect("getitem")
+                    .is_none()
+            );
+            assert!(globals.get_item("themes").expect("getitem").is_some());
+            assert!(globals.get_item("question").expect("getitem").is_some());
+            assert!(globals.get_item("SUBMIT").expect("getitem").is_some());
+
+            let source = cleanup_fn
+                .getattr("__source__")
+                .expect("cleanup source attr")
+                .extract::<String>()
+                .expect("cleanup source string");
+            assert!(source.contains("def cleanup("));
+            assert!(source.contains("Clear user-created globals"));
         });
     }
 

--- a/crates/dspy-rs/src/modules/rlm/py_bridge.rs
+++ b/crates/dspy-rs/src/modules/rlm/py_bridge.rs
@@ -7,12 +7,13 @@ use bamltype::jsonish::deserializer::coercer::run_user_checks;
 use bamltype::{BamlParseError, BamlType};
 use pyo3::IntoPyObjectExt;
 use pyo3::types::{
-    PyAnyMethods, PyBool, PyDict, PyDictMethods, PyList, PyListMethods, PyModule, PyString,
-    PyTuple, PyTupleMethods, PyTypeMethods,
+    PyAnyMethods, PyBool, PyDict, PyDictMethods, PyFloat, PyInt, PyList, PyListMethods, PyModule,
+    PyString, PyTuple, PyTupleMethods, PyTypeMethods,
 };
 use pyo3::{Bound, Py, PyAny, PyResult, Python};
 use serde_json::Value as JsonValue;
 
+use super::runtime::{InterpreterSetup, MethodSignature, MethodSource, RlmInputFields};
 use super::submit::SubmitHandler;
 use super::tools::LlmTools;
 use crate::{BamlConvertError, ConstraintLevel, ResponseCheck, Signature};
@@ -24,32 +25,25 @@ pub fn setup_interpreter_globals<S: Signature>(
     input: &S::Input,
     submit_handler: &SubmitHandler,
     llm_tools: Option<&LlmTools>,
-) -> PyResult<Py<PyDict>> {
+) -> PyResult<InterpreterSetup>
+where
+    S::Input: RlmInputFields,
+{
     let globals = PyDict::new(py);
 
-    let input_value = input.to_baml_value();
-    match input_value {
-        BamlValue::Class(_, ref fields) | BamlValue::Map(ref fields) => {
-            if let Some(name) = fields
-                .keys()
-                .find(|name| RESERVED_GLOBAL_NAMES.contains(&name.as_str()))
-            {
-                return Err(pyo3::exceptions::PyValueError::new_err(format!(
-                    "RLM input field '{name}' conflicts with reserved runtime binding. Rename this field (reserved names: {}).",
-                    RESERVED_GLOBAL_NAMES.join(", ")
-                )));
-            }
-            for (name, value) in fields {
-                globals.set_item(name, baml_value_to_py(py, value)?)?;
-            }
-        }
-        other => {
-            return Err(pyo3::exceptions::PyTypeError::new_err(format!(
-                "RLM input must serialize to object-like BamlValue, got {}",
-                other.r#type()
-            )));
-        }
+    if let Some(name) = input
+        .rlm_field_names()
+        .iter()
+        .copied()
+        .find(|name| RESERVED_GLOBAL_NAMES.contains(name))
+    {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "RLM input field '{name}' conflicts with reserved runtime binding. Rename this field (reserved names: {}).",
+            RESERVED_GLOBAL_NAMES.join(", ")
+        )));
     }
+    input.inject_into_python(py, &globals)?;
+    let methods_by_var = collect_methods_by_var(py, &globals, input.rlm_field_names())?;
 
     if let Some(llm_tools) = llm_tools {
         let tools_py = Py::new(py, llm_tools.clone())?;
@@ -62,7 +56,189 @@ pub fn setup_interpreter_globals<S: Signature>(
     }
     globals.set_item("SUBMIT", Py::new(py, submit_handler.clone())?)?;
 
-    Ok(globals.unbind())
+    Ok(InterpreterSetup {
+        globals: globals.unbind(),
+        methods_by_var,
+    })
+}
+
+fn collect_methods_by_var(
+    py: Python<'_>,
+    globals: &Bound<'_, PyDict>,
+    field_names: &[&str],
+) -> PyResult<std::collections::BTreeMap<String, Vec<MethodSignature>>> {
+    let inspect = PyModule::import(py, "inspect")?;
+    let mut methods_by_var = std::collections::BTreeMap::new();
+
+    for field_name in field_names {
+        let Some(value) = globals.get_item(field_name)? else {
+            continue;
+        };
+        let methods = collect_visible_methods_for_object(&inspect, &value)?;
+        methods_by_var.insert((*field_name).to_string(), methods);
+    }
+
+    Ok(methods_by_var)
+}
+
+fn collect_visible_methods_for_object(
+    inspect: &Bound<'_, PyModule>,
+    value: &Bound<'_, PyAny>,
+) -> PyResult<Vec<MethodSignature>> {
+    if value.is_instance_of::<PyString>()
+        || value.is_instance_of::<PyBool>()
+        || value.is_instance_of::<PyInt>()
+        || value.is_instance_of::<PyFloat>()
+        || value.is_instance_of::<PyList>()
+        || value.is_instance_of::<PyDict>()
+        || value.is_instance_of::<PyTuple>()
+    {
+        return Ok(Vec::new());
+    }
+
+    let class = value.get_type();
+    let members = inspect.call_method1("getmembers", (&class, inspect.getattr("isroutine")?))?;
+    let members = members.cast::<PyList>()?;
+    let mut methods = Vec::new();
+
+    for member in members.iter() {
+        let tuple = member.cast::<PyTuple>()?;
+        if tuple.len() != 2 {
+            continue;
+        }
+        let name = tuple.get_item(0)?.extract::<String>()?;
+        let is_dunder = name.starts_with("__") && name.ends_with("__");
+        if name == "__baml__"
+            || (is_dunder && !matches!(name.as_str(), "__len__" | "__iter__" | "__getitem__"))
+        {
+            continue;
+        }
+
+        let callable = tuple.get_item(1)?;
+        let doc = extract_trimmed_docstring(&callable)?;
+        if doc.is_empty() {
+            continue;
+        }
+
+        methods.push(MethodSignature {
+            signature: sanitize_signature(
+                &extract_signature(inspect, &callable).unwrap_or_else(|| "()".to_string()),
+            ),
+            source: classify_method_source(&name),
+            name,
+            doc,
+            is_dunder,
+        });
+    }
+
+    methods.sort_by(|a, b| {
+        a.name
+            .cmp(&b.name)
+            .then(a.signature.cmp(&b.signature))
+            .then(a.doc.cmp(&b.doc))
+    });
+    methods.dedup_by(|a, b| a.name == b.name && a.signature == b.signature);
+    Ok(methods)
+}
+
+fn extract_trimmed_docstring(callable: &Bound<'_, PyAny>) -> PyResult<String> {
+    let Some(raw_doc) = callable.getattr("__doc__")?.extract::<Option<String>>()? else {
+        return Ok(String::new());
+    };
+    Ok(raw_doc.trim().to_string())
+}
+
+fn extract_signature(
+    inspect: &Bound<'_, PyModule>,
+    callable: &Bound<'_, PyAny>,
+) -> Option<String> {
+    if let Ok(text_sig) = callable.getattr("__text_signature__")
+        && let Ok(Some(text_sig)) = text_sig.extract::<Option<String>>()
+    {
+        let trimmed = text_sig.trim();
+        if !trimmed.is_empty() {
+            return Some(trimmed.to_string());
+        }
+    }
+
+    inspect
+        .call_method1("signature", (callable,))
+        .ok()
+        .and_then(|sig| sig.str().ok())
+        .and_then(|sig| sig.extract::<String>().ok())
+        .map(|sig| sig.trim().to_string())
+        .filter(|sig| !sig.is_empty())
+        .or_else(|| {
+            callable
+                .call_method0("__signature__")
+                .ok()
+                .and_then(|sig| sig.str().ok())
+                .and_then(|sig| sig.extract::<String>().ok())
+                .map(|sig| sig.trim().to_string())
+                .filter(|sig| !sig.is_empty())
+        })
+        .or_else(|| {
+            None
+        })
+}
+
+fn sanitize_signature(raw_signature: &str) -> String {
+    let mut signature = raw_signature.trim().to_string();
+
+    if signature.starts_with("(self, /, ") {
+        signature = signature.replacen("(self, /, ", "(", 1);
+    } else if signature.starts_with("(self, ") {
+        signature = signature.replacen("(self, ", "(", 1);
+    } else if signature == "(self)" || signature == "(self, /)" {
+        signature = "()".to_string();
+    }
+    signature = signature.replace(", /)", ")");
+    signature = signature.replace(", /, ", ", ");
+
+    if !signature.starts_with('(') {
+        signature = format!("({signature})");
+    }
+
+    simplify_qualified_type_paths(&signature)
+}
+
+fn simplify_qualified_type_paths(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len());
+    let mut token = String::new();
+
+    let flush = |out: &mut String, token: &mut String| {
+        if token.is_empty() {
+            return;
+        }
+        if token.contains('.') {
+            if let Some(last) = token.rsplit('.').next() {
+                out.push_str(last);
+            }
+        } else {
+            out.push_str(token);
+        }
+        token.clear();
+    };
+
+    for ch in raw.chars() {
+        if ch.is_ascii_alphanumeric() || ch == '_' || ch == '.' {
+            token.push(ch);
+        } else {
+            flush(&mut out, &mut token);
+            out.push(ch);
+        }
+    }
+    flush(&mut out, &mut token);
+    out
+}
+
+fn classify_method_source(name: &str) -> MethodSource {
+    match name {
+        "__len__" | "__iter__" | "__getitem__" | "__repr__" | "__baml__" => {
+            MethodSource::Generated
+        }
+        _ => MethodSource::Custom,
+    }
 }
 
 /// Convert BamlValue tree to Python objects recursively.

--- a/crates/dspy-rs/src/modules/rlm/py_bridge.rs
+++ b/crates/dspy-rs/src/modules/rlm/py_bridge.rs
@@ -1,0 +1,990 @@
+use anyhow::anyhow;
+use bamltype::baml_types::ir_type::UnionTypeViewGeneric;
+use bamltype::baml_types::{BamlMap, BamlValue, LiteralValue, StreamingMode, TypeIR, TypeValue};
+use bamltype::internal_baml_jinja::types::{Class, OutputFormatContent};
+use bamltype::jsonish;
+use bamltype::jsonish::deserializer::coercer::run_user_checks;
+use bamltype::{BamlParseError, BamlType};
+use pyo3::IntoPyObjectExt;
+use pyo3::types::{
+    PyAnyMethods, PyBool, PyDict, PyDictMethods, PyList, PyListMethods, PyModule, PyString,
+    PyTuple, PyTupleMethods, PyTypeMethods,
+};
+use pyo3::{Bound, Py, PyAny, PyResult, Python};
+use serde_json::Value as JsonValue;
+
+use super::submit::SubmitHandler;
+use super::tools::LlmTools;
+use crate::{BamlConvertError, ConstraintLevel, ResponseCheck, Signature};
+
+pub fn setup_interpreter_globals<S: Signature>(
+    py: Python<'_>,
+    input: &S::Input,
+    submit_handler: &SubmitHandler,
+    llm_tools: &LlmTools,
+) -> PyResult<Py<PyDict>> {
+    let globals = PyDict::new(py);
+
+    let input_value = input.to_baml_value();
+    match input_value {
+        BamlValue::Class(_, ref fields) | BamlValue::Map(ref fields) => {
+            for (name, value) in fields {
+                globals.set_item(name, baml_value_to_py(py, value)?)?;
+            }
+        }
+        other => {
+            return Err(pyo3::exceptions::PyTypeError::new_err(format!(
+                "RLM input must serialize to object-like BamlValue, got {}",
+                other.r#type()
+            )));
+        }
+    }
+
+    let tools_py = Py::new(py, llm_tools.clone())?;
+    let tools_bound = tools_py.bind(py);
+    globals.set_item("llm_query", tools_bound.getattr("llm_query")?)?;
+    globals.set_item(
+        "llm_query_batched",
+        tools_bound.getattr("llm_query_batched")?,
+    )?;
+    globals.set_item("SUBMIT", Py::new(py, submit_handler.clone())?)?;
+
+    Ok(globals.unbind())
+}
+
+/// Convert BamlValue tree to Python objects recursively.
+pub fn baml_value_to_py(py: Python<'_>, value: &BamlValue) -> PyResult<Py<PyAny>> {
+    match value {
+        BamlValue::String(value) => Ok(value.clone().into_py_any(py)?),
+        BamlValue::Int(value) => Ok(value.into_py_any(py)?),
+        BamlValue::Float(value) => Ok(value.into_py_any(py)?),
+        BamlValue::Bool(value) => Ok(value.into_py_any(py)?),
+        BamlValue::Null => Ok(py.None()),
+        BamlValue::List(items) => {
+            let list = PyList::empty(py);
+            for item in items {
+                list.append(baml_value_to_py(py, item)?)?;
+            }
+            Ok(list.into_any().unbind())
+        }
+        BamlValue::Map(map) => {
+            let dict = PyDict::new(py);
+            for (key, value) in map.iter() {
+                dict.set_item(key, baml_value_to_py(py, value)?)?;
+            }
+            Ok(dict.into_any().unbind())
+        }
+        BamlValue::Enum(_, variant) => Ok(variant.clone().into_py_any(py)?),
+        BamlValue::Class(_, fields) => {
+            let dict = PyDict::new(py);
+            for (key, value) in fields.iter() {
+                dict.set_item(key, baml_value_to_py(py, value)?)?;
+            }
+            Ok(dict.into_any().unbind())
+        }
+        BamlValue::Media(_) => Err(pyo3::exceptions::PyTypeError::new_err(
+            "Media values are not supported in RLM V1",
+        )),
+    }
+}
+
+pub fn kwargs_to_baml_value<S: Signature>(
+    py: Python<'_>,
+    kwargs: &Bound<'_, PyDict>,
+) -> Result<BamlValue, BamlParseError> {
+    let schema = S::schema();
+    let output_format = schema.output_format();
+    let mut fields = BamlMap::new();
+
+    for field in schema.output_fields() {
+        let value = kwargs
+            .get_item(field.lm_name)
+            .map_err(py_err_to_parse)?
+            .ok_or_else(|| missing_field_error(&[], field.lm_name))?;
+        let baml_value = py_to_baml_value(py, &value, &field.type_ir, output_format)
+            .map_err(|err| add_field_context(err, field.lm_name))?;
+        fields.insert(field.rust_name.to_string(), baml_value);
+    }
+
+    if let Some(class_name) = output_class_name(output_format) {
+        Ok(BamlValue::Class(class_name, fields))
+    } else {
+        Ok(BamlValue::Map(fields))
+    }
+}
+
+pub fn collect_checks_for_output<S: Signature>(
+    value: &BamlValue,
+) -> Result<Vec<ResponseCheck>, BamlParseError> {
+    let schema = S::schema();
+
+    let fields = match value {
+        BamlValue::Class(_, fields) | BamlValue::Map(fields) => fields,
+        other => {
+            return Err(BamlParseError::Convert(BamlConvertError::new(
+                Vec::new(),
+                "object",
+                format!("{other:?}"),
+                "expected an object",
+            )));
+        }
+    };
+
+    let mut checks = Vec::new();
+    let mut failed = Vec::new();
+
+    for field in schema.output_fields() {
+        let Some(value) = fields.get(field.rust_name.as_str()) else {
+            return Err(missing_field_error(&[], field.rust_name.as_str()));
+        };
+
+        let results = run_user_checks(value, &field.type_ir).map_err(BamlParseError::from)?;
+        for (constraint, ok) in results {
+            if constraint.level == ConstraintLevel::Assert && !ok {
+                failed.push(ResponseCheck {
+                    name: constraint
+                        .label
+                        .clone()
+                        .unwrap_or_else(|| "assert".to_string()),
+                    expression: constraint.expression.0.clone(),
+                    status: "failed".to_string(),
+                });
+            }
+
+            if let Some(check) = ResponseCheck::from_check_result((constraint, ok)) {
+                checks.push(check);
+            }
+        }
+    }
+
+    if !failed.is_empty() {
+        return Err(BamlParseError::ConstraintAssertsFailed { failed });
+    }
+
+    Ok(checks)
+}
+
+fn output_class_name(output_format: &OutputFormatContent) -> Option<String> {
+    let mut current = output_format.target.clone();
+    loop {
+        match current {
+            TypeIR::Class { name, .. } => return Some(name),
+            TypeIR::RecursiveTypeAlias { name, .. } => {
+                if let Some(next) = output_format.structural_recursive_aliases.get(&name) {
+                    current = next.clone();
+                    continue;
+                }
+                return None;
+            }
+            _ => return None,
+        }
+    }
+}
+
+fn add_field_context(err: BamlParseError, field: &str) -> BamlParseError {
+    match err {
+        BamlParseError::Convert(err) => {
+            let mut path = Vec::with_capacity(err.path.len() + 1);
+            path.push(field.to_string());
+            path.extend(err.path);
+            BamlParseError::Convert(BamlConvertError::new(
+                path,
+                err.expected,
+                err.got,
+                err.message,
+            ))
+        }
+        BamlParseError::Jsonish(inner) => BamlParseError::Convert(BamlConvertError::new(
+            vec![field.to_string()],
+            "schema",
+            "python",
+            inner.to_string(),
+        )),
+        other => other,
+    }
+}
+
+pub fn py_to_baml_value(
+    py: Python<'_>,
+    obj: &Bound<'_, PyAny>,
+    r#type: &TypeIR,
+    output_format: &OutputFormatContent,
+) -> Result<BamlValue, BamlParseError> {
+    let obj = if obj.hasattr("__baml__").map_err(py_err_to_parse)? {
+        obj.call_method0("__baml__").map_err(py_err_to_parse)?
+    } else {
+        obj.clone()
+    };
+    let obj = normalize_python_object(py, &obj).map_err(py_err_to_parse)?;
+    let mut path = Vec::new();
+    py_to_baml_value_inner(py, &obj, r#type, output_format, &mut path)
+}
+
+pub fn normalize_python_object<'py>(
+    py: Python<'py>,
+    obj: &Bound<'py, PyAny>,
+) -> PyResult<Bound<'py, PyAny>> {
+    if obj.is_instance_of::<PyDict>() || obj.is_instance_of::<PyList>() {
+        return Ok(obj.clone());
+    }
+
+    if let Ok(value) = obj.call_method0("model_dump") {
+        return Ok(value);
+    }
+
+    if let Ok(value) = obj.call_method0("dict") {
+        return Ok(value);
+    }
+
+    if let Ok(value) = obj.call_method0("_asdict") {
+        return Ok(value);
+    }
+
+    if let Ok(dataclasses) = PyModule::import(py, "dataclasses")
+        && let Ok(is_dataclass) = dataclasses.getattr("is_dataclass")
+        && is_dataclass.call1((obj,))?.is_truthy()?
+        && let Ok(asdict) = dataclasses.getattr("asdict")
+    {
+        return asdict.call1((obj,));
+    }
+
+    if let Ok(attrs) = PyModule::import(py, "attr")
+        && let Ok(has) = attrs.getattr("has")
+        && has.call1((obj,))?.is_truthy()?
+        && let Ok(asdict) = attrs.getattr("asdict")
+    {
+        return asdict.call1((obj,));
+    }
+
+    if let Ok(dict) = obj.getattr("__dict__") {
+        return Ok(dict);
+    }
+
+    Ok(obj.clone())
+}
+
+fn py_to_baml_value_inner(
+    py: Python<'_>,
+    obj: &Bound<'_, PyAny>,
+    r#type: &TypeIR,
+    output_format: &OutputFormatContent,
+    path: &mut Vec<String>,
+) -> Result<BamlValue, BamlParseError> {
+    let resolved = resolve_recursive_type(r#type, output_format);
+
+    if !is_string_target(&resolved) && obj.is_instance_of::<PyString>() {
+        let raw = obj.extract::<String>().map_err(py_err_to_parse)?;
+        if let Ok(parsed_json) = serde_json::from_str::<JsonValue>(&raw) {
+            let py_obj = json_value_to_py(py, &parsed_json).into_bound(py);
+            return py_to_baml_value_inner(py, &py_obj, &resolved, output_format, path);
+        }
+    }
+
+    match &resolved {
+        TypeIR::Primitive(TypeValue::String, _) => obj
+            .extract::<String>()
+            .map(BamlValue::String)
+            .map_err(py_err_to_parse),
+        TypeIR::Primitive(TypeValue::Int, _) => {
+            if obj.is_instance_of::<PyBool>() {
+                return Err(conversion_error(path, &resolved, obj));
+            }
+            obj.extract::<i64>()
+                .map(BamlValue::Int)
+                .map_err(py_err_to_parse)
+        }
+        TypeIR::Primitive(TypeValue::Float, _) => {
+            if obj.is_instance_of::<PyBool>() {
+                return Err(conversion_error(path, &resolved, obj));
+            }
+            obj.extract::<f64>()
+                .map(BamlValue::Float)
+                .map_err(py_err_to_parse)
+        }
+        TypeIR::Primitive(TypeValue::Bool, _) => obj
+            .extract::<bool>()
+            .map(BamlValue::Bool)
+            .map_err(py_err_to_parse),
+        TypeIR::Primitive(TypeValue::Null, _) => {
+            if obj.is_none() {
+                Ok(BamlValue::Null)
+            } else {
+                Err(conversion_error(path, &resolved, obj))
+            }
+        }
+        TypeIR::Primitive(TypeValue::Media(_), _) => Err(conversion_error(path, &resolved, obj)),
+        TypeIR::Enum { name, .. } => {
+            let raw = obj.extract::<String>().map_err(py_err_to_parse)?;
+            let enum_type = output_format.enums.get(name).ok_or_else(|| {
+                BamlParseError::Jsonish(anyhow!("missing enum definition for {name}"))
+            })?;
+            let mut matches_variant = false;
+            for (value, _) in &enum_type.values {
+                if value.real_name() == raw || value.rendered_name() == raw {
+                    matches_variant = true;
+                    break;
+                }
+            }
+            if !matches_variant {
+                return Err(conversion_error(path, &resolved, obj));
+            }
+            Ok(BamlValue::Enum(name.to_string(), raw))
+        }
+        TypeIR::Literal(LiteralValue::String(literal), _) => {
+            let raw = obj.extract::<String>().map_err(py_err_to_parse)?;
+            if raw == *literal {
+                Ok(BamlValue::String(raw))
+            } else {
+                Err(conversion_error(path, &resolved, obj))
+            }
+        }
+        TypeIR::Literal(LiteralValue::Int(literal), _) => {
+            if obj.is_instance_of::<PyBool>() {
+                return Err(conversion_error(path, &resolved, obj));
+            }
+            let raw = obj.extract::<i64>().map_err(py_err_to_parse)?;
+            if raw == *literal {
+                Ok(BamlValue::Int(raw))
+            } else {
+                Err(conversion_error(path, &resolved, obj))
+            }
+        }
+        TypeIR::Literal(LiteralValue::Bool(literal), _) => {
+            let raw = obj.extract::<bool>().map_err(py_err_to_parse)?;
+            if raw == *literal {
+                Ok(BamlValue::Bool(raw))
+            } else {
+                Err(conversion_error(path, &resolved, obj))
+            }
+        }
+        TypeIR::Class { name, .. } => {
+            py_to_class_value(py, obj, name.as_str(), output_format, path)
+        }
+        TypeIR::List(item_type, _) => {
+            py_to_list_value(py, obj, item_type.as_ref(), output_format, path)
+        }
+        TypeIR::Map(key_type, value_type, _) => py_to_map_value(
+            py,
+            obj,
+            key_type.as_ref(),
+            value_type.as_ref(),
+            output_format,
+            path,
+        ),
+        TypeIR::Tuple(items, _) => py_to_tuple_value(py, obj, items, output_format, path),
+        TypeIR::RecursiveTypeAlias { name, .. } => Err(BamlParseError::Jsonish(anyhow!(
+            "missing recursive alias {name}"
+        ))),
+        TypeIR::Top(_) => py_any_to_baml_value_untyped(py, obj),
+        TypeIR::Arrow(_, _) => Err(conversion_error(path, &resolved, obj)),
+        TypeIR::Union(inner, _) => match inner.view() {
+            UnionTypeViewGeneric::Null => {
+                if obj.is_none() {
+                    Ok(BamlValue::Null)
+                } else {
+                    Err(conversion_error(path, &resolved, obj))
+                }
+            }
+            UnionTypeViewGeneric::Optional(t) => {
+                if obj.is_none() {
+                    Ok(BamlValue::Null)
+                } else {
+                    py_to_baml_value_inner(py, obj, t, output_format, path)
+                }
+            }
+            UnionTypeViewGeneric::OneOf(types) | UnionTypeViewGeneric::OneOfOptional(types) => {
+                let mut last_err: Option<BamlParseError> = None;
+                for t in types {
+                    match py_to_baml_value_inner(py, obj, t, output_format, path) {
+                        Ok(value) => return Ok(value),
+                        Err(err) => last_err = Some(err),
+                    }
+                }
+                Err(last_err.unwrap_or_else(|| conversion_error(path, &resolved, obj)))
+            }
+        },
+    }
+}
+
+fn py_to_class_value(
+    py: Python<'_>,
+    obj: &Bound<'_, PyAny>,
+    class_name: &str,
+    output_format: &OutputFormatContent,
+    path: &mut Vec<String>,
+) -> Result<BamlValue, BamlParseError> {
+    let dict = match obj.cast::<PyDict>() {
+        Ok(dict) => dict,
+        Err(_) => {
+            if let Some(value) =
+                orjson_fallback_to_baml(py, obj, &TypeIR::class(class_name), output_format)
+            {
+                return Ok(value);
+            }
+            return Err(conversion_error(path, &TypeIR::class(class_name), obj));
+        }
+    };
+
+    let class = find_class(output_format, class_name).ok_or_else(|| {
+        BamlParseError::Jsonish(anyhow!("missing class definition for {class_name}"))
+    })?;
+
+    let mut fields = BamlMap::new();
+    for field in &class.fields {
+        let (name, field_type, _, _) = field;
+        let rendered: &str = name.rendered_name();
+        let real: &str = name.real_name();
+
+        let value = dict
+            .get_item(rendered)
+            .map_err(py_err_to_parse)?
+            .or_else(|| dict.get_item(real).ok().flatten());
+
+        let value = match value {
+            Some(value) => value,
+            None => {
+                if field_type.is_optional() {
+                    fields.insert(real.to_string(), BamlValue::Null);
+                    continue;
+                }
+                return Err(missing_field_error(path, real));
+            }
+        };
+
+        path.push(real.to_string());
+        let field_value = py_to_baml_value_inner(py, &value, field_type, output_format, path)?;
+        path.pop();
+        fields.insert(real.to_string(), field_value);
+    }
+
+    Ok(BamlValue::Class(class_name.to_string(), fields))
+}
+
+fn py_to_map_value(
+    py: Python<'_>,
+    obj: &Bound<'_, PyAny>,
+    key_type: &TypeIR,
+    value_type: &TypeIR,
+    output_format: &OutputFormatContent,
+    path: &mut Vec<String>,
+) -> Result<BamlValue, BamlParseError> {
+    if !matches!(
+        key_type,
+        TypeIR::Primitive(TypeValue::String, _) | TypeIR::Literal(LiteralValue::String(_), _)
+    ) {
+        return Err(BamlParseError::Convert(BamlConvertError::new(
+            path.clone(),
+            "string",
+            format!("{}", key_type.diagnostic_repr()),
+            "map keys must be strings",
+        )));
+    }
+
+    let dict = match obj.cast::<PyDict>() {
+        Ok(dict) => dict,
+        Err(_) => {
+            if let Some(value) = orjson_fallback_to_baml(
+                py,
+                obj,
+                &TypeIR::map(key_type.clone(), value_type.clone()),
+                output_format,
+            ) {
+                return Ok(value);
+            }
+            return Err(conversion_error(
+                path,
+                &TypeIR::map(key_type.clone(), value_type.clone()),
+                obj,
+            ));
+        }
+    };
+
+    let mut map = BamlMap::new();
+    for (key, value) in dict.iter() {
+        let key = key
+            .extract::<String>()
+            .map_err(|_| conversion_error(path, key_type, &key))?;
+        path.push(key.clone());
+        let value = py_to_baml_value_inner(py, &value, value_type, output_format, path)?;
+        path.pop();
+        map.insert(key, value);
+    }
+
+    Ok(BamlValue::Map(map))
+}
+
+fn py_to_list_value(
+    py: Python<'_>,
+    obj: &Bound<'_, PyAny>,
+    item_type: &TypeIR,
+    output_format: &OutputFormatContent,
+    path: &mut Vec<String>,
+) -> Result<BamlValue, BamlParseError> {
+    let list = if let Ok(list) = obj.cast::<PyList>() {
+        list
+    } else if let Ok(tuple) = obj.cast::<PyTuple>() {
+        let mut items = Vec::with_capacity(tuple.len());
+        for (idx, item) in tuple.iter().enumerate() {
+            path.push(idx.to_string());
+            let value = py_to_baml_value_inner(py, &item, item_type, output_format, path)?;
+            path.pop();
+            items.push(value);
+        }
+        return Ok(BamlValue::List(items));
+    } else {
+        if let Some(value) =
+            orjson_fallback_to_baml(py, obj, &TypeIR::list(item_type.clone()), output_format)
+        {
+            return Ok(value);
+        }
+        return Err(conversion_error(
+            path,
+            &TypeIR::list(item_type.clone()),
+            obj,
+        ));
+    };
+
+    let mut items = Vec::with_capacity(list.len());
+    for (idx, item) in list.iter().enumerate() {
+        path.push(idx.to_string());
+        let value = py_to_baml_value_inner(py, &item, item_type, output_format, path)?;
+        path.pop();
+        items.push(value);
+    }
+
+    Ok(BamlValue::List(items))
+}
+
+fn py_to_tuple_value(
+    py: Python<'_>,
+    obj: &Bound<'_, PyAny>,
+    items: &[TypeIR],
+    output_format: &OutputFormatContent,
+    path: &mut Vec<String>,
+) -> Result<BamlValue, BamlParseError> {
+    if let Ok(tuple) = obj.cast::<PyTuple>() {
+        if tuple.len() != items.len() {
+            return Err(conversion_error(path, &TypeIR::tuple(items.to_vec()), obj));
+        }
+        let mut values = Vec::with_capacity(items.len());
+        for (idx, (item, item_type)) in tuple.iter().zip(items.iter()).enumerate() {
+            path.push(idx.to_string());
+            let value = py_to_baml_value_inner(py, &item, item_type, output_format, path)?;
+            path.pop();
+            values.push(value);
+        }
+        return Ok(BamlValue::List(values));
+    }
+
+    if let Ok(list) = obj.cast::<PyList>() {
+        if list.len() != items.len() {
+            return Err(conversion_error(path, &TypeIR::tuple(items.to_vec()), obj));
+        }
+        let mut values = Vec::with_capacity(items.len());
+        for (idx, (item, item_type)) in list.iter().zip(items.iter()).enumerate() {
+            path.push(idx.to_string());
+            let value = py_to_baml_value_inner(py, &item, item_type, output_format, path)?;
+            path.pop();
+            values.push(value);
+        }
+        return Ok(BamlValue::List(values));
+    }
+
+    Err(conversion_error(path, &TypeIR::tuple(items.to_vec()), obj))
+}
+
+fn py_any_to_baml_value_untyped(
+    py: Python<'_>,
+    obj: &Bound<'_, PyAny>,
+) -> Result<BamlValue, BamlParseError> {
+    if obj.is_none() {
+        return Ok(BamlValue::Null);
+    }
+
+    if obj.is_instance_of::<PyBool>() {
+        return obj
+            .extract::<bool>()
+            .map(BamlValue::Bool)
+            .map_err(py_err_to_parse);
+    }
+
+    if let Ok(value) = obj.extract::<i64>() {
+        return Ok(BamlValue::Int(value));
+    }
+
+    if let Ok(value) = obj.extract::<f64>() {
+        return Ok(BamlValue::Float(value));
+    }
+
+    if let Ok(value) = obj.extract::<String>() {
+        return Ok(BamlValue::String(value));
+    }
+
+    if let Ok(dict) = obj.cast::<PyDict>() {
+        let mut map = BamlMap::new();
+        for (key, value) in dict.iter() {
+            let key = key.extract::<String>().map_err(py_err_to_parse)?;
+            let value = py_any_to_baml_value_untyped(py, &value)?;
+            map.insert(key, value);
+        }
+        return Ok(BamlValue::Map(map));
+    }
+
+    if let Ok(list) = obj.cast::<PyList>() {
+        let mut items = Vec::with_capacity(list.len());
+        for item in list.iter() {
+            items.push(py_any_to_baml_value_untyped(py, &item)?);
+        }
+        return Ok(BamlValue::List(items));
+    }
+
+    if let Ok(tuple) = obj.cast::<PyTuple>() {
+        let mut items = Vec::with_capacity(tuple.len());
+        for item in tuple.iter() {
+            items.push(py_any_to_baml_value_untyped(py, &item)?);
+        }
+        return Ok(BamlValue::List(items));
+    }
+
+    let raw = python_object_to_json_string(py, obj)?;
+    let parsed: JsonValue =
+        serde_json::from_str(&raw).map_err(|err| BamlParseError::Jsonish(anyhow!(err)))?;
+    Ok(json_value_to_baml_value(&parsed))
+}
+
+fn python_object_to_json_string(
+    py: Python<'_>,
+    obj: &Bound<'_, PyAny>,
+) -> Result<String, BamlParseError> {
+    if let Ok(orjson) = PyModule::import(py, "orjson")
+        && let Ok(dumps) = orjson.getattr("dumps")
+        && let Ok(raw) = dumps.call1((obj,))
+        && let Ok(bytes) = raw.extract::<Vec<u8>>()
+    {
+        return String::from_utf8(bytes).map_err(|err| BamlParseError::Jsonish(anyhow!(err)));
+    }
+
+    let json = PyModule::import(py, "json").map_err(py_err_to_parse)?;
+    let dumps = json.getattr("dumps").map_err(py_err_to_parse)?;
+    dumps
+        .call1((obj,))
+        .map_err(py_err_to_parse)?
+        .extract::<String>()
+        .map_err(py_err_to_parse)
+}
+
+fn json_value_to_py(py: Python<'_>, value: &JsonValue) -> Py<PyAny> {
+    match value {
+        JsonValue::Null => py.None(),
+        JsonValue::Bool(value) => value.into_py_any(py).unwrap_or_else(|_| py.None()),
+        JsonValue::Number(value) => value
+            .as_i64()
+            .map(|value| value.into_py_any(py).unwrap_or_else(|_| py.None()))
+            .or_else(|| {
+                value
+                    .as_f64()
+                    .map(|value| value.into_py_any(py).unwrap_or_else(|_| py.None()))
+            })
+            .unwrap_or_else(|| py.None()),
+        JsonValue::String(value) => value.clone().into_py_any(py).unwrap_or_else(|_| py.None()),
+        JsonValue::Array(values) => {
+            let list = PyList::empty(py);
+            for item in values {
+                let _ = list.append(json_value_to_py(py, item));
+            }
+            list.into_any().unbind()
+        }
+        JsonValue::Object(values) => {
+            let dict = PyDict::new(py);
+            for (key, value) in values {
+                let _ = dict.set_item(key, json_value_to_py(py, value));
+            }
+            dict.into_any().unbind()
+        }
+    }
+}
+
+fn json_value_to_baml_value(value: &JsonValue) -> BamlValue {
+    match value {
+        JsonValue::Null => BamlValue::Null,
+        JsonValue::Bool(value) => BamlValue::Bool(*value),
+        JsonValue::Number(value) => {
+            if let Some(value) = value.as_i64() {
+                BamlValue::Int(value)
+            } else if let Some(value) = value.as_f64() {
+                BamlValue::Float(value)
+            } else {
+                BamlValue::Null
+            }
+        }
+        JsonValue::String(value) => BamlValue::String(value.clone()),
+        JsonValue::Array(values) => {
+            BamlValue::List(values.iter().map(json_value_to_baml_value).collect())
+        }
+        JsonValue::Object(values) => BamlValue::Map(
+            values
+                .iter()
+                .map(|(key, value)| (key.clone(), json_value_to_baml_value(value)))
+                .collect(),
+        ),
+    }
+}
+
+fn resolve_recursive_type(r#type: &TypeIR, output_format: &OutputFormatContent) -> TypeIR {
+    let mut current = r#type.clone();
+    loop {
+        let next = match &current {
+            TypeIR::RecursiveTypeAlias { name, .. } => output_format
+                .structural_recursive_aliases
+                .get(name)
+                .cloned(),
+            _ => None,
+        };
+
+        match next {
+            Some(next) => current = next,
+            None => return current,
+        }
+    }
+}
+
+fn find_class<'a>(output_format: &'a OutputFormatContent, class_name: &str) -> Option<&'a Class> {
+    let key = (class_name.to_string(), StreamingMode::NonStreaming);
+    if let Some(class) = output_format.classes.get(&key) {
+        return Some(class);
+    }
+
+    output_format
+        .classes
+        .iter()
+        .find(|((name, _), _)| name == class_name)
+        .map(|(_, class)| class)
+}
+
+fn is_string_target(r#type: &TypeIR) -> bool {
+    matches!(
+        r#type,
+        TypeIR::Primitive(TypeValue::String, _) | TypeIR::Literal(LiteralValue::String(_), _)
+    )
+}
+
+fn conversion_error(path: &[String], expected: &TypeIR, got: &Bound<'_, PyAny>) -> BamlParseError {
+    let got_type = py_type_name(got);
+    BamlParseError::Convert(BamlConvertError::new(
+        path.to_vec(),
+        "schema",
+        got_type,
+        format!("expected {}", expected.diagnostic_repr()),
+    ))
+}
+
+fn missing_field_error(path: &[String], field: &str) -> BamlParseError {
+    let mut full_path = path.to_vec();
+    full_path.push(field.to_string());
+
+    BamlParseError::Convert(BamlConvertError::new(
+        full_path,
+        "field",
+        "missing",
+        format!("missing required field {field}"),
+    ))
+}
+
+fn py_type_name(obj: &Bound<'_, PyAny>) -> String {
+    obj.get_type()
+        .name()
+        .ok()
+        .and_then(|name| name.extract::<String>().ok())
+        .unwrap_or_else(|| "<unknown>".to_string())
+}
+
+fn py_err_to_parse(err: pyo3::PyErr) -> BamlParseError {
+    BamlParseError::Jsonish(anyhow!(err.to_string()))
+}
+
+fn orjson_fallback_to_baml(
+    py: Python<'_>,
+    obj: &Bound<'_, PyAny>,
+    r#type: &TypeIR,
+    output_format: &OutputFormatContent,
+) -> Option<BamlValue> {
+    let raw = python_object_to_json_string(py, obj).ok()?;
+    let parsed = jsonish::from_str(output_format, r#type, &raw, true).ok()?;
+    Some(BamlValue::from(parsed))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use pyo3::types::{PyDict, PyDictMethods};
+    use tokio::runtime::Handle;
+
+    use super::*;
+    use crate::Signature;
+    use crate::modules::rlm::{LlmQuery, SubmitSlot};
+
+    #[derive(Signature, Clone, Debug)]
+    struct BridgeSig {
+        #[input]
+        question: String,
+
+        #[input]
+        count: i64,
+
+        #[output]
+        answer: String,
+
+        #[output]
+        #[check("this >= 0.0", label = "non_negative")]
+        score: f64,
+    }
+
+    #[derive(Signature, Clone, Debug)]
+    struct AssertSig {
+        #[input]
+        prompt: String,
+
+        #[output]
+        #[assert("this > 0", label = "positive")]
+        score: i64,
+    }
+
+    struct MockLm;
+
+    #[async_trait::async_trait]
+    impl LlmQuery for MockLm {
+        async fn query(&self, prompt: &str) -> anyhow::Result<String> {
+            Ok(format!("mock:{prompt}"))
+        }
+    }
+
+    #[test]
+    fn baml_value_to_py_supports_common_types() {
+        Python::attach(|py| {
+            let value = BamlValue::Map(BamlMap::from_iter([
+                ("name".to_string(), BamlValue::String("alice".to_string())),
+                (
+                    "nums".to_string(),
+                    BamlValue::List(vec![BamlValue::Int(1), BamlValue::Int(2)]),
+                ),
+                ("ok".to_string(), BamlValue::Bool(true)),
+                (
+                    "nested".to_string(),
+                    BamlValue::Class(
+                        "Nested".to_string(),
+                        BamlMap::from_iter([("x".to_string(), BamlValue::Float(1.25))]),
+                    ),
+                ),
+            ]));
+
+            let py_obj = baml_value_to_py(py, &value).expect("convert to py");
+            let dict = py_obj.bind(py).cast::<PyDict>().expect("dict");
+            assert_eq!(
+                dict.get_item("name")
+                    .expect("getitem")
+                    .expect("name")
+                    .extract::<String>()
+                    .expect("name str"),
+                "alice"
+            );
+            assert!(
+                dict.get_item("ok")
+                    .expect("getitem")
+                    .expect("ok")
+                    .extract::<bool>()
+                    .expect("ok bool")
+            );
+        });
+    }
+
+    #[test]
+    fn kwargs_to_baml_value_validates_typed_fields() {
+        Python::attach(|py| {
+            let kwargs = PyDict::new(py);
+            kwargs.set_item("answer", "done").expect("set answer");
+            kwargs.set_item("score", 0.85).expect("set score");
+
+            let converted = kwargs_to_baml_value::<BridgeSig>(py, &kwargs).expect("convert kwargs");
+            let BamlValue::Class(_, fields) = converted else {
+                panic!("expected class output");
+            };
+            assert_eq!(
+                fields.get("answer"),
+                Some(&BamlValue::String("done".to_string()))
+            );
+            assert_eq!(fields.get("score"), Some(&BamlValue::Float(0.85)));
+        });
+    }
+
+    #[test]
+    fn kwargs_to_baml_value_reports_type_error_context() {
+        Python::attach(|py| {
+            let kwargs = PyDict::new(py);
+            kwargs.set_item("answer", "done").expect("set answer");
+            kwargs.set_item("score", "oops").expect("set score");
+
+            let err = kwargs_to_baml_value::<BridgeSig>(py, &kwargs).expect_err("should fail");
+            match err {
+                BamlParseError::Convert(err) => {
+                    assert_eq!(err.path.first().map(|s| s.as_str()), Some("score"));
+                }
+                other => panic!("unexpected error: {other}"),
+            }
+        });
+    }
+
+    #[test]
+    fn collect_checks_for_output_reports_assert_failures() {
+        let value = BamlValue::Map(BamlMap::from_iter([(
+            "score".to_string(),
+            BamlValue::Int(-1),
+        )]));
+
+        let err = collect_checks_for_output::<AssertSig>(&value).expect_err("assert should fail");
+        match err {
+            BamlParseError::ConstraintAssertsFailed { failed } => {
+                assert_eq!(failed.len(), 1);
+                assert_eq!(failed[0].name, "positive");
+            }
+            other => panic!("unexpected error: {other}"),
+        }
+    }
+
+    #[test]
+    fn setup_interpreter_globals_injects_inputs_and_tools() {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+
+        runtime.block_on(async {
+            Python::attach(|py| {
+                let slot: SubmitSlot = Arc::new(std::sync::Mutex::new(None));
+                let submit = SubmitHandler::new::<BridgeSig>(Arc::clone(&slot));
+                let tools = LlmTools::with_budget(Arc::new(MockLm), 2, Handle::current());
+
+                let input = BridgeSigInput {
+                    question: "what?".to_string(),
+                    count: 3,
+                };
+
+                let globals = setup_interpreter_globals::<BridgeSig>(py, &input, &submit, &tools)
+                    .expect("setup globals")
+                    .bind(py)
+                    .clone();
+
+                assert!(globals.get_item("question").expect("getitem").is_some());
+                assert!(globals.get_item("count").expect("getitem").is_some());
+                assert!(globals.get_item("llm_query").expect("getitem").is_some());
+                assert!(
+                    globals
+                        .get_item("llm_query_batched")
+                        .expect("getitem")
+                        .is_some()
+                );
+                assert!(globals.get_item("SUBMIT").expect("getitem").is_some());
+            });
+        });
+    }
+}

--- a/crates/dspy-rs/src/modules/rlm/py_bridge.rs
+++ b/crates/dspy-rs/src/modules/rlm/py_bridge.rs
@@ -477,7 +477,7 @@ fn py_to_map_value(
         return Err(BamlParseError::Convert(BamlConvertError::new(
             path.clone(),
             "string",
-            format!("{}", key_type.diagnostic_repr()),
+            schema_type_name(key_type),
             "map keys must be strings",
         )));
     }
@@ -776,8 +776,12 @@ fn conversion_error(path: &[String], expected: &TypeIR, got: &Bound<'_, PyAny>) 
         path.to_vec(),
         "schema",
         got_type,
-        format!("expected {}", expected.diagnostic_repr()),
+        format!("expected {}", schema_type_name(expected)),
     ))
+}
+
+fn schema_type_name(type_ir: &TypeIR) -> String {
+    crate::core::render_type_name_for_prompt_with(type_ir, crate::core::simplify_type_token)
 }
 
 fn missing_field_error(path: &[String], field: &str) -> BamlParseError {

--- a/crates/dspy-rs/src/modules/rlm/py_bridge.rs
+++ b/crates/dspy-rs/src/modules/rlm/py_bridge.rs
@@ -17,6 +17,8 @@ use super::submit::SubmitHandler;
 use super::tools::LlmTools;
 use crate::{BamlConvertError, ConstraintLevel, ResponseCheck, Signature};
 
+const RESERVED_GLOBAL_NAMES: [&str; 3] = ["llm_query", "llm_query_batched", "SUBMIT"];
+
 pub fn setup_interpreter_globals<S: Signature>(
     py: Python<'_>,
     input: &S::Input,
@@ -28,6 +30,15 @@ pub fn setup_interpreter_globals<S: Signature>(
     let input_value = input.to_baml_value();
     match input_value {
         BamlValue::Class(_, ref fields) | BamlValue::Map(ref fields) => {
+            if let Some(name) = fields
+                .keys()
+                .find(|name| RESERVED_GLOBAL_NAMES.contains(&name.as_str()))
+            {
+                return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "RLM input field '{name}' conflicts with reserved runtime binding. Rename this field (reserved names: {}).",
+                    RESERVED_GLOBAL_NAMES.join(", ")
+                )));
+            }
             for (name, value) in fields {
                 globals.set_item(name, baml_value_to_py(py, value)?)?;
             }
@@ -868,6 +879,15 @@ mod tests {
         score: i64,
     }
 
+    #[derive(Signature, Clone, Debug)]
+    struct ReservedNameSig {
+        #[input]
+        llm_query: String,
+
+        #[output]
+        answer: String,
+    }
+
     struct MockLm;
 
     #[async_trait::async_trait]
@@ -1032,6 +1052,23 @@ mod tests {
                     .expect("getitem")
                     .is_none()
             );
+        });
+    }
+
+    #[test]
+    fn setup_interpreter_globals_rejects_reserved_input_names() {
+        Python::attach(|py| {
+            let slot: SubmitSlot = Arc::new(std::sync::Mutex::new(None));
+            let submit = SubmitHandler::new::<ReservedNameSig>(Arc::clone(&slot));
+            let input = ReservedNameSigInput {
+                llm_query: "collision".to_string(),
+            };
+
+            let err = setup_interpreter_globals::<ReservedNameSig>(py, &input, &submit, None)
+                .expect_err("reserved input names should fail setup");
+            let message = err.to_string();
+            assert!(message.contains("llm_query"));
+            assert!(message.contains("reserved runtime binding"));
         });
     }
 

--- a/crates/dspy-rs/src/modules/rlm/runtime.rs
+++ b/crates/dspy-rs/src/modules/rlm/runtime.rs
@@ -36,6 +36,7 @@ pub struct MethodSignature {
 pub struct InterpreterSetup {
     pub globals: Py<PyDict>,
     pub methods_by_var: BTreeMap<String, Vec<MethodSignature>>,
+    pub methods_by_type: BTreeMap<String, Vec<MethodSignature>>,
 }
 
 pub trait RlmInputFields {
@@ -115,6 +116,7 @@ impl<S: Signature> RlmRuntime<S> for StubRuntime {
         Ok(InterpreterSetup {
             globals: PyDict::new(py).unbind(),
             methods_by_var: BTreeMap::new(),
+            methods_by_type: BTreeMap::new(),
         })
     }
 

--- a/crates/dspy-rs/src/modules/rlm/runtime.rs
+++ b/crates/dspy-rs/src/modules/rlm/runtime.rs
@@ -22,12 +22,18 @@ pub use submit::{clear_submit_slot, take_submit_result};
 /// a concrete PyO3-backed implementation by implementing this trait and wiring it
 /// through `RlmBuilder::runtime(...)`.
 pub trait RlmRuntime<S: Signature>: Send + Sync {
+    /// Whether this runtime needs sub-LM tools (`llm_query*`) to be installed.
+    /// Stub runtimes can return `false` so tests can run without sub-LM wiring.
+    fn requires_sub_lm_tools(&self) -> bool {
+        true
+    }
+
     fn setup_interpreter_globals(
         &self,
         py: Python<'_>,
         input: &S::Input,
         submit_handler: &SubmitHandler,
-        llm_tools: &LlmTools,
+        llm_tools: Option<&LlmTools>,
     ) -> PyResult<Py<PyDict>>;
 
     fn execute_repl_code(
@@ -38,7 +44,7 @@ pub trait RlmRuntime<S: Signature>: Send + Sync {
         max_output_chars: usize,
     ) -> Result<String, String>;
 
-    fn sub_lm_budget_remaining(&self, llm_tools: &LlmTools) -> usize;
+    fn sub_lm_budget_remaining(&self, llm_tools: Option<&LlmTools>) -> usize;
 }
 
 #[derive(Default, Debug, Clone)]
@@ -51,12 +57,16 @@ impl StubRuntime {
 }
 
 impl<S: Signature> RlmRuntime<S> for StubRuntime {
+    fn requires_sub_lm_tools(&self) -> bool {
+        false
+    }
+
     fn setup_interpreter_globals(
         &self,
         py: Python<'_>,
         _input: &S::Input,
         _submit_handler: &SubmitHandler,
-        _llm_tools: &LlmTools,
+        _llm_tools: Option<&LlmTools>,
     ) -> PyResult<Py<PyDict>> {
         Ok(PyDict::new(py).unbind())
     }
@@ -71,7 +81,7 @@ impl<S: Signature> RlmRuntime<S> for StubRuntime {
         Ok(String::new())
     }
 
-    fn sub_lm_budget_remaining(&self, _llm_tools: &LlmTools) -> usize {
+    fn sub_lm_budget_remaining(&self, _llm_tools: Option<&LlmTools>) -> usize {
         0
     }
 }
@@ -85,7 +95,7 @@ impl<S: Signature> RlmRuntime<S> for PyO3Runtime {
         py: Python<'_>,
         input: &S::Input,
         submit_handler: &SubmitHandler,
-        llm_tools: &LlmTools,
+        llm_tools: Option<&LlmTools>,
     ) -> PyResult<Py<PyDict>> {
         py_bridge::setup_interpreter_globals::<S>(py, input, submit_handler, llm_tools)
     }
@@ -100,8 +110,8 @@ impl<S: Signature> RlmRuntime<S> for PyO3Runtime {
         exec::execute_repl_code(py, globals, code, max_output_chars)
     }
 
-    fn sub_lm_budget_remaining(&self, llm_tools: &LlmTools) -> usize {
-        llm_tools.remaining_calls()
+    fn sub_lm_budget_remaining(&self, llm_tools: Option<&LlmTools>) -> usize {
+        llm_tools.map(LlmTools::remaining_calls).unwrap_or(0)
     }
 }
 

--- a/crates/dspy-rs/src/modules/rlm/runtime.rs
+++ b/crates/dspy-rs/src/modules/rlm/runtime.rs
@@ -32,7 +32,7 @@ pub struct MethodSignature {
     pub is_dunder: bool,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct InterpreterSetup {
     pub globals: Py<PyDict>,
     pub methods_by_var: BTreeMap<String, Vec<MethodSignature>>,

--- a/crates/dspy-rs/src/modules/rlm/runtime.rs
+++ b/crates/dspy-rs/src/modules/rlm/runtime.rs
@@ -1,49 +1,20 @@
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
-use indexmap::IndexMap;
+use super::exec;
+use super::py_bridge;
+use super::submit;
+use super::tools;
+use crate::Signature;
 use pyo3::types::PyDict;
 use pyo3::{Py, PyResult, Python};
 
-use crate::{BamlValue, FieldMeta, Signature};
+pub type SubmitResultDyn = submit::SubmitResultDyn;
+pub type SubmitSlot = submit::SubmitSlot;
+pub type SubmitError = submit::SubmitError;
+pub type SubmitHandler = submit::SubmitHandler;
+pub type LlmTools = tools::LlmTools;
 
-pub type SubmitResultDyn = Result<(BamlValue, IndexMap<String, FieldMeta>), SubmitError>;
-pub type SubmitSlot = Arc<Mutex<Option<SubmitResultDyn>>>;
-
-#[derive(Debug, Clone, thiserror::Error)]
-pub enum SubmitError {
-    #[error("validation failed: {message}")]
-    ValidationError {
-        message: String,
-        errors: Vec<String>,
-    },
-
-    #[error("assertion `{label}` failed: {expression}")]
-    AssertionFailed { label: String, expression: String },
-}
-
-pub fn clear_submit_slot(slot: &SubmitSlot) {
-    let mut guard = slot.lock().expect("submit slot mutex poisoned");
-    *guard = None;
-}
-
-pub fn take_submit_result(slot: &SubmitSlot) -> Option<SubmitResultDyn> {
-    let mut guard = slot.lock().expect("submit slot mutex poisoned");
-    guard.take()
-}
-
-#[derive(Debug, Default, Clone)]
-pub struct SubmitHandler;
-
-#[derive(Debug, Default, Clone)]
-pub struct LlmTools {
-    pub max_llm_calls: usize,
-}
-
-impl LlmTools {
-    pub fn remaining_calls(&self) -> usize {
-        self.max_llm_calls
-    }
-}
+pub use submit::{clear_submit_slot, take_submit_result};
 
 /// Runtime abstraction for REPL-backed RLM execution.
 ///
@@ -70,16 +41,12 @@ pub trait RlmRuntime<S: Signature>: Send + Sync {
     fn sub_lm_budget_remaining(&self, llm_tools: &LlmTools) -> usize;
 }
 
-#[derive(Debug)]
-pub struct StubRuntime {
-    sub_lm_remaining: Mutex<usize>,
-}
+#[derive(Default, Debug, Clone)]
+pub struct StubRuntime;
 
 impl StubRuntime {
-    pub fn new(max_llm_calls: usize) -> Self {
-        Self {
-            sub_lm_remaining: Mutex::new(max_llm_calls),
-        }
+    pub fn new(_max_llm_calls: usize) -> Self {
+        Self
     }
 }
 
@@ -105,10 +72,36 @@ impl<S: Signature> RlmRuntime<S> for StubRuntime {
     }
 
     fn sub_lm_budget_remaining(&self, _llm_tools: &LlmTools) -> usize {
-        *self
-            .sub_lm_remaining
-            .lock()
-            .expect("stub runtime budget mutex poisoned")
+        0
+    }
+}
+
+#[derive(Default, Debug, Clone)]
+pub struct PyO3Runtime;
+
+impl<S: Signature> RlmRuntime<S> for PyO3Runtime {
+    fn setup_interpreter_globals(
+        &self,
+        py: Python<'_>,
+        input: &S::Input,
+        submit_handler: &SubmitHandler,
+        llm_tools: &LlmTools,
+    ) -> PyResult<Py<PyDict>> {
+        py_bridge::setup_interpreter_globals::<S>(py, input, submit_handler, llm_tools)
+    }
+
+    fn execute_repl_code(
+        &self,
+        py: Python<'_>,
+        globals: &Py<PyDict>,
+        code: &str,
+        max_output_chars: usize,
+    ) -> Result<String, String> {
+        exec::execute_repl_code(py, globals, code, max_output_chars)
+    }
+
+    fn sub_lm_budget_remaining(&self, llm_tools: &LlmTools) -> usize {
+        llm_tools.remaining_calls()
     }
 }
 

--- a/crates/dspy-rs/src/modules/rlm/runtime.rs
+++ b/crates/dspy-rs/src/modules/rlm/runtime.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use super::exec;
@@ -5,8 +6,8 @@ use super::py_bridge;
 use super::submit;
 use super::tools;
 use crate::Signature;
-use pyo3::types::PyDict;
-use pyo3::{Py, PyResult, Python};
+use pyo3::types::{PyAny, PyDict, PyDictMethods};
+use pyo3::{Bound, Py, PyResult, Python};
 
 pub type SubmitResultDyn = submit::SubmitResultDyn;
 pub type SubmitSlot = submit::SubmitSlot;
@@ -15,6 +16,44 @@ pub type SubmitHandler = submit::SubmitHandler;
 pub type LlmTools = tools::LlmTools;
 
 pub use submit::{clear_submit_slot, take_submit_result};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum MethodSource {
+    Generated,
+    Custom,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct MethodSignature {
+    pub name: String,
+    pub signature: String,
+    pub doc: String,
+    pub source: MethodSource,
+    pub is_dunder: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct InterpreterSetup {
+    pub globals: Py<PyDict>,
+    pub methods_by_var: BTreeMap<String, Vec<MethodSignature>>,
+}
+
+pub trait RlmInputFields {
+    fn rlm_field_names(&self) -> &'static [&'static str];
+
+    fn rlm_py_fields(&self, py: Python<'_>) -> PyResult<Vec<(String, Py<PyAny>)>>;
+
+    fn inject_into_python<'py>(
+        &self,
+        py: Python<'py>,
+        globals: &Bound<'py, PyDict>,
+    ) -> PyResult<()> {
+        for (name, obj) in self.rlm_py_fields(py)? {
+            globals.set_item(name, obj)?;
+        }
+        Ok(())
+    }
+}
 
 /// Runtime abstraction for REPL-backed RLM execution.
 ///
@@ -34,7 +73,9 @@ pub trait RlmRuntime<S: Signature>: Send + Sync {
         input: &S::Input,
         submit_handler: &SubmitHandler,
         llm_tools: Option<&LlmTools>,
-    ) -> PyResult<Py<PyDict>>;
+    ) -> PyResult<InterpreterSetup>
+    where
+        S::Input: RlmInputFields;
 
     fn execute_repl_code(
         &self,
@@ -67,8 +108,14 @@ impl<S: Signature> RlmRuntime<S> for StubRuntime {
         _input: &S::Input,
         _submit_handler: &SubmitHandler,
         _llm_tools: Option<&LlmTools>,
-    ) -> PyResult<Py<PyDict>> {
-        Ok(PyDict::new(py).unbind())
+    ) -> PyResult<InterpreterSetup>
+    where
+        S::Input: RlmInputFields,
+    {
+        Ok(InterpreterSetup {
+            globals: PyDict::new(py).unbind(),
+            methods_by_var: BTreeMap::new(),
+        })
     }
 
     fn execute_repl_code(
@@ -96,7 +143,10 @@ impl<S: Signature> RlmRuntime<S> for PyO3Runtime {
         input: &S::Input,
         submit_handler: &SubmitHandler,
         llm_tools: Option<&LlmTools>,
-    ) -> PyResult<Py<PyDict>> {
+    ) -> PyResult<InterpreterSetup>
+    where
+        S::Input: RlmInputFields,
+    {
         py_bridge::setup_interpreter_globals::<S>(py, input, submit_handler, llm_tools)
     }
 

--- a/crates/dspy-rs/src/modules/rlm/runtime.rs
+++ b/crates/dspy-rs/src/modules/rlm/runtime.rs
@@ -1,0 +1,115 @@
+use std::sync::{Arc, Mutex};
+
+use indexmap::IndexMap;
+use pyo3::types::PyDict;
+use pyo3::{Py, PyResult, Python};
+
+use crate::{BamlValue, FieldMeta, Signature};
+
+pub type SubmitResultDyn = Result<(BamlValue, IndexMap<String, FieldMeta>), SubmitError>;
+pub type SubmitSlot = Arc<Mutex<Option<SubmitResultDyn>>>;
+
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum SubmitError {
+    #[error("validation failed: {message}")]
+    ValidationError {
+        message: String,
+        errors: Vec<String>,
+    },
+
+    #[error("assertion `{label}` failed: {expression}")]
+    AssertionFailed { label: String, expression: String },
+}
+
+pub fn clear_submit_slot(slot: &SubmitSlot) {
+    let mut guard = slot.lock().expect("submit slot mutex poisoned");
+    *guard = None;
+}
+
+pub fn take_submit_result(slot: &SubmitSlot) -> Option<SubmitResultDyn> {
+    let mut guard = slot.lock().expect("submit slot mutex poisoned");
+    guard.take()
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct SubmitHandler;
+
+#[derive(Debug, Default, Clone)]
+pub struct LlmTools {
+    pub max_llm_calls: usize,
+}
+
+impl LlmTools {
+    pub fn remaining_calls(&self) -> usize {
+        self.max_llm_calls
+    }
+}
+
+/// Runtime abstraction for REPL-backed RLM execution.
+///
+/// V1 ships with a stub implementation in this crate. Another module can provide
+/// a concrete PyO3-backed implementation by implementing this trait and wiring it
+/// through `RlmBuilder::runtime(...)`.
+pub trait RlmRuntime<S: Signature>: Send + Sync {
+    fn setup_interpreter_globals(
+        &self,
+        py: Python<'_>,
+        input: &S::Input,
+        submit_handler: &SubmitHandler,
+        llm_tools: &LlmTools,
+    ) -> PyResult<Py<PyDict>>;
+
+    fn execute_repl_code(
+        &self,
+        py: Python<'_>,
+        globals: &Py<PyDict>,
+        code: &str,
+        max_output_chars: usize,
+    ) -> Result<String, String>;
+
+    fn sub_lm_budget_remaining(&self, llm_tools: &LlmTools) -> usize;
+}
+
+#[derive(Debug)]
+pub struct StubRuntime {
+    sub_lm_remaining: Mutex<usize>,
+}
+
+impl StubRuntime {
+    pub fn new(max_llm_calls: usize) -> Self {
+        Self {
+            sub_lm_remaining: Mutex::new(max_llm_calls),
+        }
+    }
+}
+
+impl<S: Signature> RlmRuntime<S> for StubRuntime {
+    fn setup_interpreter_globals(
+        &self,
+        py: Python<'_>,
+        _input: &S::Input,
+        _submit_handler: &SubmitHandler,
+        _llm_tools: &LlmTools,
+    ) -> PyResult<Py<PyDict>> {
+        Ok(PyDict::new(py).unbind())
+    }
+
+    fn execute_repl_code(
+        &self,
+        _py: Python<'_>,
+        _globals: &Py<PyDict>,
+        _code: &str,
+        _max_output_chars: usize,
+    ) -> Result<String, String> {
+        Ok(String::new())
+    }
+
+    fn sub_lm_budget_remaining(&self, _llm_tools: &LlmTools) -> usize {
+        *self
+            .sub_lm_remaining
+            .lock()
+            .expect("stub runtime budget mutex poisoned")
+    }
+}
+
+pub type DynRuntime<S> = Arc<dyn RlmRuntime<S>>;

--- a/crates/dspy-rs/src/modules/rlm/submit.rs
+++ b/crates/dspy-rs/src/modules/rlm/submit.rs
@@ -8,7 +8,7 @@ use pyo3::prelude::*;
 use pyo3::types::{PyAnyMethods, PyDict, PyDictMethods};
 
 use crate::{
-    BamlValue, ConstraintKind, ConstraintResult, FieldMeta, Flag, ResponseCheck, Signature,
+    BamlValue, ConstraintKind, ConstraintResult, FieldMeta, ResponseCheck, Signature,
     SignatureSchema,
 };
 
@@ -30,10 +30,9 @@ pub enum SubmitError {
     },
 }
 
-pub struct ParsedDyn {
-    pub baml_value: BamlValue,
-    pub flags: Vec<Flag>,
-    pub checks: Vec<ResponseCheck>,
+struct ParsedDyn {
+    baml_value: BamlValue,
+    checks: Vec<ResponseCheck>,
 }
 
 type ParseFn = dyn for<'py> Fn(Python<'py>, &Bound<'py, PyDict>) -> Result<ParsedDyn, BamlParseError>
@@ -54,11 +53,15 @@ pub fn is_submit_terminated(err: &PyErr, py: Python<'_>) -> bool {
 }
 
 pub fn clear_submit_slot(slot: &SubmitSlot) {
-    *slot.lock().expect("submit slot lock poisoned") = None;
+    set_submit_result(slot, None);
 }
 
 pub fn take_submit_result(slot: &SubmitSlot) -> Option<SubmitResultDyn> {
     slot.lock().expect("submit slot lock poisoned").take()
+}
+
+fn set_submit_result(slot: &SubmitSlot, value: Option<SubmitResultDyn>) {
+    *slot.lock().expect("submit slot lock poisoned") = value;
 }
 
 #[pyclass]
@@ -86,11 +89,7 @@ impl SubmitHandler {
         let parse_fn: Arc<ParseFn> = Arc::new(|py, kwargs| {
             let baml_value = super::py_bridge::kwargs_to_baml_value::<S>(py, kwargs)?;
             let checks = super::py_bridge::collect_checks_for_output::<S>(&baml_value)?;
-            Ok(ParsedDyn {
-                baml_value,
-                flags: Vec::new(),
-                checks,
-            })
+            Ok(ParsedDyn { baml_value, checks })
         });
 
         Self {
@@ -155,8 +154,10 @@ impl SubmitHandler {
             };
 
             let user_message = format_submit_error("Validation failed", &errors, None);
-            *self.slot.lock().expect("submit slot lock poisoned") =
-                Some(Err(SubmitError::ValidationError { message, errors }));
+            set_submit_result(
+                &self.slot,
+                Some(Err(SubmitError::ValidationError { message, errors })),
+            );
             return Ok(user_message);
         }
 
@@ -164,11 +165,11 @@ impl SubmitHandler {
 
         match parsed_result {
             Ok(parsed) => {
-                let raw_text = serde_json::to_string(&parsed.baml_value)
+                let ParsedDyn { baml_value, checks } = parsed;
+                let raw_text = serde_json::to_string(&baml_value)
                     .unwrap_or_else(|_| "<unserializable>".to_string());
-                let metas = build_field_metas(&parsed, &raw_text);
-                *self.slot.lock().expect("submit slot lock poisoned") =
-                    Some(Ok((parsed.baml_value.clone(), metas)));
+                let metas = build_field_metas(&checks, &raw_text);
+                set_submit_result(&self.slot, Some(Ok((baml_value, metas))));
 
                 Err(SubmitTerminated::new_err("SUBMIT accepted"))
             }
@@ -179,11 +180,13 @@ impl SubmitHandler {
                     )
                 })?;
 
-                *self.slot.lock().expect("submit slot lock poisoned") =
+                set_submit_result(
+                    &self.slot,
                     Some(Err(SubmitError::AssertionFailed {
                         label: failure.name.clone(),
                         expression: failure.expression.clone(),
-                    }));
+                    })),
+                );
 
                 Ok(format_submit_error(
                     "Assertion failed",
@@ -196,11 +199,13 @@ impl SubmitHandler {
             }
             Err(err) => {
                 let errors = format_parse_errors(kwargs, &self.schema, &err);
-                *self.slot.lock().expect("submit slot lock poisoned") =
+                set_submit_result(
+                    &self.slot,
                     Some(Err(SubmitError::ValidationError {
                         message: err.to_string(),
                         errors: errors.clone(),
-                    }));
+                    })),
+                );
 
                 Ok(format_submit_error(
                     "Validation failed",
@@ -220,7 +225,7 @@ impl SubmitHandler {
     }
 }
 
-fn build_field_metas(parsed: &ParsedDyn, raw_json: &str) -> IndexMap<String, FieldMeta> {
+fn build_field_metas(checks: &[ResponseCheck], raw_json: &str) -> IndexMap<String, FieldMeta> {
     let mut metas = IndexMap::new();
     let mut meta = FieldMeta {
         raw_text: raw_json.to_string(),
@@ -228,9 +233,7 @@ fn build_field_metas(parsed: &ParsedDyn, raw_json: &str) -> IndexMap<String, Fie
         checks: Vec::new(),
     };
 
-    meta.flags.extend(parsed.flags.iter().cloned());
-
-    for check in &parsed.checks {
+    for check in checks {
         meta.checks.push(ConstraintResult {
             label: check.name.clone(),
             expression: check.expression.clone(),

--- a/crates/dspy-rs/src/modules/rlm/submit.rs
+++ b/crates/dspy-rs/src/modules/rlm/submit.rs
@@ -389,34 +389,7 @@ fn py_err_to_value(err: pyo3::PyErr) -> pyo3::PyErr {
 }
 
 fn format_type_name(type_ir: &crate::TypeIR) -> String {
-    let raw = type_ir.diagnostic_repr().to_string();
-    simplify_type_name(&raw)
-        .replace("class ", "")
-        .replace("enum ", "")
-        .replace(" | ", " or ")
-        .trim()
-        .to_string()
-}
-
-fn simplify_type_name(raw: &str) -> String {
-    let mut result = String::with_capacity(raw.len());
-    let mut chars = raw.chars();
-    while let Some(ch) = chars.next() {
-        if ch == '`' {
-            let mut token = String::new();
-            for next in chars.by_ref() {
-                if next == '`' {
-                    break;
-                }
-                token.push(next);
-            }
-            let simplified = token.rsplit("::").next().unwrap_or(&token);
-            result.push_str(simplified);
-        } else {
-            result.push(ch);
-        }
-    }
-    result
+    crate::core::render_type_name_for_prompt_with(type_ir, crate::core::simplify_type_token)
 }
 
 #[cfg(test)]

--- a/crates/dspy-rs/src/modules/rlm/submit.rs
+++ b/crates/dspy-rs/src/modules/rlm/submit.rs
@@ -357,7 +357,10 @@ fn generate_schema_description(schema: &SignatureSchema) -> String {
     desc.push_str(") where:\n");
 
     for field in fields {
-        let type_name = format_type_name(&field.type_ir);
+        let type_name = crate::core::render_type_name_for_prompt_with(
+            &field.type_ir,
+            crate::core::simplify_type_token,
+        );
         desc.push_str(&format!("  {}: {}", field.lm_name, type_name));
 
         if !field.docs.is_empty() {
@@ -386,10 +389,6 @@ fn generate_schema_description(schema: &SignatureSchema) -> String {
 
 fn py_err_to_value(err: pyo3::PyErr) -> pyo3::PyErr {
     pyo3::exceptions::PyValueError::new_err(err.to_string())
-}
-
-fn format_type_name(type_ir: &crate::TypeIR) -> String {
-    crate::core::render_type_name_for_prompt_with(type_ir, crate::core::simplify_type_token)
 }
 
 #[cfg(test)]

--- a/crates/dspy-rs/src/modules/rlm/submit.rs
+++ b/crates/dspy-rs/src/modules/rlm/submit.rs
@@ -274,6 +274,8 @@ fn format_convert_error(
         .strip_prefix("expected ")
         .unwrap_or(err.expected)
         .trim();
+    let expected = to_python_type_name(expected);
+    let got = to_python_type_name(err.got.as_str());
 
     let field_path = err.path_string();
     let value_repr = first_path_value_repr(kwargs, schema, &err.path);
@@ -281,12 +283,26 @@ fn format_convert_error(
     match value_repr {
         Some(value_repr) => format!(
             "field '{}' expected {}, got {} {}",
-            field_path, expected, err.got, value_repr
+            field_path, expected, got, value_repr
         ),
-        None => format!(
-            "field '{}' expected {}, got {}",
-            field_path, expected, err.got
-        ),
+        None => format!("field '{}' expected {}, got {}", field_path, expected, got),
+    }
+}
+
+fn to_python_type_name(raw: &str) -> String {
+    let trimmed = raw.trim();
+    let base = trimmed.strip_prefix("BamlValue::").unwrap_or(trimmed);
+    match base {
+        "String" => "str".to_string(),
+        "Int" => "int".to_string(),
+        "Float" => "float".to_string(),
+        "Bool" => "bool".to_string(),
+        "Null" => "None".to_string(),
+        "List" => "list".to_string(),
+        "Map" | "Class" => "dict".to_string(),
+        "Enum" => "enum".to_string(),
+        "Media" => "media".to_string(),
+        other => other.to_string(),
     }
 }
 
@@ -517,5 +533,19 @@ mod tests {
 
         clear_submit_slot(&slot);
         assert!(slot.lock().expect("lock").is_none());
+    }
+
+    #[test]
+    fn python_type_name_mapping_covers_baml_tokens() {
+        assert_eq!(to_python_type_name("BamlValue::String"), "str");
+        assert_eq!(to_python_type_name("BamlValue::Int"), "int");
+        assert_eq!(to_python_type_name("BamlValue::Float"), "float");
+        assert_eq!(to_python_type_name("BamlValue::Bool"), "bool");
+        assert_eq!(to_python_type_name("BamlValue::Null"), "None");
+        assert_eq!(to_python_type_name("BamlValue::List"), "list");
+        assert_eq!(to_python_type_name("BamlValue::Map"), "dict");
+        assert_eq!(to_python_type_name("BamlValue::Class"), "dict");
+        assert_eq!(to_python_type_name("BamlValue::Enum"), "enum");
+        assert_eq!(to_python_type_name("BamlValue::Media"), "media");
     }
 }

--- a/crates/dspy-rs/src/modules/rlm/submit.rs
+++ b/crates/dspy-rs/src/modules/rlm/submit.rs
@@ -1,0 +1,545 @@
+use std::collections::HashSet;
+use std::sync::{Arc, Mutex};
+
+use bamltype::BamlParseError;
+use indexmap::IndexMap;
+use pyo3::exceptions::PyException;
+use pyo3::prelude::*;
+use pyo3::types::{PyAnyMethods, PyDict, PyDictMethods};
+
+use crate::{
+    BamlValue, ConstraintKind, ConstraintResult, FieldMeta, Flag, ResponseCheck, Signature,
+    SignatureSchema,
+};
+
+/// Type-erased SUBMIT result used by the outer loop controller.
+pub type SubmitResultDyn = Result<(BamlValue, IndexMap<String, FieldMeta>), SubmitError>;
+
+/// Shared storage slot written by SUBMIT and consumed by the RLM loop.
+pub type SubmitSlot = Arc<Mutex<Option<SubmitResultDyn>>>;
+
+#[derive(Debug, Clone)]
+pub enum SubmitError {
+    ValidationError {
+        message: String,
+        errors: Vec<String>,
+    },
+    AssertionFailed {
+        label: String,
+        expression: String,
+    },
+}
+
+pub struct ParsedDyn {
+    pub baml_value: BamlValue,
+    pub flags: Vec<Flag>,
+    pub checks: Vec<ResponseCheck>,
+}
+
+type ParseFn = dyn for<'py> Fn(Python<'py>, &Bound<'py, PyDict>) -> Result<ParsedDyn, BamlParseError>
+    + Send
+    + Sync;
+
+pyo3::create_exception!(
+    dspy_rs_rlm,
+    SubmitTerminated,
+    PyException,
+    "Raised to terminate REPL execution after a successful SUBMIT."
+);
+
+pub const SUBMIT_STDOUT_ATTR: &str = "__dsrs_stdout__";
+
+pub fn is_submit_terminated(err: &PyErr, py: Python<'_>) -> bool {
+    err.is_instance_of::<SubmitTerminated>(py)
+}
+
+pub fn clear_submit_slot(slot: &SubmitSlot) {
+    *slot.lock().expect("submit slot lock poisoned") = None;
+}
+
+pub fn take_submit_result(slot: &SubmitSlot) -> Option<SubmitResultDyn> {
+    slot.lock().expect("submit slot lock poisoned").take()
+}
+
+#[pyclass]
+#[derive(Clone)]
+pub struct SubmitHandler {
+    parse_fn: Arc<ParseFn>,
+    schema: Arc<SignatureSchema>,
+    slot: SubmitSlot,
+    schema_description: String,
+    output_fields_lm: Vec<String>,
+    output_fields_set: HashSet<String>,
+}
+
+impl SubmitHandler {
+    pub fn new<S: Signature>(slot: SubmitSlot) -> Self {
+        let schema = Arc::new(S::schema().clone());
+        let schema_description = generate_schema_description(schema.as_ref());
+        let output_fields_lm = schema
+            .output_fields()
+            .iter()
+            .map(|field| field.lm_name.to_string())
+            .collect::<Vec<_>>();
+        let output_fields_set = output_fields_lm.iter().cloned().collect::<HashSet<_>>();
+
+        let parse_fn: Arc<ParseFn> = Arc::new(|py, kwargs| {
+            let baml_value = super::py_bridge::kwargs_to_baml_value::<S>(py, kwargs)?;
+            let checks = super::py_bridge::collect_checks_for_output::<S>(&baml_value)?;
+            Ok(ParsedDyn {
+                baml_value,
+                flags: Vec::new(),
+                checks,
+            })
+        });
+
+        Self {
+            parse_fn,
+            schema,
+            slot,
+            schema_description,
+            output_fields_lm,
+            output_fields_set,
+        }
+    }
+
+    pub fn with_new_slot<S: Signature>() -> (Self, SubmitSlot) {
+        let slot = Arc::new(Mutex::new(None));
+        (Self::new::<S>(Arc::clone(&slot)), slot)
+    }
+}
+
+#[pymethods]
+impl SubmitHandler {
+    #[pyo3(signature = (**kwargs))]
+    fn __call__(&self, py: Python<'_>, kwargs: Option<&Bound<'_, PyDict>>) -> PyResult<String> {
+        let kwargs = kwargs.ok_or_else(|| {
+            pyo3::exceptions::PyValueError::new_err(
+                "SUBMIT requires keyword arguments. Usage: SUBMIT(field1=value1, field2=value2)",
+            )
+        })?;
+
+        let mut unexpected = Vec::new();
+        for (key, _) in kwargs.iter() {
+            let key = key.extract::<String>().map_err(py_err_to_value)?;
+            if !self.output_fields_set.contains(&key) {
+                unexpected.push(key);
+            }
+        }
+        unexpected.sort();
+
+        let mut missing = Vec::new();
+        for field in &self.output_fields_lm {
+            let present = kwargs.contains(field.as_str()).map_err(py_err_to_value)?;
+            if !present {
+                missing.push(field.clone());
+            }
+        }
+
+        if !missing.is_empty() || !unexpected.is_empty() {
+            let usage = format_submit_usage(&self.output_fields_lm);
+            let mut errors = Vec::new();
+            if !missing.is_empty() {
+                errors.push(format!("Missing fields: {:?}", missing));
+            }
+            if !unexpected.is_empty() {
+                errors.push(format!("Unexpected fields: {:?}", unexpected));
+            }
+
+            let (message, user_message) = match (missing.is_empty(), unexpected.is_empty()) {
+                (false, true) => (
+                    "Missing output fields".to_string(),
+                    format!(
+                        "[Error] Missing output fields: {:?}. Use SUBMIT({usage})",
+                        missing
+                    ),
+                ),
+                (true, false) => (
+                    "Unexpected output fields".to_string(),
+                    format!(
+                        "[Error] Unexpected output fields: {:?}. Use SUBMIT({usage})",
+                        unexpected
+                    ),
+                ),
+                (false, false) => (
+                    "Invalid output fields".to_string(),
+                    format!(
+                        "[Error] Invalid output fields. Missing: {:?}. Unexpected: {:?}. Use SUBMIT({usage})",
+                        missing, unexpected
+                    ),
+                ),
+                (true, true) => unreachable!(),
+            };
+
+            *self.slot.lock().expect("submit slot lock poisoned") =
+                Some(Err(SubmitError::ValidationError { message, errors }));
+            return Ok(user_message);
+        }
+
+        let parsed_result = (self.parse_fn)(py, kwargs);
+
+        match parsed_result {
+            Ok(parsed) => {
+                let raw_text = serde_json::to_string(&parsed.baml_value)
+                    .unwrap_or_else(|_| "<unserializable>".to_string());
+                let metas = build_field_metas(&parsed, &raw_text);
+                *self.slot.lock().expect("submit slot lock poisoned") =
+                    Some(Ok((parsed.baml_value.clone(), metas)));
+
+                Err(SubmitTerminated::new_err("SUBMIT accepted"))
+            }
+            Err(BamlParseError::ConstraintAssertsFailed { failed }) => {
+                let failure = failed.first().ok_or_else(|| {
+                    pyo3::exceptions::PyValueError::new_err(
+                        "SUBMIT assertion failed with no details",
+                    )
+                })?;
+
+                *self.slot.lock().expect("submit slot lock poisoned") =
+                    Some(Err(SubmitError::AssertionFailed {
+                        label: failure.name.clone(),
+                        expression: failure.expression.clone(),
+                    }));
+
+                Ok(format!(
+                    "[Error] Assertion '{}' failed: {}\nPlease fix and try again.",
+                    failure.name, failure.expression
+                ))
+            }
+            Err(err) => {
+                let errors = format_parse_errors(kwargs, &self.schema, &err);
+                *self.slot.lock().expect("submit slot lock poisoned") =
+                    Some(Err(SubmitError::ValidationError {
+                        message: err.to_string(),
+                        errors: errors.clone(),
+                    }));
+
+                let joined = errors.join("\n");
+                if self.schema_description.is_empty() {
+                    Ok(joined)
+                } else {
+                    Ok(format!(
+                        "{}\n\nExpected schema:\n{}",
+                        joined, self.schema_description
+                    ))
+                }
+            }
+        }
+    }
+
+    pub fn schema(&self) -> String {
+        self.schema_description.clone()
+    }
+}
+
+fn build_field_metas(parsed: &ParsedDyn, raw_json: &str) -> IndexMap<String, FieldMeta> {
+    let mut metas = IndexMap::new();
+    let mut meta = FieldMeta {
+        raw_text: raw_json.to_string(),
+        flags: Vec::new(),
+        checks: Vec::new(),
+    };
+
+    meta.flags.extend(parsed.flags.iter().cloned());
+
+    for check in &parsed.checks {
+        meta.checks.push(ConstraintResult {
+            label: check.name.clone(),
+            expression: check.expression.clone(),
+            passed: check.status == "succeeded",
+        });
+    }
+
+    metas.insert("_root".to_string(), meta);
+    metas
+}
+
+fn format_parse_errors(
+    kwargs: &Bound<'_, PyDict>,
+    schema: &SignatureSchema,
+    err: &BamlParseError,
+) -> Vec<String> {
+    match err {
+        BamlParseError::Convert(err) => vec![format_convert_error(kwargs, schema, err)],
+        BamlParseError::Jsonish(err) => vec![format!("[Error] {err}")],
+        BamlParseError::ConstraintAssertsFailed { failed } => failed
+            .iter()
+            .map(|check| {
+                format!(
+                    "[Error] Assertion '{}' failed: {}",
+                    check.name, check.expression
+                )
+            })
+            .collect(),
+    }
+}
+
+fn format_convert_error(
+    kwargs: &Bound<'_, PyDict>,
+    schema: &SignatureSchema,
+    err: &crate::BamlConvertError,
+) -> String {
+    if err.expected == "field" && err.got == "missing" {
+        return format!("[Error] Missing required field: {}", err.path_string());
+    }
+
+    let expected = err
+        .message
+        .strip_prefix("expected ")
+        .unwrap_or(err.expected)
+        .trim();
+
+    let field_path = err.path_string();
+    let value_repr = first_path_value_repr(kwargs, schema, &err.path);
+
+    match value_repr {
+        Some(value_repr) => format!(
+            "[Error] field '{}' expected {}, got {} {}",
+            field_path, expected, err.got, value_repr
+        ),
+        None => format!(
+            "[Error] field '{}' expected {}, got {}",
+            field_path, expected, err.got
+        ),
+    }
+}
+
+fn first_path_value_repr(
+    kwargs: &Bound<'_, PyDict>,
+    schema: &SignatureSchema,
+    path: &[String],
+) -> Option<String> {
+    let first = path.first()?;
+
+    let lm_name = schema
+        .output_fields()
+        .iter()
+        .find_map(|field| {
+            if field.rust_name == *first || field.lm_name == first {
+                Some(field.lm_name)
+            } else {
+                None
+            }
+        })
+        .unwrap_or(first.as_str());
+
+    let value = kwargs.get_item(lm_name).ok().flatten()?;
+    value
+        .repr()
+        .ok()
+        .and_then(|repr| repr.extract::<String>().ok())
+}
+
+fn format_submit_usage(fields: &[String]) -> String {
+    fields
+        .iter()
+        .map(|field| format!("{field}={field}"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn generate_schema_description(schema: &SignatureSchema) -> String {
+    let fields = schema.output_fields();
+    if fields.is_empty() {
+        return String::new();
+    }
+
+    let mut desc = String::new();
+    desc.push_str("SUBMIT(");
+    desc.push_str(
+        &fields
+            .iter()
+            .map(|field| field.lm_name)
+            .collect::<Vec<_>>()
+            .join(", "),
+    );
+    desc.push_str(") where:\n");
+
+    for field in fields {
+        let type_name = format_type_name(&field.type_ir);
+        desc.push_str(&format!("  {}: {}", field.lm_name, type_name));
+
+        if !field.docs.is_empty() {
+            desc.push_str(&format!("  # {}", field.docs));
+        }
+        desc.push('\n');
+
+        for constraint in field.constraints {
+            let kind = match constraint.kind {
+                ConstraintKind::Check => "check",
+                ConstraintKind::Assert => "ASSERT",
+            };
+            if constraint.label.is_empty() {
+                desc.push_str(&format!("    [{kind}] {}\n", constraint.expression));
+            } else {
+                desc.push_str(&format!(
+                    "    [{kind}] {}: {}\n",
+                    constraint.label, constraint.expression
+                ));
+            }
+        }
+    }
+
+    desc.trim_end().to_string()
+}
+
+fn py_err_to_value(err: pyo3::PyErr) -> pyo3::PyErr {
+    pyo3::exceptions::PyValueError::new_err(err.to_string())
+}
+
+fn format_type_name(type_ir: &crate::TypeIR) -> String {
+    let raw = type_ir.diagnostic_repr().to_string();
+    simplify_type_name(&raw)
+        .replace("class ", "")
+        .replace("enum ", "")
+        .replace(" | ", " or ")
+        .trim()
+        .to_string()
+}
+
+fn simplify_type_name(raw: &str) -> String {
+    let mut result = String::with_capacity(raw.len());
+    let mut chars = raw.chars();
+    while let Some(ch) = chars.next() {
+        if ch == '`' {
+            let mut token = String::new();
+            for next in chars.by_ref() {
+                if next == '`' {
+                    break;
+                }
+                token.push(next);
+            }
+            let simplified = token.rsplit("::").next().unwrap_or(&token);
+            result.push_str(simplified);
+        } else {
+            result.push(ch);
+        }
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use pyo3::types::PyDict;
+
+    use super::*;
+    use crate::Signature;
+
+    #[derive(Signature, Clone, Debug)]
+    struct SubmitSig {
+        #[input]
+        question: String,
+
+        #[output]
+        answer: String,
+
+        #[output]
+        score: f64,
+    }
+
+    #[derive(Signature, Clone, Debug)]
+    struct SubmitAssertSig {
+        #[input]
+        question: String,
+
+        #[output]
+        #[assert("this > 0", label = "positive")]
+        score: i64,
+    }
+
+    #[test]
+    fn submit_success_writes_slot_and_raises_terminated() {
+        Python::attach(|py| {
+            let (handler, slot) = SubmitHandler::with_new_slot::<SubmitSig>();
+            let kwargs = PyDict::new(py);
+            kwargs.set_item("answer", "ok").expect("set answer");
+            kwargs.set_item("score", 0.9).expect("set score");
+
+            let err = handler
+                .__call__(py, Some(&kwargs))
+                .expect_err("successful submit must raise SubmitTerminated");
+            assert!(is_submit_terminated(&err, py));
+
+            let stored = take_submit_result(&slot).expect("slot must be populated");
+            assert!(stored.is_ok());
+        });
+    }
+
+    #[test]
+    fn missing_field_returns_validation_error() {
+        Python::attach(|py| {
+            let (handler, slot) = SubmitHandler::with_new_slot::<SubmitSig>();
+            let kwargs = PyDict::new(py);
+            kwargs.set_item("answer", "ok").expect("set answer");
+
+            let message = handler
+                .__call__(py, Some(&kwargs))
+                .expect("missing field should return recoverable message");
+            assert!(message.contains("Missing output fields"));
+
+            let stored = take_submit_result(&slot).expect("slot must be populated");
+            match stored {
+                Err(SubmitError::ValidationError { errors, .. }) => {
+                    assert!(errors.iter().any(|err| err.contains("Missing fields")));
+                }
+                other => panic!("unexpected stored result: {other:?}"),
+            }
+        });
+    }
+
+    #[test]
+    fn type_mismatch_returns_detailed_field_error() {
+        Python::attach(|py| {
+            let (handler, slot) = SubmitHandler::with_new_slot::<SubmitSig>();
+            let kwargs = PyDict::new(py);
+            kwargs.set_item("answer", "ok").expect("set answer");
+            kwargs.set_item("score", "oops").expect("set score");
+
+            let message = handler
+                .__call__(py, Some(&kwargs))
+                .expect("type mismatch should be recoverable");
+            assert!(message.contains("field 'score'"));
+            assert!(message.contains("expected"));
+            assert!(message.contains("got"));
+
+            let stored = take_submit_result(&slot).expect("slot must be populated");
+            assert!(matches!(stored, Err(SubmitError::ValidationError { .. })));
+        });
+    }
+
+    #[test]
+    fn assertion_failure_is_recorded() {
+        Python::attach(|py| {
+            let (handler, slot) = SubmitHandler::with_new_slot::<SubmitAssertSig>();
+            let kwargs = PyDict::new(py);
+            kwargs.set_item("score", -1).expect("set score");
+
+            let message = handler
+                .__call__(py, Some(&kwargs))
+                .expect("assertion failure should be recoverable");
+            assert!(message.contains("Assertion 'positive' failed"));
+
+            let stored = take_submit_result(&slot).expect("slot must be populated");
+            match stored {
+                Err(SubmitError::AssertionFailed { label, .. }) => {
+                    assert_eq!(label, "positive");
+                }
+                other => panic!("unexpected stored result: {other:?}"),
+            }
+        });
+    }
+
+    #[test]
+    fn clear_submit_slot_removes_previous_value() {
+        let (handler, slot) = SubmitHandler::with_new_slot::<SubmitSig>();
+        drop(handler);
+
+        *slot.lock().expect("lock") = Some(Err(SubmitError::ValidationError {
+            message: "x".to_string(),
+            errors: vec!["y".to_string()],
+        }));
+
+        clear_submit_slot(&slot);
+        assert!(slot.lock().expect("lock").is_none());
+    }
+}

--- a/crates/dspy-rs/src/modules/rlm/submit.rs
+++ b/crates/dspy-rs/src/modules/rlm/submit.rs
@@ -140,37 +140,21 @@ impl SubmitHandler {
             let usage = format_submit_usage(&self.output_fields_lm);
             let mut errors = Vec::new();
             if !missing.is_empty() {
-                errors.push(format!("Missing fields: {:?}", missing));
+                errors.push(format!("missing fields: {:?}", missing));
             }
             if !unexpected.is_empty() {
-                errors.push(format!("Unexpected fields: {:?}", unexpected));
+                errors.push(format!("unexpected fields: {:?}", unexpected));
             }
+            errors.push(format!("use SUBMIT({usage})"));
 
-            let (message, user_message) = match (missing.is_empty(), unexpected.is_empty()) {
-                (false, true) => (
-                    "Missing output fields".to_string(),
-                    format!(
-                        "[Error] Missing output fields: {:?}. Use SUBMIT({usage})",
-                        missing
-                    ),
-                ),
-                (true, false) => (
-                    "Unexpected output fields".to_string(),
-                    format!(
-                        "[Error] Unexpected output fields: {:?}. Use SUBMIT({usage})",
-                        unexpected
-                    ),
-                ),
-                (false, false) => (
-                    "Invalid output fields".to_string(),
-                    format!(
-                        "[Error] Invalid output fields. Missing: {:?}. Unexpected: {:?}. Use SUBMIT({usage})",
-                        missing, unexpected
-                    ),
-                ),
+            let message = match (missing.is_empty(), unexpected.is_empty()) {
+                (false, true) => "Missing output fields".to_string(),
+                (true, false) => "Unexpected output fields".to_string(),
+                (false, false) => "Invalid output fields".to_string(),
                 (true, true) => unreachable!(),
             };
 
+            let user_message = format_submit_error("Validation failed", &errors, None);
             *self.slot.lock().expect("submit slot lock poisoned") =
                 Some(Err(SubmitError::ValidationError { message, errors }));
             return Ok(user_message);
@@ -201,9 +185,13 @@ impl SubmitHandler {
                         expression: failure.expression.clone(),
                     }));
 
-                Ok(format!(
-                    "[Error] Assertion '{}' failed: {}\nPlease fix and try again.",
-                    failure.name, failure.expression
+                Ok(format_submit_error(
+                    "Assertion failed",
+                    &[format!(
+                        "'{}': {} (please fix and try again)",
+                        failure.name, failure.expression
+                    )],
+                    None,
                 ))
             }
             Err(err) => {
@@ -214,15 +202,15 @@ impl SubmitHandler {
                         errors: errors.clone(),
                     }));
 
-                let joined = errors.join("\n");
-                if self.schema_description.is_empty() {
-                    Ok(joined)
-                } else {
-                    Ok(format!(
-                        "{}\n\nExpected schema:\n{}",
-                        joined, self.schema_description
-                    ))
-                }
+                Ok(format_submit_error(
+                    "Validation failed",
+                    &errors,
+                    if self.schema_description.is_empty() {
+                        None
+                    } else {
+                        Some(self.schema_description.as_str())
+                    },
+                ))
             }
         }
     }
@@ -261,15 +249,10 @@ fn format_parse_errors(
 ) -> Vec<String> {
     match err {
         BamlParseError::Convert(err) => vec![format_convert_error(kwargs, schema, err)],
-        BamlParseError::Jsonish(err) => vec![format!("[Error] {err}")],
+        BamlParseError::Jsonish(err) => vec![err.to_string()],
         BamlParseError::ConstraintAssertsFailed { failed } => failed
             .iter()
-            .map(|check| {
-                format!(
-                    "[Error] Assertion '{}' failed: {}",
-                    check.name, check.expression
-                )
-            })
+            .map(|check| format!("assertion '{}' failed: {}", check.name, check.expression))
             .collect(),
     }
 }
@@ -280,7 +263,7 @@ fn format_convert_error(
     err: &crate::BamlConvertError,
 ) -> String {
     if err.expected == "field" && err.got == "missing" {
-        return format!("[Error] Missing required field: {}", err.path_string());
+        return format!("missing required field: {}", err.path_string());
     }
 
     let expected = err
@@ -294,14 +277,32 @@ fn format_convert_error(
 
     match value_repr {
         Some(value_repr) => format!(
-            "[Error] field '{}' expected {}, got {} {}",
+            "field '{}' expected {}, got {} {}",
             field_path, expected, err.got, value_repr
         ),
         None => format!(
-            "[Error] field '{}' expected {}, got {}",
+            "field '{}' expected {}, got {}",
             field_path, expected, err.got
         ),
     }
+}
+
+fn format_submit_error(summary: &str, details: &[String], schema: Option<&str>) -> String {
+    let mut message = format!("SubmitError: {summary}");
+    if !details.is_empty() {
+        message.push('\n');
+        for detail in details {
+            message.push_str("  - ");
+            message.push_str(detail);
+            message.push('\n');
+        }
+        message.pop();
+    }
+    if let Some(schema) = schema {
+        message.push_str("\n\nExpected schema:\n");
+        message.push_str(schema);
+    }
+    message
 }
 
 fn first_path_value_repr(
@@ -475,12 +476,12 @@ mod tests {
             let message = handler
                 .__call__(py, Some(&kwargs))
                 .expect("missing field should return recoverable message");
-            assert!(message.contains("Missing output fields"));
+            assert!(message.contains("SubmitError: Validation failed"));
 
             let stored = take_submit_result(&slot).expect("slot must be populated");
             match stored {
                 Err(SubmitError::ValidationError { errors, .. }) => {
-                    assert!(errors.iter().any(|err| err.contains("Missing fields")));
+                    assert!(errors.iter().any(|err| err.contains("missing fields")));
                 }
                 other => panic!("unexpected stored result: {other:?}"),
             }
@@ -517,7 +518,7 @@ mod tests {
             let message = handler
                 .__call__(py, Some(&kwargs))
                 .expect("assertion failure should be recoverable");
-            assert!(message.contains("Assertion 'positive' failed"));
+            assert!(message.contains("SubmitError: Assertion failed"));
 
             let stored = take_submit_result(&slot).expect("slot must be populated");
             match stored {

--- a/crates/dspy-rs/src/modules/rlm/tools.rs
+++ b/crates/dspy-rs/src/modules/rlm/tools.rs
@@ -279,4 +279,49 @@ mod tests {
             assert!(err.to_string().contains("mock failure for bad"));
         });
     }
+
+    #[test]
+    fn shared_budget_is_enforced_across_single_and_batched_calls() {
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+
+        rt.block_on(async {
+            let tools = LlmTools::with_budget(Arc::new(MockLm::default()), 3, Handle::current());
+
+            let first = tools.llm_query("one".to_string()).expect("first call");
+            assert_eq!(first, "answer:one");
+            assert_eq!(tools.remaining_calls(), 2);
+
+            let responses = tools
+                .llm_query_batched(vec!["two".to_string(), "three".to_string()])
+                .expect("batched call");
+            assert_eq!(responses, vec!["answer:two", "answer:three"]);
+            assert_eq!(tools.remaining_calls(), 0);
+
+            let err = tools
+                .llm_query("four".to_string())
+                .expect_err("budget should be exhausted");
+            assert!(err.to_string().contains("budget exhausted"));
+        });
+    }
+
+    #[test]
+    fn empty_batched_call_returns_immediately_without_consuming_budget() {
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+
+        rt.block_on(async {
+            let tools = LlmTools::with_budget(Arc::new(MockLm::default()), 2, Handle::current());
+
+            let responses = tools
+                .llm_query_batched(Vec::new())
+                .expect("empty batch should be valid");
+            assert!(responses.is_empty());
+            assert_eq!(tools.remaining_calls(), 2);
+        });
+    }
 }

--- a/crates/dspy-rs/src/modules/rlm/tools.rs
+++ b/crates/dspy-rs/src/modules/rlm/tools.rs
@@ -5,6 +5,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use async_trait::async_trait;
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
+use pyo3::types::PyModule;
 use tokio::runtime::{Handle, RuntimeFlavor};
 
 use crate::LM;
@@ -89,6 +90,43 @@ impl LlmTools {
         }
     }
 
+    fn reserve_calls_for_batch(&self, requested: usize) -> usize {
+        loop {
+            let current = self.budget_remaining.load(Ordering::SeqCst);
+            let to_execute = current.min(requested);
+            if self
+                .budget_remaining
+                .compare_exchange(
+                    current,
+                    current.saturating_sub(to_execute),
+                    Ordering::SeqCst,
+                    Ordering::SeqCst,
+                )
+                .is_ok()
+            {
+                return to_execute;
+            }
+        }
+    }
+
+    fn emit_budget_warning(&self, executed: usize, requested: usize) {
+        if executed >= requested {
+            return;
+        }
+        let remaining = self.remaining_calls();
+        let warning = format!(
+            "⚠ Budget: executed {executed} of {requested} requested queries ({remaining} remaining of {} max)",
+            self.max_llm_calls
+        );
+        Python::attach(|py| {
+            if let Ok(builtins) = PyModule::import(py, "builtins")
+                && let Ok(print_fn) = builtins.getattr("print")
+            {
+                let _ = print_fn.call1((warning,));
+            }
+        });
+    }
+
     fn ensure_prompt(prompt: &str) -> PyResult<()> {
         if prompt.trim().is_empty() {
             return Err(PyValueError::new_err(
@@ -147,10 +185,19 @@ impl LlmTools {
             Self::ensure_prompt(prompt)?;
         }
 
-        self.reserve_calls(prompts.len())?;
+        let requested = prompts.len();
+        let executable = self.reserve_calls_for_batch(requested);
+        if executable == 0 {
+            self.emit_budget_warning(0, requested);
+            return Ok(Vec::new());
+        }
+        self.emit_budget_warning(executable, requested);
 
         let responses = self.block_with_runtime(async {
-            let futures = prompts.iter().map(|prompt| self.lm.query(prompt));
+            let futures = prompts
+                .iter()
+                .take(executable)
+                .map(|prompt| self.lm.query(prompt));
             futures::future::join_all(futures).await
         })?;
 
@@ -285,6 +332,55 @@ mod tests {
                 .expect_err("second prompt should fail");
 
             assert!(err.to_string().contains("mock failure for bad"));
+        });
+    }
+
+    #[test]
+    fn llm_query_batched_executes_partial_batch_when_budget_is_short() {
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+
+        rt.block_on(async {
+            let lm = Arc::new(MockLm::default());
+            let tools = LlmTools::with_budget(lm.clone(), 2, Handle::current());
+
+            let responses = tools
+                .llm_query_batched(vec![
+                    "one".to_string(),
+                    "two".to_string(),
+                    "three".to_string(),
+                ])
+                .expect("partial batch should succeed");
+            assert_eq!(responses, vec!["answer:one", "answer:two"]);
+            assert_eq!(tools.remaining_calls(), 0);
+
+            let calls = lm.calls.lock().expect("calls lock").clone();
+            assert_eq!(calls, vec!["one".to_string(), "two".to_string()]);
+        });
+    }
+
+    #[test]
+    fn llm_query_batched_returns_empty_when_budget_is_zero() {
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+
+        rt.block_on(async {
+            let lm = Arc::new(MockLm::default());
+            let tools = LlmTools::with_budget(lm.clone(), 1, Handle::current());
+            let _ = tools.llm_query("one".to_string()).expect("first call");
+            assert_eq!(tools.remaining_calls(), 0);
+
+            let responses = tools
+                .llm_query_batched(vec!["two".to_string(), "three".to_string()])
+                .expect("zero-budget batch should not error");
+            assert!(responses.is_empty());
+
+            let calls = lm.calls.lock().expect("calls lock").clone();
+            assert_eq!(calls, vec!["one".to_string()]);
         });
     }
 

--- a/crates/dspy-rs/src/modules/rlm/tools.rs
+++ b/crates/dspy-rs/src/modules/rlm/tools.rs
@@ -1,0 +1,282 @@
+use std::future::Future;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use async_trait::async_trait;
+use pyo3::exceptions::{PyRuntimeError, PyValueError};
+use pyo3::prelude::*;
+use tokio::runtime::Handle;
+
+use crate::LM;
+use crate::core::lm::{Chat, Message, ToolLoopMode};
+
+#[async_trait]
+pub trait LlmQuery: Send + Sync {
+    async fn query(&self, prompt: &str) -> anyhow::Result<String>;
+}
+
+#[async_trait]
+impl LlmQuery for LM {
+    async fn query(&self, prompt: &str) -> anyhow::Result<String> {
+        let messages = Chat::new(vec![Message::user(prompt)]);
+        let response = self
+            .call(messages, Vec::new(), ToolLoopMode::CallerManaged)
+            .await?;
+        Ok(response.output.text_content())
+    }
+}
+
+#[pyclass]
+#[derive(Clone)]
+pub struct LlmTools {
+    lm: Arc<dyn LlmQuery>,
+    pub max_llm_calls: usize,
+    budget_remaining: Arc<AtomicUsize>,
+    handle: Handle,
+}
+
+impl LlmTools {
+    pub fn new(
+        lm: Arc<dyn LlmQuery>,
+        budget_remaining: Arc<AtomicUsize>,
+        max_llm_calls: usize,
+        handle: Handle,
+    ) -> Self {
+        Self {
+            lm,
+            max_llm_calls,
+            budget_remaining,
+            handle,
+        }
+    }
+
+    pub fn with_budget(lm: Arc<dyn LlmQuery>, max_llm_calls: usize, handle: Handle) -> Self {
+        Self::new(
+            lm,
+            Arc::new(AtomicUsize::new(max_llm_calls)),
+            max_llm_calls,
+            handle,
+        )
+    }
+
+    pub fn budget_remaining(&self) -> Arc<AtomicUsize> {
+        Arc::clone(&self.budget_remaining)
+    }
+
+    pub fn call_count(&self) -> usize {
+        self.max_llm_calls
+            .saturating_sub(self.budget_remaining.load(Ordering::SeqCst))
+    }
+
+    pub fn remaining_calls(&self) -> usize {
+        self.budget_remaining.load(Ordering::SeqCst)
+    }
+
+    pub fn max_llm_calls(&self) -> usize {
+        self.max_llm_calls
+    }
+
+    fn reserve_calls(&self, count: usize) -> PyResult<()> {
+        loop {
+            let current = self.budget_remaining.load(Ordering::SeqCst);
+            if current < count {
+                return Err(PyRuntimeError::new_err(format!(
+                    "[Error] RuntimeError: LLM call budget exhausted: requested {count}, remaining {current}, max {}. This is retryable after reducing llm_query usage.",
+                    self.max_llm_calls
+                )));
+            }
+
+            if self
+                .budget_remaining
+                .compare_exchange(current, current - count, Ordering::SeqCst, Ordering::SeqCst)
+                .is_ok()
+            {
+                return Ok(());
+            }
+        }
+    }
+
+    fn ensure_prompt(prompt: &str) -> PyResult<()> {
+        if prompt.trim().is_empty() {
+            return Err(PyValueError::new_err(
+                "[Error] ValueError: prompt cannot be empty",
+            ));
+        }
+        Ok(())
+    }
+
+    fn block_with_runtime<F, T>(&self, fut: F) -> T
+    where
+        F: Future<Output = T>,
+    {
+        tokio::task::block_in_place(|| self.handle.block_on(fut))
+    }
+
+    fn runtime_error(err: impl std::fmt::Display) -> PyErr {
+        PyRuntimeError::new_err(format!("[Error] RuntimeError: {err}"))
+    }
+}
+
+#[pymethods]
+impl LlmTools {
+    fn llm_query(&self, prompt: String) -> PyResult<String> {
+        Self::ensure_prompt(&prompt)?;
+        self.reserve_calls(1)?;
+
+        let response = self
+            .block_with_runtime(self.lm.query(&prompt))
+            .map_err(Self::runtime_error)?;
+
+        Ok(response)
+    }
+
+    fn llm_query_batched(&self, prompts: Vec<String>) -> PyResult<Vec<String>> {
+        if prompts.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        for prompt in &prompts {
+            Self::ensure_prompt(prompt)?;
+        }
+
+        self.reserve_calls(prompts.len())?;
+
+        let responses = self.block_with_runtime(async {
+            let futures = prompts.iter().map(|prompt| self.lm.query(prompt));
+            futures::future::join_all(futures).await
+        });
+
+        let mut results = Vec::with_capacity(responses.len());
+        for response in responses {
+            match response {
+                Ok(text) => results.push(text),
+                Err(err) => return Err(Self::runtime_error(err)),
+            }
+        }
+        Ok(results)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+    use std::sync::Mutex;
+
+    use super::*;
+
+    #[derive(Default)]
+    struct MockLm {
+        calls: Mutex<Vec<String>>,
+        fail_on: Mutex<HashSet<String>>,
+    }
+
+    #[async_trait]
+    impl LlmQuery for MockLm {
+        async fn query(&self, prompt: &str) -> anyhow::Result<String> {
+            self.calls
+                .lock()
+                .expect("calls mutex poisoned")
+                .push(prompt.to_string());
+
+            if self
+                .fail_on
+                .lock()
+                .expect("fail_on mutex poisoned")
+                .contains(prompt)
+            {
+                anyhow::bail!("mock failure for {prompt}");
+            }
+
+            Ok(format!("answer:{prompt}"))
+        }
+    }
+
+    #[test]
+    fn llm_query_consumes_budget_and_returns_text() {
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+
+        rt.block_on(async {
+            let lm = Arc::new(MockLm::default());
+            let tools = LlmTools::with_budget(lm.clone(), 2, Handle::current());
+
+            let first = tools.llm_query("hello".to_string()).expect("first call");
+            assert_eq!(first, "answer:hello");
+            assert_eq!(tools.call_count(), 1);
+
+            let second = tools.llm_query("world".to_string()).expect("second call");
+            assert_eq!(second, "answer:world");
+            assert_eq!(tools.call_count(), 2);
+
+            let calls = lm.calls.lock().expect("calls lock").clone();
+            assert_eq!(calls, vec!["hello".to_string(), "world".to_string()]);
+        });
+    }
+
+    #[test]
+    fn budget_exhaustion_returns_retryable_runtime_error() {
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+
+        rt.block_on(async {
+            let tools = LlmTools::with_budget(Arc::new(MockLm::default()), 1, Handle::current());
+            let _ = tools.llm_query("one".to_string()).expect("first call");
+
+            let err = tools
+                .llm_query("two".to_string())
+                .expect_err("budget should be exhausted");
+            assert!(err.to_string().contains("budget exhausted"));
+            assert!(err.to_string().contains("retryable"));
+        });
+    }
+
+    #[test]
+    fn llm_query_batched_runs_all_prompts() {
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+
+        rt.block_on(async {
+            let lm = Arc::new(MockLm::default());
+            let tools = LlmTools::with_budget(lm.clone(), 5, Handle::current());
+
+            let responses = tools
+                .llm_query_batched(vec!["a".to_string(), "b".to_string(), "c".to_string()])
+                .expect("batched call");
+            assert_eq!(responses, vec!["answer:a", "answer:b", "answer:c"]);
+            assert_eq!(tools.call_count(), 3);
+
+            let mut calls = lm.calls.lock().expect("calls lock").clone();
+            calls.sort();
+            assert_eq!(calls, vec!["a", "b", "c"]);
+        });
+    }
+
+    #[test]
+    fn llm_query_batched_propagates_runtime_errors() {
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+
+        rt.block_on(async {
+            let lm = Arc::new(MockLm::default());
+            lm.fail_on
+                .lock()
+                .expect("fail_on lock")
+                .insert("bad".to_string());
+
+            let tools = LlmTools::with_budget(lm, 3, Handle::current());
+            let err = tools
+                .llm_query_batched(vec!["ok".to_string(), "bad".to_string()])
+                .expect_err("second prompt should fail");
+
+            assert!(err.to_string().contains("mock failure for bad"));
+        });
+    }
+}

--- a/crates/dspy-rs/src/modules/rlm/tools.rs
+++ b/crates/dspy-rs/src/modules/rlm/tools.rs
@@ -59,21 +59,14 @@ impl LlmTools {
         )
     }
 
-    pub fn budget_remaining(&self) -> Arc<AtomicUsize> {
-        Arc::clone(&self.budget_remaining)
-    }
-
-    pub fn call_count(&self) -> usize {
+    #[cfg(test)]
+    fn call_count(&self) -> usize {
         self.max_llm_calls
             .saturating_sub(self.budget_remaining.load(Ordering::SeqCst))
     }
 
     pub fn remaining_calls(&self) -> usize {
         self.budget_remaining.load(Ordering::SeqCst)
-    }
-
-    pub fn max_llm_calls(&self) -> usize {
-        self.max_llm_calls
     }
 
     fn reserve_calls(&self, count: usize) -> PyResult<()> {

--- a/crates/dspy-rs/src/modules/rlm/tools.rs
+++ b/crates/dspy-rs/src/modules/rlm/tools.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use async_trait::async_trait;
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
-use tokio::runtime::Handle;
+use tokio::runtime::{Handle, RuntimeFlavor};
 
 use crate::LM;
 use crate::core::lm::{Chat, Message, ToolLoopMode};
@@ -98,11 +98,27 @@ impl LlmTools {
         Ok(())
     }
 
-    fn block_with_runtime<F, T>(&self, fut: F) -> T
+    fn block_with_runtime<F, T>(&self, fut: F) -> PyResult<T>
     where
         F: Future<Output = T>,
     {
-        tokio::task::block_in_place(|| self.handle.block_on(fut))
+        let current_handle = Handle::try_current().map_err(|err| {
+            Self::runtime_error(format!("an active Tokio runtime is required: {err}"))
+        })?;
+        if current_handle.runtime_flavor() == RuntimeFlavor::CurrentThread {
+            return Err(Self::runtime_error(
+                "llm_query requires a multi-thread Tokio runtime; current-thread runtime is not supported",
+            ));
+        }
+
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            tokio::task::block_in_place(|| self.handle.block_on(fut))
+        }))
+        .map_err(|_| {
+            Self::runtime_error(
+                "failed to block in the current Tokio runtime; use a multi-thread runtime",
+            )
+        })
     }
 
     fn runtime_error(err: impl std::fmt::Display) -> PyErr {
@@ -116,9 +132,8 @@ impl LlmTools {
         Self::ensure_prompt(&prompt)?;
         self.reserve_calls(1)?;
 
-        let response = self
-            .block_with_runtime(self.lm.query(&prompt))
-            .map_err(Self::runtime_error)?;
+        let response = self.block_with_runtime(self.lm.query(&prompt))?;
+        let response = response.map_err(Self::runtime_error)?;
 
         Ok(response)
     }
@@ -137,7 +152,7 @@ impl LlmTools {
         let responses = self.block_with_runtime(async {
             let futures = prompts.iter().map(|prompt| self.lm.query(prompt));
             futures::future::join_all(futures).await
-        });
+        })?;
 
         let mut results = Vec::with_capacity(responses.len());
         for response in responses {
@@ -315,6 +330,25 @@ mod tests {
                 .expect("empty batch should be valid");
             assert!(responses.is_empty());
             assert_eq!(tools.remaining_calls(), 2);
+        });
+    }
+
+    #[test]
+    fn current_thread_runtime_returns_clear_error_instead_of_panicking() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+
+        rt.block_on(async {
+            let tools = LlmTools::with_budget(Arc::new(MockLm::default()), 1, Handle::current());
+            let err = tools
+                .llm_query("hello".to_string())
+                .expect_err("current-thread runtime should fail gracefully");
+
+            let message = err.to_string();
+            assert!(message.contains("multi-thread Tokio runtime"));
+            assert!(message.contains("current-thread"));
         });
     }
 }

--- a/crates/dspy-rs/src/modules/rlm/tools.rs
+++ b/crates/dspy-rs/src/modules/rlm/tools.rs
@@ -115,8 +115,9 @@ impl LlmTools {
         }
         let remaining = self.remaining_calls();
         let warning = format!(
-            "⚠ Budget: executed {executed} of {requested} requested queries ({remaining} remaining of {} max)",
-            self.max_llm_calls
+            "⚠ Budget: executed first {executed} of {requested} requested queries ({remaining} remaining of {} max). \
+results[i] aligns to prompts[i] for i < {executed}; skipped prompts[{executed}..{requested}].",
+            self.max_llm_calls,
         );
         Python::attach(|py| {
             if let Ok(builtins) = PyModule::import(py, "builtins")

--- a/crates/dspy-rs/src/optimizer/copro.rs
+++ b/crates/dspy-rs/src/optimizer/copro.rs
@@ -216,7 +216,7 @@ mod tests {
 
     use super::*;
     use crate::evaluate::{MetricOutcome, TypedMetric};
-    use crate::{CallMetadata, Predict, PredictError, Predicted, Signature};
+    use crate::{CallMetadata, Chat, Predict, PredictError, Predicted, Signature};
 
     #[derive(Signature, Clone, Debug)]
     struct CoproStateSig {
@@ -246,6 +246,7 @@ mod tests {
                     answer: input.prompt,
                 },
                 CallMetadata::default(),
+                Chat::new(vec![]),
             ))
         }
     }

--- a/crates/dspy-rs/src/optimizer/gepa.rs
+++ b/crates/dspy-rs/src/optimizer/gepa.rs
@@ -506,7 +506,7 @@ mod tests {
 
     use super::*;
     use crate::evaluate::{MetricOutcome, TypedMetric};
-    use crate::{CallMetadata, Predict, PredictError, Predicted, Signature};
+    use crate::{CallMetadata, Chat, Predict, PredictError, Predicted, Signature};
 
     #[derive(Signature, Clone, Debug)]
     struct GepaStateSig {
@@ -536,6 +536,7 @@ mod tests {
                     answer: input.prompt,
                 },
                 CallMetadata::default(),
+                Chat::new(vec![]),
             ))
         }
     }

--- a/crates/dspy-rs/src/optimizer/mipro.rs
+++ b/crates/dspy-rs/src/optimizer/mipro.rs
@@ -184,7 +184,7 @@ impl MIPROv2 {
             let input = example.input.clone();
             let predicted = module.call(input).await.map_err(|err| anyhow!("{err}"))?;
             let outcome = metric.evaluate(example, &predicted).await?;
-            let (output, _) = predicted.into_parts();
+            let (output, _, _) = predicted.into_parts();
             traces.push(Trace::new(
                 example.input.clone(),
                 output.to_baml_value(),
@@ -417,7 +417,7 @@ mod tests {
 
     use super::*;
     use crate::evaluate::{MetricOutcome, TypedMetric};
-    use crate::{CallMetadata, Predict, PredictError, Predicted, Signature};
+    use crate::{CallMetadata, Chat, Predict, PredictError, Predicted, Signature};
 
     #[derive(Signature, Clone, Debug)]
     struct MiproStateSig {
@@ -447,6 +447,7 @@ mod tests {
                     answer: input.prompt,
                 },
                 CallMetadata::default(),
+                Chat::new(vec![]),
             ))
         }
     }

--- a/crates/dspy-rs/src/predictors/predict.rs
+++ b/crates/dspy-rs/src/predictors/predict.rs
@@ -127,6 +127,8 @@ pub struct Predict<S: Signature> {
     demos: Vec<Example<S>>,
     instruction_override: Option<String>,
     #[facet(skip, opaque)]
+    adapter: Option<ChatAdapter>,
+    #[facet(skip, opaque)]
     _marker: PhantomData<S>,
 }
 
@@ -137,6 +139,7 @@ impl<S: Signature> Predict<S> {
             tools: Vec::new(),
             demos: Vec::new(),
             instruction_override: None,
+            adapter: None,
             _marker: PhantomData,
         }
     }
@@ -144,6 +147,12 @@ impl<S: Signature> Predict<S> {
     /// Returns a builder for configuring demos, instruction, and tools.
     pub fn builder() -> PredictBuilder<S> {
         PredictBuilder::new()
+    }
+
+    /// Overrides the adapter used for prompt composition and response parsing.
+    pub fn adapter(mut self, adapter: ChatAdapter) -> Self {
+        self.adapter = Some(adapter);
+        self
     }
 
     /// Calls the LM with this predictor's signature, demos, and tools.
@@ -195,7 +204,7 @@ impl<S: Signature> Predict<S> {
     where
         S::Input: BamlType,
     {
-        let chat_adapter = ChatAdapter;
+        let chat_adapter = self.adapter.clone().unwrap_or_default();
         let user = chat_adapter.format_user_message_typed::<S>(input);
         trace!(
             user_len = user.len(),
@@ -294,7 +303,7 @@ impl<S: Signature> Predict<S> {
             None
         };
 
-        let chat_adapter = ChatAdapter;
+        let chat_adapter = self.adapter.clone().unwrap_or_default();
         let raw_response = output.content().to_string();
         let lm_usage = usage.clone();
 
@@ -312,6 +321,7 @@ impl<S: Signature> Predict<S> {
                     source: err,
                     raw_response,
                     lm_usage,
+                    chat: chat.clone(),
                 });
             }
         };
@@ -379,6 +389,7 @@ pub struct PredictBuilder<S: Signature> {
     tools: Vec<Arc<dyn ToolDyn>>,
     demos: Vec<Example<S>>,
     instruction_override: Option<String>,
+    adapter: Option<ChatAdapter>,
     _marker: PhantomData<S>,
 }
 
@@ -388,6 +399,7 @@ impl<S: Signature> PredictBuilder<S> {
             tools: Vec::new(),
             demos: Vec::new(),
             instruction_override: None,
+            adapter: None,
             _marker: PhantomData,
         }
     }
@@ -422,12 +434,19 @@ impl<S: Signature> PredictBuilder<S> {
         self
     }
 
+    /// Overrides the adapter used for prompt composition and parsing.
+    pub fn adapter(mut self, adapter: ChatAdapter) -> Self {
+        self.adapter = Some(adapter);
+        self
+    }
+
     /// Builds the [`Predict`].
     pub fn build(self) -> Predict<S> {
         Predict {
             tools: self.tools,
             demos: self.demos,
             instruction_override: self.instruction_override,
+            adapter: self.adapter,
             _marker: PhantomData,
         }
     }

--- a/crates/dspy-rs/tests/test_adapter_dialect_passthrough.rs
+++ b/crates/dspy-rs/tests/test_adapter_dialect_passthrough.rs
@@ -1,0 +1,154 @@
+use dspy_rs::{
+    ChatAdapter, LM, LMClient, ParseError, Predict, PredictError, Signature, TestCompletionModel,
+    configure,
+};
+use rig::completion::AssistantContent;
+use rig::message::Text;
+use std::sync::LazyLock;
+use tokio::sync::Mutex;
+
+static SETTINGS_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+fn text_response(text: impl Into<String>) -> AssistantContent {
+    AssistantContent::Text(Text { text: text.into() })
+}
+
+fn structured_response(fields: &[(&str, &str)]) -> String {
+    let mut response = String::new();
+    for (name, value) in fields {
+        response.push_str(&format!("[[ ## {name} ## ]]\n{value}\n\n"));
+    }
+    response.push_str("[[ ## completed ## ]]\n");
+    response
+}
+
+async fn configure_test_lm(responses: Vec<String>) {
+    let client = TestCompletionModel::new(responses.into_iter().map(text_response));
+    let lm = temp_env::async_with_vars(
+        [("OPENAI_API_KEY", Some("test"))],
+        LM::builder()
+            .model("openai:gpt-4o-mini".to_string())
+            .build(),
+    )
+    .await
+    .unwrap()
+    .with_client(LMClient::Test(client))
+    .await
+    .unwrap();
+    configure(lm, ChatAdapter::new());
+}
+
+#[derive(Signature, Clone, Debug, PartialEq)]
+/// Generate executable Python code for the task.
+struct RlmActionLike {
+    #[input]
+    task: String,
+
+    #[output]
+    code: String,
+}
+
+#[derive(Signature, Clone, Debug, PartialEq)]
+/// Answer the question.
+struct QaLike {
+    #[input]
+    question: String,
+
+    #[output]
+    answer: String,
+}
+
+#[cfg_attr(miri, ignore = "MIRI has issues with tokio's I/O driver")]
+#[tokio::test]
+async fn passthrough_adapter_maps_entire_response_to_code() {
+    let _lock = SETTINGS_LOCK.lock().await;
+    configure_test_lm(vec![r#"print("ok")"#.to_string()]).await;
+
+    let predict = Predict::<RlmActionLike>::new().adapter(ChatAdapter::passthrough());
+    let result = predict
+        .call(RlmActionLikeInput {
+            task: "print ok".to_string(),
+        })
+        .await
+        .expect("passthrough parse should succeed");
+
+    assert_eq!(result.into_inner().code, r#"print("ok")"#);
+}
+
+#[cfg_attr(miri, ignore = "MIRI has issues with tokio's I/O driver")]
+#[tokio::test]
+async fn passthrough_adapter_extracts_fenced_code() {
+    let _lock = SETTINGS_LOCK.lock().await;
+    configure_test_lm(vec!["```python\nprint('hello')\n```\n".to_string()]).await;
+
+    let predict = Predict::<RlmActionLike>::new().adapter(ChatAdapter::passthrough());
+    let result = predict
+        .call(RlmActionLikeInput {
+            task: "say hello".to_string(),
+        })
+        .await
+        .expect("fenced passthrough parse should succeed");
+
+    assert_eq!(result.into_inner().code, "print('hello')");
+}
+
+#[cfg_attr(miri, ignore = "MIRI has issues with tokio's I/O driver")]
+#[tokio::test]
+async fn passthrough_whitespace_response_surfaces_parse_error_with_chat() {
+    let _lock = SETTINGS_LOCK.lock().await;
+    configure_test_lm(vec!["   \n\t".to_string()]).await;
+
+    let predict = Predict::<RlmActionLike>::new().adapter(ChatAdapter::passthrough());
+    let err = predict
+        .call(RlmActionLikeInput {
+            task: "do something".to_string(),
+        })
+        .await
+        .expect_err("whitespace passthrough response should fail parse");
+
+    match err {
+        PredictError::Parse {
+            source: ParseError::ExtractionFailed { .. },
+            raw_response,
+            chat,
+            ..
+        } => {
+            assert!(raw_response.trim().is_empty());
+            assert!(
+                !chat.is_empty(),
+                "parse error should carry conversation chat for recovery"
+            );
+        }
+        other => panic!("unexpected error variant: {other:?}"),
+    }
+}
+
+#[cfg_attr(miri, ignore = "MIRI has issues with tokio's I/O driver")]
+#[tokio::test]
+async fn per_predict_adapter_selection_allows_mixed_dialects() {
+    let _lock = SETTINGS_LOCK.lock().await;
+    configure_test_lm(vec![
+        "print(2 + 2)".to_string(),
+        structured_response(&[("answer", "4")]),
+    ])
+    .await;
+
+    let action_predict = Predict::<RlmActionLike>::new().adapter(ChatAdapter::passthrough());
+    let extract_predict = Predict::<QaLike>::new();
+
+    let action = action_predict
+        .call(RlmActionLikeInput {
+            task: "math".to_string(),
+        })
+        .await
+        .expect("passthrough action parse should succeed");
+    assert_eq!(action.code, "print(2 + 2)");
+
+    let extract = extract_predict
+        .call(QaLikeInput {
+            question: "2 + 2".to_string(),
+        })
+        .await
+        .expect("default chat parse should succeed");
+    assert_eq!(extract.answer, "4");
+}

--- a/crates/dspy-rs/tests/test_adapters.rs
+++ b/crates/dspy-rs/tests/test_adapters.rs
@@ -51,7 +51,7 @@ struct DeepFlattenSig {
 
 #[test]
 fn chat_adapter_formats_typed_system_prompt() {
-    let adapter = ChatAdapter;
+    let adapter = ChatAdapter::new();
     let system = adapter
         .format_system_message_typed::<BasicSignature>()
         .expect("system prompt should format");
@@ -65,7 +65,7 @@ fn chat_adapter_formats_typed_system_prompt() {
 
 #[test]
 fn chat_adapter_formats_user_and_assistant_messages() {
-    let adapter = ChatAdapter;
+    let adapter = ChatAdapter::new();
 
     let user = adapter.format_user_message_typed::<BasicSignature>(&BasicSignatureInput {
         problem: "What is the capital of France?".to_string(),
@@ -87,7 +87,7 @@ fn chat_adapter_formats_user_and_assistant_messages() {
 
 #[test]
 fn chat_adapter_parses_typed_response() {
-    let adapter = ChatAdapter;
+    let adapter = ChatAdapter::new();
     let response = Message::assistant("[[ ## answer ## ]]\nParis\n\n[[ ## completed ## ]]");
 
     let (output, field_meta) = adapter
@@ -114,7 +114,7 @@ fn parse_sections_accepts_non_word_field_names() {
 
 #[test]
 fn chat_adapter_formats_user_messages_with_multi_level_flatten_paths() {
-    let adapter = ChatAdapter;
+    let adapter = ChatAdapter::new();
     let user = adapter.format_user_message_typed::<DeepFlattenSig>(&DeepFlattenSigInput {
         question: "What should we answer?".to_string(),
         middle: FlattenMiddleSigInput {

--- a/crates/dspy-rs/tests/test_bamltype_docs_contract.rs
+++ b/crates/dspy-rs/tests/test_bamltype_docs_contract.rs
@@ -63,7 +63,7 @@ struct DocsTypeEffectsSig {
 }
 
 fn system_message() -> String {
-    let adapter = ChatAdapter;
+    let adapter = ChatAdapter::new();
     adapter
         .format_system_message_typed::<DocsTypeEffectsSig>()
         .expect("system message")

--- a/crates/dspy-rs/tests/test_call_outcome.rs
+++ b/crates/dspy-rs/tests/test_call_outcome.rs
@@ -1,5 +1,5 @@
 use dspy_rs::{
-    CallMetadata, ConstraintResult, FieldMeta, LmUsage, ParseError, PredictError, Predicted,
+    CallMetadata, Chat, ConstraintResult, FieldMeta, LmUsage, ParseError, PredictError, Predicted,
 };
 use indexmap::IndexMap;
 
@@ -60,7 +60,7 @@ fn predicted_exposes_field_metadata() {
         field_meta,
     );
 
-    let predicted = Predicted::new("Paris".to_string(), metadata);
+    let predicted = Predicted::new("Paris".to_string(), metadata, Chat::new(vec![]));
     assert_eq!(predicted.metadata().field_raw("answer"), Some("Paris"));
     assert!(!predicted.metadata().has_failed_checks());
 

--- a/crates/dspy-rs/tests/test_call_outcome.rs
+++ b/crates/dspy-rs/tests/test_call_outcome.rs
@@ -17,6 +17,7 @@ fn parse_error_preserves_raw_response_and_usage() {
         },
         raw_response: "raw response".to_string(),
         lm_usage: usage.clone(),
+        chat: Chat::new(vec![]),
     };
 
     match err {
@@ -24,6 +25,7 @@ fn parse_error_preserves_raw_response_and_usage() {
             source: ParseError::MissingField { field, .. },
             raw_response,
             lm_usage,
+            ..
         } => {
             assert_eq!(field, "answer");
             assert_eq!(raw_response, "raw response");

--- a/crates/dspy-rs/tests/test_caller_managed_conversation.rs
+++ b/crates/dspy-rs/tests/test_caller_managed_conversation.rs
@@ -56,8 +56,8 @@ struct CodeExec {
 /// The full RLM-style loop:
 /// 1. Predict builds initial chat → calls LM → model requests a tool call
 /// 2. CallerManaged mode: LM returns the tool call without executing it
-/// 3. Caller manually executes the tool, appends result to chat
-/// 4. Caller calls forward_continue → LM returns the final text answer
+/// 3. Caller manually executes the tool, then calls Predict forward with prior chat history
+/// 4. LM returns the final text answer
 ///
 /// This is the exact pattern RLM will use for Python REPL interaction.
 #[cfg_attr(miri, ignore = "MIRI has issues with tokio's I/O driver")]
@@ -80,27 +80,26 @@ async fn caller_managed_tool_loop_with_conversation() {
         prompt: "Calculate 6 * 7".to_string(),
     };
 
-    // Turn 1: Build chat and call LM
-    let chat = predict
-        .build_chat(&input)
-        .expect("build_chat should succeed");
-    let (first_result, mut chat) = predict
-        .call_and_parse(chat)
+    // Turn 1
+    let first_result = predict
+        .forward(input, None)
         .await
-        .expect("first turn should succeed");
+        .expect("first turn forward should succeed");
+    let chat = first_result.chat().clone();
     assert_eq!(
         first_result.into_inner().result,
         "Need to execute code first"
     );
 
-    // Caller simulates tool execution: append user message with result
-    chat.push_message(Message::user("Tool output: 42"));
-
-    // Turn 2: Continue the conversation
-    let (second_result, final_chat) = predict
-        .forward_continue(chat)
+    // Turn 2: continue with prior chat and typed follow-up
+    let follow_up = CodeExecInput {
+        prompt: "Tool output: 42".to_string(),
+    };
+    let second_result = predict
+        .forward(follow_up, Some(chat))
         .await
-        .expect("second turn should succeed");
+        .expect("second turn forward should succeed");
+    let final_chat = second_result.chat().clone();
     assert_eq!(second_result.into_inner().result, "42");
 
     // Verify chat grew across turns
@@ -139,7 +138,7 @@ async fn lm_caller_managed_returns_tool_calls_in_chat_history() {
 
     let chat = dspy_rs::Chat::new(vec![Message::user("Run some code")]);
     let response = lm
-        .call_with_tool_loop_mode(chat, vec![], ToolLoopMode::CallerManaged)
+        .call(chat, vec![], ToolLoopMode::CallerManaged)
         .await
         .expect("caller-managed call should succeed");
 
@@ -178,14 +177,16 @@ async fn parse_failure_on_second_turn_includes_correct_raw_response() {
     };
 
     // Turn 1: succeeds
-    let chat = predict.build_chat(&input).expect("build_chat");
-    let (first_result, mut chat) = predict.call_and_parse(chat).await.expect("turn 1");
+    let first_result = predict.forward(input, None).await.expect("turn 1");
+    let chat = first_result.chat().clone();
     assert_eq!(first_result.into_inner().result, "first answer");
 
     // Turn 2: should fail with parse error containing the bad response
-    chat.push_message(Message::user("follow up"));
+    let follow_up = CodeExecInput {
+        prompt: "follow up".to_string(),
+    };
     let err = predict
-        .forward_continue(chat)
+        .forward(follow_up, Some(chat))
         .await
         .expect_err("second turn should fail");
 

--- a/crates/dspy-rs/tests/test_caller_managed_conversation.rs
+++ b/crates/dspy-rs/tests/test_caller_managed_conversation.rs
@@ -1,0 +1,215 @@
+//! CallerManaged + tools + conversation flow test.
+//!
+//! This is the RLM critical path: the caller controls tool execution and
+//! manages the conversation loop, not the LM layer's auto tool loop.
+
+use dspy_rs::{
+    ChatAdapter, LM, LMClient, Message, Predict, Role, Signature, TestCompletionModel,
+    ToolLoopMode, configure,
+};
+use rig::completion::AssistantContent;
+use rig::message::{Text, ToolCall, ToolFunction};
+use std::sync::LazyLock;
+use tokio::sync::Mutex;
+
+static SETTINGS_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+fn response_with_fields(fields: &[(&str, &str)]) -> String {
+    let mut response = String::new();
+    for (name, value) in fields {
+        response.push_str(&format!("[[ ## {name} ## ]]\n{value}\n\n"));
+    }
+    response.push_str("[[ ## completed ## ]]\n");
+    response
+}
+
+fn text_response(text: impl Into<String>) -> AssistantContent {
+    AssistantContent::Text(Text { text: text.into() })
+}
+
+async fn build_test_lm(responses: Vec<AssistantContent>) -> (LM, TestCompletionModel) {
+    let client = TestCompletionModel::new(responses);
+    let lm = temp_env::async_with_vars(
+        [("OPENAI_API_KEY", Some("test"))],
+        LM::builder()
+            .model("openai:gpt-4o-mini".to_string())
+            .build(),
+    )
+    .await
+    .unwrap()
+    .with_client(LMClient::Test(client.clone()))
+    .await
+    .unwrap();
+    (lm, client)
+}
+
+#[derive(Signature, Clone, Debug, PartialEq)]
+/// Code execution signature for RLM-style interaction.
+struct CodeExec {
+    #[input]
+    prompt: String,
+
+    #[output]
+    result: String,
+}
+
+/// The full RLM-style loop:
+/// 1. Predict builds initial chat → calls LM → model requests a tool call
+/// 2. CallerManaged mode: LM returns the tool call without executing it
+/// 3. Caller manually executes the tool, appends result to chat
+/// 4. Caller calls forward_continue → LM returns the final text answer
+///
+/// This is the exact pattern RLM will use for Python REPL interaction.
+#[cfg_attr(miri, ignore = "MIRI has issues with tokio's I/O driver")]
+#[tokio::test]
+async fn caller_managed_tool_loop_with_conversation() {
+    let _lock = SETTINGS_LOCK.lock().await;
+
+    // Response 1: model wants to call a tool (returned as text since TestCompletionModel
+    // only supports single-content responses via AssistantContent)
+    let tool_call_response =
+        text_response("[[ ## result ## ]]\nNeed to execute code first\n\n[[ ## completed ## ]]\n");
+    // Response 2: after seeing tool result, model gives final answer
+    let final_response = text_response(response_with_fields(&[("result", "42")]));
+
+    let (lm, _client) = build_test_lm(vec![tool_call_response, final_response]).await;
+    configure(lm, ChatAdapter {});
+
+    let predict = Predict::<CodeExec>::new();
+    let input = CodeExecInput {
+        prompt: "Calculate 6 * 7".to_string(),
+    };
+
+    // Turn 1: Build chat and call LM
+    let chat = predict
+        .build_chat(&input)
+        .expect("build_chat should succeed");
+    let (first_result, mut chat) = predict
+        .call_and_parse(chat)
+        .await
+        .expect("first turn should succeed");
+    assert_eq!(
+        first_result.into_inner().result,
+        "Need to execute code first"
+    );
+
+    // Caller simulates tool execution: append user message with result
+    chat.push_message(Message::user("Tool output: 42"));
+
+    // Turn 2: Continue the conversation
+    let (second_result, final_chat) = predict
+        .forward_continue(chat)
+        .await
+        .expect("second turn should succeed");
+    assert_eq!(second_result.into_inner().result, "42");
+
+    // Verify chat grew across turns
+    assert!(
+        final_chat.len() >= 5,
+        "chat should have system + user + asst + user + asst, got {}",
+        final_chat.len()
+    );
+
+    // Verify turn ordering
+    assert_eq!(final_chat.messages[0].role, Role::System);
+    assert_eq!(final_chat.messages[1].role, Role::User);
+    assert_eq!(final_chat.messages[2].role, Role::Assistant);
+    assert_eq!(final_chat.messages[3].role, Role::User); // caller's tool result
+    assert_eq!(final_chat.messages[4].role, Role::Assistant); // final answer
+}
+
+/// Tests the LM-level CallerManaged mode directly: when a tool call is requested
+/// with CallerManaged mode, the LM returns the tool calls without executing them
+/// and the caller controls what happens next.
+#[cfg_attr(miri, ignore = "MIRI has issues with tokio's I/O driver")]
+#[tokio::test]
+async fn lm_caller_managed_returns_tool_calls_in_chat_history() {
+    let _lock = SETTINGS_LOCK.lock().await;
+
+    // Model responds with a tool call
+    let tool_call_content = AssistantContent::ToolCall(ToolCall::new(
+        "tc-1".to_string(),
+        ToolFunction {
+            name: "python_repl".to_string(),
+            arguments: serde_json::json!({"code": "print(6 * 7)"}),
+        },
+    ));
+
+    let (lm, _client) = build_test_lm(vec![tool_call_content]).await;
+
+    let chat = dspy_rs::Chat::new(vec![Message::user("Run some code")]);
+    let response = lm
+        .call_with_tool_loop_mode(chat, vec![], ToolLoopMode::CallerManaged)
+        .await
+        .expect("caller-managed call should succeed");
+
+    // Tool calls returned but NOT executed
+    assert_eq!(response.tool_calls.len(), 1);
+    assert_eq!(response.tool_calls[0].function.name, "python_repl");
+    assert!(
+        response.tool_executions.is_empty(),
+        "CallerManaged should not execute tools"
+    );
+
+    // Chat history should contain the tool call message
+    assert!(
+        response.chat.messages.iter().any(|m| m.has_tool_calls()),
+        "chat history should include the tool call message"
+    );
+}
+
+/// Multi-turn with parse failure on second turn verifies that errors
+/// include the correct raw_response from the continuation, not the first turn.
+#[cfg_attr(miri, ignore = "MIRI has issues with tokio's I/O driver")]
+#[tokio::test]
+async fn parse_failure_on_second_turn_includes_correct_raw_response() {
+    let _lock = SETTINGS_LOCK.lock().await;
+
+    let good_response = text_response(response_with_fields(&[("result", "first answer")]));
+    // Second response is malformed — no field markers
+    let bad_response = text_response("This response has no field markers at all.");
+
+    let (lm, _client) = build_test_lm(vec![good_response, bad_response]).await;
+    configure(lm, ChatAdapter {});
+
+    let predict = Predict::<CodeExec>::new();
+    let input = CodeExecInput {
+        prompt: "test".to_string(),
+    };
+
+    // Turn 1: succeeds
+    let chat = predict.build_chat(&input).expect("build_chat");
+    let (first_result, mut chat) = predict.call_and_parse(chat).await.expect("turn 1");
+    assert_eq!(first_result.into_inner().result, "first answer");
+
+    // Turn 2: should fail with parse error containing the bad response
+    chat.push_message(Message::user("follow up"));
+    let err = predict
+        .forward_continue(chat)
+        .await
+        .expect_err("second turn should fail");
+
+    match err {
+        dspy_rs::PredictError::Parse {
+            raw_response,
+            source,
+            ..
+        } => {
+            assert!(
+                raw_response.contains("no field markers"),
+                "raw_response should be from the second turn, got: {}",
+                raw_response
+            );
+            // The error should mention the missing field
+            let fields = source.fields();
+            assert!(
+                !fields.is_empty() || source.field().is_some(),
+                "parse error should identify which field(s) failed"
+            );
+        }
+        other => panic!(
+            "expected PredictError::Parse, got: {:?}",
+            std::mem::discriminant(&other)
+        ),
+    }
+}

--- a/crates/dspy-rs/tests/test_caller_managed_conversation.rs
+++ b/crates/dspy-rs/tests/test_caller_managed_conversation.rs
@@ -73,7 +73,7 @@ async fn caller_managed_tool_loop_with_conversation() {
     let final_response = text_response(response_with_fields(&[("result", "42")]));
 
     let (lm, _client) = build_test_lm(vec![tool_call_response, final_response]).await;
-    configure(lm, ChatAdapter {});
+    configure(lm, ChatAdapter::new());
 
     let predict = Predict::<CodeExec>::new();
     let input = CodeExecInput {
@@ -169,7 +169,7 @@ async fn parse_failure_on_second_turn_includes_correct_raw_response() {
     let bad_response = text_response("This response has no field markers at all.");
 
     let (lm, _client) = build_test_lm(vec![good_response, bad_response]).await;
-    configure(lm, ChatAdapter {});
+    configure(lm, ChatAdapter::new());
 
     let predict = Predict::<CodeExec>::new();
     let input = CodeExecInput {

--- a/crates/dspy-rs/tests/test_chain_of_thought_swap.rs
+++ b/crates/dspy-rs/tests/test_chain_of_thought_swap.rs
@@ -23,19 +23,18 @@ fn text_response(text: impl Into<String>) -> AssistantContent {
 }
 
 async fn configure_test_lm(responses: Vec<String>) {
-    unsafe {
-        std::env::set_var("OPENAI_API_KEY", "test");
-    }
-
     let client = TestCompletionModel::new(responses.into_iter().map(text_response));
-    let lm = LM::builder()
-        .model("openai:gpt-4o-mini".to_string())
-        .build()
-        .await
-        .unwrap()
-        .with_client(LMClient::Test(client))
-        .await
-        .unwrap();
+    let lm = temp_env::async_with_vars(
+        [("OPENAI_API_KEY", Some("test"))],
+        LM::builder()
+            .model("openai:gpt-4o-mini".to_string())
+            .build(),
+    )
+    .await
+    .unwrap()
+    .with_client(LMClient::Test(client))
+    .await
+    .unwrap();
 
     configure(lm, ChatAdapter {});
 }

--- a/crates/dspy-rs/tests/test_chain_of_thought_swap.rs
+++ b/crates/dspy-rs/tests/test_chain_of_thought_swap.rs
@@ -36,7 +36,7 @@ async fn configure_test_lm(responses: Vec<String>) {
     .await
     .unwrap();
 
-    configure(lm, ChatAdapter {});
+    configure(lm, ChatAdapter::new());
 }
 
 #[derive(Signature, Clone, Debug, PartialEq, facet::Facet)]

--- a/crates/dspy-rs/tests/test_chat_adapter_schema.rs
+++ b/crates/dspy-rs/tests/test_chat_adapter_schema.rs
@@ -1,4 +1,4 @@
-use dspy_rs::{CallMetadata, ChatAdapter, Message, Predicted, Signature};
+use dspy_rs::{CallMetadata, Chat, ChatAdapter, Message, Predicted, Signature};
 
 #[derive(Signature, Clone, Debug)]
 /// Adapter schema parse fixture.
@@ -42,7 +42,7 @@ fn parse_response_typed_uses_schema_field_names() {
         None,
         field_meta,
     );
-    let predicted = Predicted::new(output, metadata);
+    let predicted = Predicted::new(output, metadata, Chat::new(vec![]));
 
     assert_eq!(predicted.metadata().field_raw("answer"), Some("Paris"));
     assert!(!predicted.metadata().has_failed_checks());

--- a/crates/dspy-rs/tests/test_chat_adapter_schema.rs
+++ b/crates/dspy-rs/tests/test_chat_adapter_schema.rs
@@ -23,7 +23,7 @@ struct AliasSig {
 
 #[test]
 fn parse_response_typed_uses_schema_field_names() {
-    let adapter = ChatAdapter;
+    let adapter = ChatAdapter::new();
     let response = Message::assistant("[[ ## answer ## ]]\nParis\n\n[[ ## completed ## ]]\n");
 
     let (output, field_meta) = adapter
@@ -51,7 +51,7 @@ fn parse_response_typed_uses_schema_field_names() {
 
 #[test]
 fn parse_response_typed_accepts_dotted_field_markers() {
-    let adapter = ChatAdapter;
+    let adapter = ChatAdapter::new();
     let response = Message::assistant("[[ ## answer.value ## ]]\nParis\n\n[[ ## completed ## ]]\n");
 
     let (output, field_meta) = adapter

--- a/crates/dspy-rs/tests/test_chat_prompt_composition.rs
+++ b/crates/dspy-rs/tests/test_chat_prompt_composition.rs
@@ -185,6 +185,37 @@ fn typed_and_schema_user_builders_match_and_append_requirements() {
 }
 
 #[test]
+fn passthrough_user_message_has_no_marker_or_output_protocol_ceremony() {
+    let adapter = ChatAdapter::passthrough();
+    let input = PromptPartsSigInput {
+        question: "What is the capital of France?".to_string(),
+        context: "Facts: Paris is the capital city of France.".to_string(),
+    };
+
+    let typed = adapter.format_user_message_typed::<PromptPartsSig>(&input);
+    let schema = adapter.format_input(PromptPartsSig::schema(), &input);
+    assert_eq!(typed, schema);
+
+    assert!(
+        !typed.contains("[[ ##"),
+        "passthrough message should not include marker protocol:\n{typed}"
+    );
+    assert!(
+        !typed.contains("Respond with the corresponding output fields"),
+        "passthrough message should not include output format instructions:\n{typed}"
+    );
+    assert!(
+        !typed.contains("[[ ## completed ## ]]"),
+        "passthrough message should not include completion marker:\n{typed}"
+    );
+
+    assert!(typed.contains("question:"));
+    assert!(typed.contains("context:"));
+    assert!(typed.contains("What is the capital of France?"));
+    assert!(typed.contains("Facts: Paris is the capital city of France."));
+}
+
+#[test]
 fn demo_format_composes_user_and_assistant_parts() {
     let adapter = ChatAdapter::new();
     let demo = Example::<PromptPartsSig>::new(

--- a/crates/dspy-rs/tests/test_chat_prompt_composition.rs
+++ b/crates/dspy-rs/tests/test_chat_prompt_composition.rs
@@ -216,6 +216,31 @@ fn passthrough_user_message_has_no_marker_or_output_protocol_ceremony() {
 }
 
 #[test]
+fn passthrough_system_with_instruction_override_is_raw_instruction_only() {
+    let adapter = ChatAdapter::passthrough();
+    let override_instruction = "Use Python only.\nCall SUBMIT when done.";
+    let system = adapter
+        .format_system_message_typed_with_instruction::<PromptPartsSig>(Some(override_instruction))
+        .expect("passthrough system prompt should format");
+
+    assert_eq!(system, override_instruction);
+    assert!(!system.contains("Your input fields are:"));
+    assert!(!system.contains("Your objective is:"));
+}
+
+#[test]
+fn passthrough_system_without_override_keeps_existing_scaffolding() {
+    let adapter = ChatAdapter::passthrough();
+    let system = adapter
+        .format_system_message_typed::<PromptPartsSig>()
+        .expect("passthrough system prompt should format");
+
+    assert!(system.contains("Your input fields are:"));
+    assert!(system.contains("Your objective is:"));
+    assert!(system.contains("Answer the prompt using the provided context."));
+}
+
+#[test]
 fn demo_format_composes_user_and_assistant_parts() {
     let adapter = ChatAdapter::new();
     let demo = Example::<PromptPartsSig>::new(

--- a/crates/dspy-rs/tests/test_chat_prompt_composition.rs
+++ b/crates/dspy-rs/tests/test_chat_prompt_composition.rs
@@ -40,7 +40,7 @@ fn response_instruction_line(message: &str) -> &str {
 
 #[test]
 fn system_prompt_includes_all_sections_in_order_with_boundaries() {
-    let adapter = ChatAdapter;
+    let adapter = ChatAdapter::new();
     let system = adapter
         .format_system_message_typed::<PromptPartsSig>()
         .expect("system prompt should format");
@@ -80,7 +80,7 @@ fn system_prompt_includes_all_sections_in_order_with_boundaries() {
 
 #[test]
 fn system_prompt_field_descriptions_and_structure_are_present() {
-    let adapter = ChatAdapter;
+    let adapter = ChatAdapter::new();
     let system = adapter
         .format_system_message_typed::<PromptPartsSig>()
         .expect("system prompt should format");
@@ -101,7 +101,7 @@ fn system_prompt_field_descriptions_and_structure_are_present() {
 
 #[test]
 fn response_instruction_line_orders_output_fields() {
-    let adapter = ChatAdapter;
+    let adapter = ChatAdapter::new();
     let system = adapter
         .format_system_message_typed::<PromptPartsSig>()
         .expect("system prompt should format");
@@ -115,7 +115,7 @@ fn response_instruction_line_orders_output_fields() {
 
 #[test]
 fn instruction_override_is_used_in_objective_section() {
-    let adapter = ChatAdapter;
+    let adapter = ChatAdapter::new();
     let override_instruction = "Follow the rubric.\nCite the context.";
     let system = adapter
         .format_system_message_typed_with_instruction::<PromptPartsSig>(Some(override_instruction))
@@ -129,7 +129,7 @@ fn instruction_override_is_used_in_objective_section() {
 
 #[test]
 fn empty_instruction_uses_generated_fallback_objective() {
-    let adapter = ChatAdapter;
+    let adapter = ChatAdapter::new();
     let system = adapter
         .format_system_message_typed::<EmptyInstructionSig>()
         .expect("system prompt should format");
@@ -140,7 +140,7 @@ fn empty_instruction_uses_generated_fallback_objective() {
 
 #[test]
 fn typed_and_schema_system_builders_match() {
-    let adapter = ChatAdapter;
+    let adapter = ChatAdapter::new();
     let typed = adapter
         .format_system_message_typed_with_instruction::<PromptPartsSig>(Some("Override objective"))
         .expect("typed system prompt");
@@ -153,7 +153,7 @@ fn typed_and_schema_system_builders_match() {
 
 #[test]
 fn typed_and_schema_user_builders_match_and_append_requirements() {
-    let adapter = ChatAdapter;
+    let adapter = ChatAdapter::new();
     let input = PromptPartsSigInput {
         question: "What is the capital of France?".to_string(),
         context: "Facts: Paris is the capital city of France.".to_string(),
@@ -186,7 +186,7 @@ fn typed_and_schema_user_builders_match_and_append_requirements() {
 
 #[test]
 fn demo_format_composes_user_and_assistant_parts() {
-    let adapter = ChatAdapter;
+    let adapter = ChatAdapter::new();
     let demo = Example::<PromptPartsSig>::new(
         PromptPartsSigInput {
             question: "Question?".to_string(),
@@ -213,7 +213,7 @@ fn demo_format_composes_user_and_assistant_parts() {
 
 #[test]
 fn typed_and_schema_assistant_builders_match_and_end_with_completed_marker() {
-    let adapter = ChatAdapter;
+    let adapter = ChatAdapter::new();
     let output = PromptPartsSigOutput {
         answer: "Paris".to_string(),
         confidence: 0.9,

--- a/crates/dspy-rs/tests/test_chat_prompt_golden.rs
+++ b/crates/dspy-rs/tests/test_chat_prompt_golden.rs
@@ -11,7 +11,7 @@ struct GoldenSig {
 
 #[test]
 fn golden_system_prompt_is_stable() {
-    let adapter = ChatAdapter;
+    let adapter = ChatAdapter::new();
     let system = adapter
         .format_system_message_typed::<GoldenSig>()
         .expect("system prompt should format");
@@ -44,7 +44,7 @@ fn golden_system_prompt_is_stable() {
 
 #[test]
 fn golden_user_prompt_is_stable() {
-    let adapter = ChatAdapter;
+    let adapter = ChatAdapter::new();
     let input = GoldenSigInput {
         question: "What is 2+2?".to_string(),
     };
@@ -62,7 +62,7 @@ fn golden_user_prompt_is_stable() {
 
 #[test]
 fn golden_assistant_prompt_is_stable() {
-    let adapter = ChatAdapter;
+    let adapter = ChatAdapter::new();
     let output = GoldenSigOutput {
         answer: "4".to_string(),
     };
@@ -79,7 +79,7 @@ fn golden_assistant_prompt_is_stable() {
 
 #[test]
 fn golden_demo_messages_are_stable() {
-    let adapter = ChatAdapter;
+    let adapter = ChatAdapter::new();
     let demo = Example::<GoldenSig>::new(
         GoldenSigInput {
             question: "What is 2+2?".to_string(),

--- a/crates/dspy-rs/tests/test_dataloader.rs
+++ b/crates/dspy-rs/tests/test_dataloader.rs
@@ -4,7 +4,7 @@ use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
 use bon::Builder;
 use dspy_rs::{
-    COPRO, CallMetadata, DataLoader, Example, MetricOutcome, Module, Optimizer, Predict,
+    COPRO, CallMetadata, Chat, DataLoader, Example, MetricOutcome, Module, Optimizer, Predict,
     PredictError, Predicted, Signature, TypedLoadOptions, TypedMetric, UnknownFieldPolicy,
     average_score, evaluate_trainset,
 };
@@ -54,6 +54,7 @@ impl Module for EchoModule {
                 answer: input.question,
             },
             CallMetadata::default(),
+            Chat::new(vec![]),
         ))
     }
 }

--- a/crates/dspy-rs/tests/test_evaluate_trainset_typed.rs
+++ b/crates/dspy-rs/tests/test_evaluate_trainset_typed.rs
@@ -1,7 +1,7 @@
 use anyhow::{Result, anyhow};
 use dspy_rs::{
-    CallMetadata, Example, MetricOutcome, Module, PredictError, Predicted, Signature, TypedMetric,
-    average_score, evaluate_trainset,
+    CallMetadata, Chat, Example, MetricOutcome, Module, PredictError, Predicted, Signature,
+    TypedMetric, average_score, evaluate_trainset,
 };
 use std::sync::{Arc, Mutex};
 
@@ -26,6 +26,7 @@ impl Module for EchoModule {
                 answer: input.prompt,
             },
             CallMetadata::default(),
+            Chat::new(vec![]),
         ))
     }
 }

--- a/crates/dspy-rs/tests/test_flatten_roundtrip.rs
+++ b/crates/dspy-rs/tests/test_flatten_roundtrip.rs
@@ -11,7 +11,7 @@ struct QA {
 
 #[test]
 fn augmented_demo_roundtrips_through_adapter() {
-    let adapter = ChatAdapter;
+    let adapter = ChatAdapter::new();
     let demo = Example::<Augmented<QA, Reasoning>>::new(
         QAInput {
             question: "What is 2+2?".to_string(),

--- a/crates/dspy-rs/tests/test_gepa_typed_metric_feedback.rs
+++ b/crates/dspy-rs/tests/test_gepa_typed_metric_feedback.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use dspy_rs::{
-    CallMetadata, Example, FeedbackMetric, GEPA, MetricOutcome, Module, Optimizer, Predict,
+    CallMetadata, Chat, Example, FeedbackMetric, GEPA, MetricOutcome, Module, Optimizer, Predict,
     PredictError, Predicted, Signature, TypedMetric,
 };
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -35,6 +35,7 @@ impl Module for InstructionEchoModule {
                 answer: input.prompt,
             },
             CallMetadata::default(),
+            Chat::new(vec![]),
         ))
     }
 }

--- a/crates/dspy-rs/tests/test_input_format.rs
+++ b/crates/dspy-rs/tests/test_input_format.rs
@@ -161,7 +161,7 @@ fn extract_baml_field<'a>(value: &'a BamlValue, field_name: &str) -> &'a BamlVal
 
 #[test]
 fn typed_input_format_yaml_renders_field_names() {
-    let adapter = ChatAdapter;
+    let adapter = ChatAdapter::new();
     let input = FormatSigInput {
         question: "What is YAML?".to_string(),
         context: vec![Document {
@@ -179,7 +179,7 @@ fn typed_input_format_yaml_renders_field_names() {
 
 #[test]
 fn typed_input_format_json_is_parsable() {
-    let adapter = ChatAdapter;
+    let adapter = ChatAdapter::new();
     let input = FormatJsonSigInput {
         question: "What is JSON?".to_string(),
         context: vec![Document {
@@ -201,7 +201,7 @@ fn typed_input_format_json_is_parsable() {
 
 #[test]
 fn typed_input_format_toon_matches_formatter() {
-    let adapter = ChatAdapter;
+    let adapter = ChatAdapter::new();
     let input = FormatToonSigInput {
         question: "What is TOON?".to_string(),
         context: vec![Document {
@@ -224,7 +224,7 @@ fn typed_input_format_toon_matches_formatter() {
 
 #[test]
 fn typed_input_default_string_is_raw() {
-    let adapter = ChatAdapter;
+    let adapter = ChatAdapter::new();
     let input = DefaultFormatSigInput {
         question: "Raw string".to_string(),
         context: vec![Document {
@@ -240,7 +240,7 @@ fn typed_input_default_string_is_raw() {
 
 #[test]
 fn typed_input_default_non_string_is_json() {
-    let adapter = ChatAdapter;
+    let adapter = ChatAdapter::new();
     let input = DefaultFormatSigInput {
         question: "Default JSON".to_string(),
         context: vec![Document {
@@ -261,7 +261,7 @@ fn typed_input_default_non_string_is_json() {
 
 #[test]
 fn typed_input_appends_response_instruction_reminder() {
-    let adapter = ChatAdapter;
+    let adapter = ChatAdapter::new();
     let input = DefaultFormatSigInput {
         question: "Reminder check".to_string(),
         context: vec![Document {
@@ -277,7 +277,7 @@ fn typed_input_appends_response_instruction_reminder() {
 
 #[test]
 fn typed_input_render_jinja_uses_context_values() {
-    let adapter = ChatAdapter;
+    let adapter = ChatAdapter::new();
     let input = RenderJinjaSigInput {
         question: "Question".to_string(),
         context: Document {
@@ -296,7 +296,7 @@ fn typed_input_render_jinja_uses_context_values() {
 
 #[test]
 fn typed_input_render_jinja_missing_var_panics() {
-    let adapter = ChatAdapter;
+    let adapter = ChatAdapter::new();
     let input = RenderJinjaStrictSigInput {
         question: "Question".to_string(),
     };
@@ -309,7 +309,7 @@ fn typed_input_render_jinja_missing_var_panics() {
 
 #[test]
 fn typed_input_render_jinja_exposes_field_metadata_and_vars() {
-    let adapter = ChatAdapter;
+    let adapter = ChatAdapter::new();
     let input = RenderJinjaFieldMetaSigInput {
         context: Document {
             text: "Hello".to_string(),
@@ -329,7 +329,7 @@ fn typed_input_render_jinja_exposes_field_metadata_and_vars() {
 
 #[test]
 fn typed_input_render_jinja_non_string_primitives() {
-    let adapter = ChatAdapter;
+    let adapter = ChatAdapter::new();
     let input = RenderPrimitiveSigInput {
         count: 42,
         is_ready: true,
@@ -345,7 +345,7 @@ fn typed_input_render_jinja_non_string_primitives() {
 
 #[test]
 fn typed_input_render_jinja_supports_contrib_filters() {
-    let adapter = ChatAdapter;
+    let adapter = ChatAdapter::new();
     let input = RenderContribFilterSigInput {
         context: Document {
             text: "abcdefg".to_string(),

--- a/crates/dspy-rs/tests/test_lm.rs
+++ b/crates/dspy-rs/tests/test_lm.rs
@@ -84,16 +84,15 @@ fn test_lm_usage_add() {
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
 async fn test_lm_with_cache_enabled() {
-    unsafe {
-        std::env::set_var("OPENAI_API_KEY", "test");
-    }
-    // Create LM with cache enabled
-    let lm = LM::builder()
-        .model("openai:gpt-4o-mini".to_string())
-        .cache(true)
-        .build()
-        .await
-        .unwrap();
+    let lm = temp_env::async_with_vars(
+        [("OPENAI_API_KEY", Some("test"))],
+        LM::builder()
+            .model("openai:gpt-4o-mini".to_string())
+            .cache(true)
+            .build(),
+    )
+    .await
+    .unwrap();
 
     // Verify cache handler is initialized
     assert!(lm.cache_handler.is_some());
@@ -102,16 +101,15 @@ async fn test_lm_with_cache_enabled() {
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
 async fn test_lm_with_cache_disabled() {
-    unsafe {
-        std::env::set_var("OPENAI_API_KEY", "test");
-    }
-    // Create LM with cache explicitly disabled
-    let lm = LM::builder()
-        .model("openai:gpt-4o-mini".to_string())
-        .cache(false)
-        .build()
-        .await
-        .unwrap();
+    let lm = temp_env::async_with_vars(
+        [("OPENAI_API_KEY", Some("test"))],
+        LM::builder()
+            .model("openai:gpt-4o-mini".to_string())
+            .cache(false)
+            .build(),
+    )
+    .await
+    .unwrap();
 
     // Verify cache handler is NOT initialized when cache is disabled
     assert!(lm.cache_handler.is_none());
@@ -120,16 +118,15 @@ async fn test_lm_with_cache_disabled() {
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
 async fn test_lm_cache_initialization_on_first_call() {
-    unsafe {
-        std::env::set_var("OPENAI_API_KEY", "test");
-    }
-    // Create LM with cache enabled
-    let lm = LM::builder()
-        .model("openai:gpt-4o-mini".to_string())
-        .cache(true)
-        .build()
-        .await
-        .unwrap();
+    let lm = temp_env::async_with_vars(
+        [("OPENAI_API_KEY", Some("test"))],
+        LM::builder()
+            .model("openai:gpt-4o-mini".to_string())
+            .cache(true)
+            .build(),
+    )
+    .await
+    .unwrap();
 
     // After build, cache_handler should be initialized
     assert!(lm.cache_handler.is_some());
@@ -138,20 +135,19 @@ async fn test_lm_cache_initialization_on_first_call() {
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
 async fn test_lm_cache_direct_operations() {
-    unsafe {
-        std::env::set_var("OPENAI_API_KEY", "test");
-    }
     use dspy_rs::Prediction;
     use dspy_rs::data::RawExample;
     use std::collections::HashMap;
 
-    // Create LM with cache enabled
-    let lm = LM::builder()
-        .model("openai:gpt-4o-mini".to_string())
-        .cache(true)
-        .build()
-        .await
-        .unwrap();
+    let lm = temp_env::async_with_vars(
+        [("OPENAI_API_KEY", Some("test"))],
+        LM::builder()
+            .model("openai:gpt-4o-mini".to_string())
+            .cache(true)
+            .build(),
+    )
+    .await
+    .unwrap();
 
     // Get cache handler
     let cache = lm
@@ -207,20 +203,19 @@ async fn test_lm_cache_direct_operations() {
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
 async fn test_lm_cache_with_different_models() {
-    unsafe {
-        std::env::set_var("OPENAI_API_KEY", "test");
-        std::env::set_var("ANTHROPIC_API_KEY", "test");
-    }
     // Test that cache works with different model configurations
     let models = vec!["openai:gpt-3.5-turbo", "anthropic:claude-3-haiku-20240307"];
 
     for model in models {
-        let lm = LM::builder()
-            .model(model.to_string())
-            .cache(true)
-            .build()
-            .await
-            .unwrap();
+        let lm = temp_env::async_with_vars(
+            [
+                ("OPENAI_API_KEY", Some("test")),
+                ("ANTHROPIC_API_KEY", Some("test")),
+            ],
+            LM::builder().model(model.to_string()).cache(true).build(),
+        )
+        .await
+        .unwrap();
 
         // Cache should be initialized regardless of model
         assert!(
@@ -234,20 +229,19 @@ async fn test_lm_cache_with_different_models() {
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
 async fn test_cache_with_complex_inputs() {
-    unsafe {
-        std::env::set_var("OPENAI_API_KEY", "test");
-    }
     use dspy_rs::Prediction;
     use dspy_rs::data::RawExample;
     use std::collections::HashMap;
 
-    // Create LM with cache enabled
-    let lm = LM::builder()
-        .model("openai:gpt-4o-mini".to_string())
-        .cache(true)
-        .build()
-        .await
-        .unwrap();
+    let lm = temp_env::async_with_vars(
+        [("OPENAI_API_KEY", Some("test"))],
+        LM::builder()
+            .model("openai:gpt-4o-mini".to_string())
+            .cache(true)
+            .build(),
+    )
+    .await
+    .unwrap();
 
     let cache = lm
         .cache_handler

--- a/crates/dspy-rs/tests/test_lm.rs
+++ b/crates/dspy-rs/tests/test_lm.rs
@@ -204,7 +204,11 @@ async fn test_lm_cache_direct_operations() {
 #[cfg_attr(miri, ignore)]
 async fn test_lm_cache_with_different_models() {
     // Test that cache works with different model configurations
-    let models = vec!["openai:gpt-3.5-turbo", "anthropic:claude-3-haiku-20240307"];
+    let models = vec![
+        "openai:gpt-3.5-turbo",
+        "openai-responses:gpt-4o-mini",
+        "anthropic:claude-3-haiku-20240307",
+    ];
 
     for model in models {
         let lm = temp_env::async_with_vars(
@@ -224,6 +228,19 @@ async fn test_lm_cache_with_different_models() {
             model
         );
     }
+}
+
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn test_lm_local_openai_responses_provider_builds() {
+    let lm = LM::builder()
+        .base_url("http://localhost:11434/v1".to_string())
+        .model("openai-responses:gpt-5.2".to_string())
+        .build()
+        .await
+        .expect("openai-responses local build should succeed");
+
+    assert_eq!(lm.model, "openai-responses:gpt-5.2");
 }
 
 #[tokio::test]

--- a/crates/dspy-rs/tests/test_message_roundtrip.rs
+++ b/crates/dspy-rs/tests/test_message_roundtrip.rs
@@ -1,0 +1,345 @@
+//! Round-trip tests for the new Message model.
+//!
+//! Verifies that the grouped Role + ContentBlock representation preserves
+//! all content through: DSRs Message → rig Message → DSRs Message, and
+//! through JSON serialization/deserialization.
+
+use dspy_rs::core::lm::chat::{Chat, ContentBlock, Message, Role};
+use rig::OneOrMany;
+use rig::message::{
+    Message as RigMessage, Reasoning, ToolCall, ToolFunction, ToolResult, ToolResultContent,
+};
+use serde_json::json;
+
+// ---------------------------------------------------------------------------
+// Reasoning continuity round-trip
+// ---------------------------------------------------------------------------
+
+/// Anthropic's thinking turns produce [Reasoning, Reasoning, ToolCall] in a
+/// single assistant turn. The entire chain of thought must survive:
+///   DSRs Message → rig → DSRs Message
+#[test]
+fn reasoning_chain_survives_rig_roundtrip() {
+    let original = Message::with_content(
+        Role::Assistant,
+        vec![
+            ContentBlock::reasoning(Reasoning::new("step 1: analyze the query")),
+            ContentBlock::reasoning(Reasoning::new("step 2: plan the search")),
+            ContentBlock::tool_call(ToolCall::new(
+                "tc-1".to_string(),
+                ToolFunction {
+                    name: "search".to_string(),
+                    arguments: json!({"q": "rust ownership"}),
+                },
+            )),
+        ],
+    );
+
+    // Forward: DSRs → rig
+    let rig_msg = original
+        .to_rig_message()
+        .expect("assistant message should convert to rig");
+
+    // Backward: rig → DSRs
+    let roundtripped = Message::from(rig_msg);
+
+    assert_eq!(roundtripped.role, Role::Assistant);
+    assert_eq!(
+        roundtripped.content.len(),
+        3,
+        "all three content blocks must survive: got {:?}",
+        roundtripped.content
+    );
+
+    assert!(
+        matches!(&roundtripped.content[0], ContentBlock::Reasoning { reasoning } if reasoning.display_text().contains("step 1")),
+        "first reasoning block lost"
+    );
+    assert!(
+        matches!(&roundtripped.content[1], ContentBlock::Reasoning { reasoning } if reasoning.display_text().contains("step 2")),
+        "second reasoning block lost"
+    );
+    assert!(
+        matches!(&roundtripped.content[2], ContentBlock::ToolCall { tool_call } if tool_call.function.name == "search"),
+        "tool call lost"
+    );
+}
+
+/// A reasoning-only assistant turn (no text, no tool call) must round-trip.
+#[test]
+fn reasoning_only_turn_roundtrips() {
+    let original = Message::with_content(
+        Role::Assistant,
+        vec![ContentBlock::reasoning(Reasoning::new(
+            "just thinking out loud",
+        ))],
+    );
+
+    let rig_msg = original.to_rig_message().unwrap();
+    let roundtripped = Message::from(rig_msg);
+
+    assert_eq!(roundtripped.role, Role::Assistant);
+    assert_eq!(roundtripped.content.len(), 1);
+    assert!(roundtripped.has_reasoning());
+    assert!(!roundtripped.has_tool_calls());
+}
+
+// ---------------------------------------------------------------------------
+// Multi-content user messages
+// ---------------------------------------------------------------------------
+
+/// A user message with both text and a tool result must preserve both.
+#[test]
+fn user_text_plus_tool_result_roundtrips() {
+    let original = Message::with_content(
+        Role::User,
+        vec![
+            ContentBlock::text("Here is context"),
+            ContentBlock::tool_result(ToolResult {
+                id: "tr-1".to_string(),
+                call_id: Some("tc-1".to_string()),
+                content: OneOrMany::one(ToolResultContent::text("search result")),
+            }),
+        ],
+    );
+
+    let rig_msg = original.to_rig_message().unwrap();
+    let roundtripped = Message::from(rig_msg);
+
+    assert_eq!(roundtripped.role, Role::User);
+    assert_eq!(
+        roundtripped.content.len(),
+        2,
+        "both text and tool result must survive"
+    );
+    assert!(matches!(
+        &roundtripped.content[0],
+        ContentBlock::Text { text } if text == "Here is context"
+    ));
+    assert!(roundtripped.has_tool_results());
+}
+
+// ---------------------------------------------------------------------------
+// Multi-turn conversation with reasoning in history
+// ---------------------------------------------------------------------------
+
+/// Build a multi-turn conversation where an earlier assistant turn has
+/// reasoning blocks. Convert the full chat to rig format and back.
+/// The reasoning from earlier turns must be preserved.
+#[test]
+fn multi_turn_conversation_preserves_earlier_reasoning() {
+    let chat = Chat::new(vec![
+        Message::system("You are a helpful assistant."),
+        Message::user("What is the capital of France?"),
+        // Turn 1 reply: reasoning + text answer
+        Message::with_content(
+            Role::Assistant,
+            vec![
+                ContentBlock::reasoning(Reasoning::new("The user is asking about geography.")),
+                ContentBlock::text("The capital of France is Paris."),
+            ],
+        ),
+        // User follow-up
+        Message::user("And Germany?"),
+        // Turn 2 reply: just text
+        Message::assistant("The capital of Germany is Berlin."),
+    ]);
+
+    // Convert to rig and back
+    let rig_history = chat.to_rig_chat_history();
+    // rig_history should have 4 messages (system excluded)
+    assert_eq!(rig_history.len(), 4);
+
+    // Reconstruct from rig history
+    let mut reconstructed = Chat::new(vec![Message::system(chat.system_prompt())]);
+    for rig_msg in rig_history {
+        reconstructed.push_message(Message::from(rig_msg));
+    }
+
+    assert_eq!(reconstructed.len(), 5);
+
+    // Verify turn 1's reasoning survived
+    let turn1_reply = &reconstructed.messages[2];
+    assert_eq!(turn1_reply.role, Role::Assistant);
+    assert!(
+        turn1_reply.has_reasoning(),
+        "turn 1 reasoning must survive rig round-trip"
+    );
+    assert_eq!(
+        turn1_reply.content.len(),
+        2,
+        "turn 1 must have both reasoning and text"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// JSON serialization round-trip
+// ---------------------------------------------------------------------------
+
+/// Full multi-content message survives JSON serialization.
+#[test]
+fn grouped_message_json_roundtrip() {
+    let original = Chat::new(vec![
+        Message::system("Be helpful"),
+        Message::with_content(
+            Role::Assistant,
+            vec![
+                ContentBlock::reasoning(Reasoning::new("let me think")),
+                ContentBlock::text("the answer is 42"),
+                ContentBlock::tool_call(ToolCall::new(
+                    "tc-1".to_string(),
+                    ToolFunction {
+                        name: "verify".to_string(),
+                        arguments: json!({"answer": 42}),
+                    },
+                )),
+            ],
+        ),
+        Message::with_content(
+            Role::User,
+            vec![
+                ContentBlock::tool_result(ToolResult {
+                    id: "tc-1".to_string(),
+                    call_id: None,
+                    content: OneOrMany::one(ToolResultContent::text("confirmed")),
+                }),
+                ContentBlock::text("Thanks! Can you also check 43?"),
+            ],
+        ),
+    ]);
+
+    let json = original.to_json();
+    let reparsed = Chat::new(vec![]).from_json(json).unwrap();
+
+    assert_eq!(reparsed.len(), 3);
+
+    // Verify the assistant message preserved all 3 content blocks
+    let asst = &reparsed.messages[1];
+    assert_eq!(asst.role, Role::Assistant);
+    assert_eq!(asst.content.len(), 3);
+    assert!(asst.has_reasoning());
+    assert!(asst.has_tool_calls());
+
+    // Verify the user message preserved both blocks
+    let user = &reparsed.messages[2];
+    assert_eq!(user.role, Role::User);
+    assert_eq!(user.content.len(), 2);
+    assert!(user.has_tool_results());
+}
+
+/// Legacy JSON format (content as plain string) still parses correctly.
+#[test]
+fn legacy_plain_string_json_parses_into_new_model() {
+    let legacy_json = json!([
+        {"role": "system", "content": "Be helpful"},
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "Hi there!"}
+    ]);
+
+    let chat = Chat::new(vec![]).from_json(legacy_json).unwrap();
+    assert_eq!(chat.len(), 3);
+    assert_eq!(chat.messages[0].role, Role::System);
+    assert_eq!(chat.messages[0].content(), "Be helpful");
+    assert_eq!(chat.messages[2].text_content(), "Hi there!");
+}
+
+// ---------------------------------------------------------------------------
+// Accessor correctness
+// ---------------------------------------------------------------------------
+
+#[test]
+fn text_content_excludes_non_text_blocks() {
+    let msg = Message::with_content(
+        Role::Assistant,
+        vec![
+            ContentBlock::reasoning(Reasoning::new("internal monologue")),
+            ContentBlock::text("visible answer"),
+            ContentBlock::tool_call(ToolCall::new(
+                "tc".to_string(),
+                ToolFunction {
+                    name: "search".to_string(),
+                    arguments: json!({}),
+                },
+            )),
+        ],
+    );
+
+    assert_eq!(msg.text_content(), "visible answer");
+    // content() includes everything
+    let full = msg.content();
+    assert!(full.contains("internal monologue"));
+    assert!(full.contains("visible answer"));
+    assert!(full.contains("search"));
+}
+
+#[test]
+fn tool_calls_accessor_returns_all_tool_calls() {
+    let msg = Message::with_content(
+        Role::Assistant,
+        vec![
+            ContentBlock::reasoning(Reasoning::new("planning")),
+            ContentBlock::tool_call(ToolCall::new(
+                "tc-1".to_string(),
+                ToolFunction {
+                    name: "search".to_string(),
+                    arguments: json!({"q": "a"}),
+                },
+            )),
+            ContentBlock::tool_call(ToolCall::new(
+                "tc-2".to_string(),
+                ToolFunction {
+                    name: "calculate".to_string(),
+                    arguments: json!({"expr": "1+1"}),
+                },
+            )),
+        ],
+    );
+
+    let calls = msg.tool_calls();
+    assert_eq!(calls.len(), 2);
+    assert_eq!(calls[0].function.name, "search");
+    assert_eq!(calls[1].function.name, "calculate");
+}
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+/// Empty content vec (pathological) should not panic.
+#[test]
+fn empty_content_message_does_not_panic() {
+    let msg = Message::with_content(Role::Assistant, vec![]);
+    assert_eq!(msg.content(), "");
+    assert_eq!(msg.text_content(), "");
+    assert!(!msg.has_tool_calls());
+    assert!(!msg.has_reasoning());
+
+    // Rig conversion should produce an assistant message with empty text
+    let rig_msg = msg.to_rig_message().unwrap();
+    match rig_msg {
+        RigMessage::Assistant { content, .. } => {
+            assert_eq!(content.iter().count(), 1); // empty text fallback
+        }
+        _ => panic!("expected assistant message"),
+    }
+}
+
+/// System messages return None from to_rig_message (handled as preamble).
+#[test]
+fn system_message_excluded_from_rig_conversion() {
+    let msg = Message::system("You are helpful");
+    assert!(msg.to_rig_message().is_none());
+}
+
+/// Message ID (e.g. Anthropic thinking turn IDs) survives round-trip.
+#[test]
+fn message_id_survives_rig_roundtrip() {
+    let mut msg = Message::assistant("some text");
+    msg.id = Some("msg_abc123".to_string());
+
+    let rig_msg = msg.to_rig_message().unwrap();
+    let roundtripped = Message::from(rig_msg);
+
+    // Note: rig's User messages don't carry IDs, but Assistant messages do
+    assert_eq!(roundtripped.id, Some("msg_abc123".to_string()));
+}

--- a/crates/dspy-rs/tests/test_message_roundtrip.rs
+++ b/crates/dspy-rs/tests/test_message_roundtrip.rs
@@ -1,182 +1,14 @@
-//! Round-trip tests for the new Message model.
+//! Public-API tests for the grouped Message model.
 //!
-//! Verifies that the grouped Role + ContentBlock representation preserves
-//! all content through: DSRs Message → rig Message → DSRs Message, and
-//! through JSON serialization/deserialization.
+//! These tests validate message/content behavior through stable public methods
+//! (`to_json`/`from_json`, content accessors) without calling crate-internal
+//! rig conversion helpers.
 
-use dspy_rs::core::lm::chat::{Chat, ContentBlock, Message, Role};
+use dspy_rs::{Chat, ContentBlock, Message, Role};
 use rig::OneOrMany;
-use rig::message::{
-    Message as RigMessage, Reasoning, ToolCall, ToolFunction, ToolResult, ToolResultContent,
-};
+use rig::message::{Reasoning, ToolCall, ToolFunction, ToolResult, ToolResultContent};
 use serde_json::json;
 
-// ---------------------------------------------------------------------------
-// Reasoning continuity round-trip
-// ---------------------------------------------------------------------------
-
-/// Anthropic's thinking turns produce [Reasoning, Reasoning, ToolCall] in a
-/// single assistant turn. The entire chain of thought must survive:
-///   DSRs Message → rig → DSRs Message
-#[test]
-fn reasoning_chain_survives_rig_roundtrip() {
-    let original = Message::with_content(
-        Role::Assistant,
-        vec![
-            ContentBlock::reasoning(Reasoning::new("step 1: analyze the query")),
-            ContentBlock::reasoning(Reasoning::new("step 2: plan the search")),
-            ContentBlock::tool_call(ToolCall::new(
-                "tc-1".to_string(),
-                ToolFunction {
-                    name: "search".to_string(),
-                    arguments: json!({"q": "rust ownership"}),
-                },
-            )),
-        ],
-    );
-
-    // Forward: DSRs → rig
-    let rig_msg = original
-        .to_rig_message()
-        .expect("assistant message should convert to rig");
-
-    // Backward: rig → DSRs
-    let roundtripped = Message::from(rig_msg);
-
-    assert_eq!(roundtripped.role, Role::Assistant);
-    assert_eq!(
-        roundtripped.content.len(),
-        3,
-        "all three content blocks must survive: got {:?}",
-        roundtripped.content
-    );
-
-    assert!(
-        matches!(&roundtripped.content[0], ContentBlock::Reasoning { reasoning } if reasoning.display_text().contains("step 1")),
-        "first reasoning block lost"
-    );
-    assert!(
-        matches!(&roundtripped.content[1], ContentBlock::Reasoning { reasoning } if reasoning.display_text().contains("step 2")),
-        "second reasoning block lost"
-    );
-    assert!(
-        matches!(&roundtripped.content[2], ContentBlock::ToolCall { tool_call } if tool_call.function.name == "search"),
-        "tool call lost"
-    );
-}
-
-/// A reasoning-only assistant turn (no text, no tool call) must round-trip.
-#[test]
-fn reasoning_only_turn_roundtrips() {
-    let original = Message::with_content(
-        Role::Assistant,
-        vec![ContentBlock::reasoning(Reasoning::new(
-            "just thinking out loud",
-        ))],
-    );
-
-    let rig_msg = original.to_rig_message().unwrap();
-    let roundtripped = Message::from(rig_msg);
-
-    assert_eq!(roundtripped.role, Role::Assistant);
-    assert_eq!(roundtripped.content.len(), 1);
-    assert!(roundtripped.has_reasoning());
-    assert!(!roundtripped.has_tool_calls());
-}
-
-// ---------------------------------------------------------------------------
-// Multi-content user messages
-// ---------------------------------------------------------------------------
-
-/// A user message with both text and a tool result must preserve both.
-#[test]
-fn user_text_plus_tool_result_roundtrips() {
-    let original = Message::with_content(
-        Role::User,
-        vec![
-            ContentBlock::text("Here is context"),
-            ContentBlock::tool_result(ToolResult {
-                id: "tr-1".to_string(),
-                call_id: Some("tc-1".to_string()),
-                content: OneOrMany::one(ToolResultContent::text("search result")),
-            }),
-        ],
-    );
-
-    let rig_msg = original.to_rig_message().unwrap();
-    let roundtripped = Message::from(rig_msg);
-
-    assert_eq!(roundtripped.role, Role::User);
-    assert_eq!(
-        roundtripped.content.len(),
-        2,
-        "both text and tool result must survive"
-    );
-    assert!(matches!(
-        &roundtripped.content[0],
-        ContentBlock::Text { text } if text == "Here is context"
-    ));
-    assert!(roundtripped.has_tool_results());
-}
-
-// ---------------------------------------------------------------------------
-// Multi-turn conversation with reasoning in history
-// ---------------------------------------------------------------------------
-
-/// Build a multi-turn conversation where an earlier assistant turn has
-/// reasoning blocks. Convert the full chat to rig format and back.
-/// The reasoning from earlier turns must be preserved.
-#[test]
-fn multi_turn_conversation_preserves_earlier_reasoning() {
-    let chat = Chat::new(vec![
-        Message::system("You are a helpful assistant."),
-        Message::user("What is the capital of France?"),
-        // Turn 1 reply: reasoning + text answer
-        Message::with_content(
-            Role::Assistant,
-            vec![
-                ContentBlock::reasoning(Reasoning::new("The user is asking about geography.")),
-                ContentBlock::text("The capital of France is Paris."),
-            ],
-        ),
-        // User follow-up
-        Message::user("And Germany?"),
-        // Turn 2 reply: just text
-        Message::assistant("The capital of Germany is Berlin."),
-    ]);
-
-    // Convert to rig and back
-    let rig_history = chat.to_rig_chat_history();
-    // rig_history should have 4 messages (system excluded)
-    assert_eq!(rig_history.len(), 4);
-
-    // Reconstruct from rig history
-    let mut reconstructed = Chat::new(vec![Message::system(chat.system_prompt())]);
-    for rig_msg in rig_history {
-        reconstructed.push_message(Message::from(rig_msg));
-    }
-
-    assert_eq!(reconstructed.len(), 5);
-
-    // Verify turn 1's reasoning survived
-    let turn1_reply = &reconstructed.messages[2];
-    assert_eq!(turn1_reply.role, Role::Assistant);
-    assert!(
-        turn1_reply.has_reasoning(),
-        "turn 1 reasoning must survive rig round-trip"
-    );
-    assert_eq!(
-        turn1_reply.content.len(),
-        2,
-        "turn 1 must have both reasoning and text"
-    );
-}
-
-// ---------------------------------------------------------------------------
-// JSON serialization round-trip
-// ---------------------------------------------------------------------------
-
-/// Full multi-content message survives JSON serialization.
 #[test]
 fn grouped_message_json_roundtrip() {
     let original = Chat::new(vec![
@@ -213,39 +45,54 @@ fn grouped_message_json_roundtrip() {
 
     assert_eq!(reparsed.len(), 3);
 
-    // Verify the assistant message preserved all 3 content blocks
     let asst = &reparsed.messages[1];
     assert_eq!(asst.role, Role::Assistant);
     assert_eq!(asst.content.len(), 3);
     assert!(asst.has_reasoning());
     assert!(asst.has_tool_calls());
 
-    // Verify the user message preserved both blocks
     let user = &reparsed.messages[2];
     assert_eq!(user.role, Role::User);
     assert_eq!(user.content.len(), 2);
     assert!(user.has_tool_results());
 }
 
-/// Legacy JSON format (content as plain string) still parses correctly.
 #[test]
-fn legacy_plain_string_json_parses_into_new_model() {
+fn multi_turn_json_roundtrip_preserves_earlier_reasoning() {
+    let chat = Chat::new(vec![
+        Message::system("You are a helpful assistant."),
+        Message::user("What is the capital of France?"),
+        Message::with_content(
+            Role::Assistant,
+            vec![
+                ContentBlock::reasoning(Reasoning::new("The user is asking about geography.")),
+                ContentBlock::text("The capital of France is Paris."),
+            ],
+        ),
+        Message::user("And Germany?"),
+        Message::assistant("The capital of Germany is Berlin."),
+    ]);
+
+    let reparsed = Chat::new(vec![]).from_json(chat.to_json()).unwrap();
+    assert_eq!(reparsed.len(), 5);
+
+    let turn1_reply = &reparsed.messages[2];
+    assert_eq!(turn1_reply.role, Role::Assistant);
+    assert!(turn1_reply.has_reasoning());
+    assert_eq!(turn1_reply.content.len(), 2);
+}
+
+#[test]
+fn legacy_plain_string_json_is_rejected() {
     let legacy_json = json!([
         {"role": "system", "content": "Be helpful"},
         {"role": "user", "content": "Hello"},
         {"role": "assistant", "content": "Hi there!"}
     ]);
 
-    let chat = Chat::new(vec![]).from_json(legacy_json).unwrap();
-    assert_eq!(chat.len(), 3);
-    assert_eq!(chat.messages[0].role, Role::System);
-    assert_eq!(chat.messages[0].content(), "Be helpful");
-    assert_eq!(chat.messages[2].text_content(), "Hi there!");
+    let err = Chat::new(vec![]).from_json(legacy_json).unwrap_err();
+    assert!(err.to_string().contains("content must be an array"));
 }
-
-// ---------------------------------------------------------------------------
-// Accessor correctness
-// ---------------------------------------------------------------------------
 
 #[test]
 fn text_content_excludes_non_text_blocks() {
@@ -265,7 +112,6 @@ fn text_content_excludes_non_text_blocks() {
     );
 
     assert_eq!(msg.text_content(), "visible answer");
-    // content() includes everything
     let full = msg.content();
     assert!(full.contains("internal monologue"));
     assert!(full.contains("visible answer"));
@@ -301,11 +147,6 @@ fn tool_calls_accessor_returns_all_tool_calls() {
     assert_eq!(calls[1].function.name, "calculate");
 }
 
-// ---------------------------------------------------------------------------
-// Edge cases
-// ---------------------------------------------------------------------------
-
-/// Empty content vec (pathological) should not panic.
 #[test]
 fn empty_content_message_does_not_panic() {
     let msg = Message::with_content(Role::Assistant, vec![]);
@@ -313,33 +154,16 @@ fn empty_content_message_does_not_panic() {
     assert_eq!(msg.text_content(), "");
     assert!(!msg.has_tool_calls());
     assert!(!msg.has_reasoning());
-
-    // Rig conversion should produce an assistant message with empty text
-    let rig_msg = msg.to_rig_message().unwrap();
-    match rig_msg {
-        RigMessage::Assistant { content, .. } => {
-            assert_eq!(content.iter().count(), 1); // empty text fallback
-        }
-        _ => panic!("expected assistant message"),
-    }
 }
 
-/// System messages return None from to_rig_message (handled as preamble).
 #[test]
-fn system_message_excluded_from_rig_conversion() {
-    let msg = Message::system("You are helpful");
-    assert!(msg.to_rig_message().is_none());
-}
-
-/// Message ID (e.g. Anthropic thinking turn IDs) survives round-trip.
-#[test]
-fn message_id_survives_rig_roundtrip() {
+fn message_id_survives_json_roundtrip() {
     let mut msg = Message::assistant("some text");
     msg.id = Some("msg_abc123".to_string());
 
-    let rig_msg = msg.to_rig_message().unwrap();
-    let roundtripped = Message::from(rig_msg);
+    let chat = Chat::new(vec![msg]);
+    let reparsed = Chat::new(vec![]).from_json(chat.to_json()).unwrap();
 
-    // Note: rig's User messages don't carry IDs, but Assistant messages do
-    assert_eq!(roundtripped.id, Some("msg_abc123".to_string()));
+    assert_eq!(reparsed.messages.len(), 1);
+    assert_eq!(reparsed.messages[0].id, Some("msg_abc123".to_string()));
 }

--- a/crates/dspy-rs/tests/test_module_ext.rs
+++ b/crates/dspy-rs/tests/test_module_ext.rs
@@ -1,4 +1,6 @@
-use dspy_rs::{BamlType, CallMetadata, Module, ModuleExt, ParseError, PredictError, Predicted};
+use dspy_rs::{
+    BamlType, CallMetadata, Chat, Module, ModuleExt, ParseError, PredictError, Predicted,
+};
 
 struct MaybeFails;
 
@@ -44,6 +46,7 @@ impl Module for MaybeFails {
                     value: input_value * 2,
                 },
                 metadata,
+                Chat::new(vec![]),
             ))
         }
     }

--- a/crates/dspy-rs/tests/test_module_ext.rs
+++ b/crates/dspy-rs/tests/test_module_ext.rs
@@ -39,6 +39,7 @@ impl Module for MaybeFails {
                 },
                 raw_response: format!("raw:{input_value}"),
                 lm_usage: dspy_rs::LmUsage::default(),
+                chat: Chat::new(vec![]),
             })
         } else {
             Ok(Predicted::new(
@@ -69,6 +70,7 @@ fn transform_int_payload(value: IntPayload) -> Result<TextPayload, PredictError>
             },
             raw_response: "transform".to_string(),
             lm_usage: dspy_rs::LmUsage::default(),
+            chat: Chat::new(vec![]),
         })
     }
 }

--- a/crates/dspy-rs/tests/test_module_facet_shapes.rs
+++ b/crates/dspy-rs/tests/test_module_facet_shapes.rs
@@ -117,21 +117,20 @@ fn and_then_shape_exposes_inner_chain_of_thought_shape() {
 
 #[cfg(feature = "rlm")]
 #[test]
-fn rlm_shape_exposes_generate_action_and_extract_and_skips_runtime_fields() {
+fn rlm_shape_exposes_extract_and_skips_runtime_fields() {
     let module = Rlm::<QA>::new();
     let shape = shape_of(&module);
 
-    let generate_action = find_field(shape, "generate_action");
     let extract = find_field(shape, "extract");
-    assert!(!generate_action.should_skip_deserializing());
     assert!(!extract.should_skip_deserializing());
-    assert_eq!(generate_action.shape().type_identifier, "Predict");
     assert_eq!(extract.shape().type_identifier, "Predict");
 
     let config = find_field(shape, "config");
+    let instruction_override = find_field(shape, "instruction_override");
     let sub_lm = find_field(shape, "sub_lm");
     let runtime = find_field(shape, "runtime");
     assert!(config.should_skip_deserializing());
+    assert!(instruction_override.should_skip_deserializing());
     assert!(sub_lm.should_skip_deserializing());
     assert!(runtime.should_skip_deserializing());
 }

--- a/crates/dspy-rs/tests/test_module_facet_shapes.rs
+++ b/crates/dspy-rs/tests/test_module_facet_shapes.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "rlm")]
+use dspy_rs::Rlm;
 use dspy_rs::{ChainOfThought, Facet, ModuleExt, PredictError, ReAct, Signature};
 use facet::{self, Type, UserType};
 
@@ -111,4 +113,25 @@ fn and_then_shape_exposes_inner_chain_of_thought_shape() {
 
     let nested_predictor = find_field(inner.shape(), "predictor");
     assert_eq!(nested_predictor.shape().type_identifier, "Predict");
+}
+
+#[cfg(feature = "rlm")]
+#[test]
+fn rlm_shape_exposes_generate_action_and_extract_and_skips_runtime_fields() {
+    let module = Rlm::<QA>::new();
+    let shape = shape_of(&module);
+
+    let generate_action = find_field(shape, "generate_action");
+    let extract = find_field(shape, "extract");
+    assert!(!generate_action.should_skip_deserializing());
+    assert!(!extract.should_skip_deserializing());
+    assert_eq!(generate_action.shape().type_identifier, "Predict");
+    assert_eq!(extract.shape().type_identifier, "Predict");
+
+    let config = find_field(shape, "config");
+    let sub_lm = find_field(shape, "sub_lm");
+    let runtime = find_field(shape, "runtime");
+    assert!(config.should_skip_deserializing());
+    assert!(sub_lm.should_skip_deserializing());
+    assert!(runtime.should_skip_deserializing());
 }

--- a/crates/dspy-rs/tests/test_module_forward_all.rs
+++ b/crates/dspy-rs/tests/test_module_forward_all.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use dspy_rs::{BamlType, CallMetadata, Module, PredictError, Predicted, forward_all};
+use dspy_rs::{BamlType, CallMetadata, Chat, Module, PredictError, Predicted, forward_all};
 use tokio::time::sleep;
 
 struct DelayEcho;
@@ -27,6 +27,7 @@ impl Module for DelayEcho {
         Ok(Predicted::new(
             DelayOutput { value: input.value },
             CallMetadata::default(),
+            Chat::new(vec![]),
         ))
     }
 }

--- a/crates/dspy-rs/tests/test_optimizer_named_parameters_integration.rs
+++ b/crates/dspy-rs/tests/test_optimizer_named_parameters_integration.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use dspy_rs::{
-    COPRO, CallMetadata, Example, MetricOutcome, Module, Optimizer, Predict, PredictError,
+    COPRO, CallMetadata, Chat, Example, MetricOutcome, Module, Optimizer, Predict, PredictError,
     Predicted, Signature, TypedMetric,
 };
 
@@ -33,6 +33,7 @@ impl Module for InstructionEchoModule {
                 answer: input.prompt,
             },
             CallMetadata::default(),
+            Chat::new(vec![]),
         ))
     }
 }

--- a/crates/dspy-rs/tests/test_optimizer_typed_metric.rs
+++ b/crates/dspy-rs/tests/test_optimizer_typed_metric.rs
@@ -1,7 +1,7 @@
 use anyhow::{Result, anyhow};
 use dspy_rs::{
-    COPRO, CallMetadata, Example, MIPROv2, MetricOutcome, Module, Optimizer, Predict, PredictError,
-    Predicted, Signature, TypedMetric,
+    COPRO, CallMetadata, Chat, Example, MIPROv2, MetricOutcome, Module, Optimizer, Predict,
+    PredictError, Predicted, Signature, TypedMetric,
 };
 use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
@@ -35,6 +35,7 @@ impl Module for InstructionEchoModule {
                 answer: input.prompt,
             },
             CallMetadata::default(),
+            Chat::new(vec![]),
         ))
     }
 }

--- a/crates/dspy-rs/tests/test_predict_conversation.rs
+++ b/crates/dspy-rs/tests/test_predict_conversation.rs
@@ -1,5 +1,5 @@
 use dspy_rs::{
-    ChatAdapter, LM, LMClient, Message, Predict, Role, Signature, TestCompletionModel, configure,
+    ChatAdapter, LM, LMClient, Predict, Role, Signature, TestCompletionModel, configure,
 };
 use rig::completion::{AssistantContent, CompletionRequest};
 use rig::message::{Message as RigMessage, Text, UserContent};
@@ -91,7 +91,7 @@ struct ConversationQA {
 
 #[cfg_attr(miri, ignore = "MIRI has issues with tokio's I/O driver")]
 #[tokio::test]
-async fn forward_returns_chat_and_prediction() {
+async fn forward_returns_prediction_with_chat_metadata() {
     let _lock = SETTINGS_LOCK.lock().await;
     let response = response_with_fields(&[("answer", "Paris")]);
     let _client = configure_test_lm(vec![response]).await;
@@ -101,24 +101,22 @@ async fn forward_returns_chat_and_prediction() {
         question: "What is the capital of France?".to_string(),
     };
 
-    let chat = predict
-        .build_chat(&input)
-        .expect("build_chat should succeed");
-    let (predicted, chat) = predict
-        .call_and_parse(chat)
+    let predicted = predict
+        .forward(input, None)
         .await
-        .expect("first turn should succeed");
+        .expect("forward should succeed");
+    let chat = predicted.chat();
 
-    assert_eq!(predicted.into_inner().answer, "Paris");
     assert_eq!(chat.len(), 3);
     assert_eq!(chat.messages[0].role, Role::System);
     assert_eq!(chat.messages[1].role, Role::User);
     assert_eq!(chat.messages[2].role, Role::Assistant);
+    assert_eq!(predicted.into_inner().answer, "Paris");
 }
 
 #[cfg_attr(miri, ignore = "MIRI has issues with tokio's I/O driver")]
 #[tokio::test]
-async fn forward_continue_supports_two_turn_roundtrip() {
+async fn forward_with_history_supports_two_turn_roundtrip() {
     let _lock = SETTINGS_LOCK.lock().await;
     let first_response = response_with_fields(&[("answer", "First turn answer")]);
     let second_response = response_with_fields(&[("answer", "Second turn answer")]);
@@ -129,24 +127,24 @@ async fn forward_continue_supports_two_turn_roundtrip() {
         question: "Turn 1 question".to_string(),
     };
 
-    // First turn: build fresh chat
-    let chat = predict
-        .build_chat(&first_input)
-        .expect("build_chat should succeed");
-    let (first_predicted, mut chat) = predict
-        .call_and_parse(chat)
+    let first_predicted = predict
+        .forward(first_input, None)
         .await
-        .expect("first turn should succeed");
+        .expect("first turn forward should succeed");
+    let chat = first_predicted.chat().clone();
     assert_eq!(first_predicted.into_inner().answer, "First turn answer");
 
-    // Second turn: append follow-up, continue conversation
+    // Second turn: typed follow-up with prior history
     let caller_follow_up = "Caller follow-up message";
-    chat.push_message(Message::user(caller_follow_up));
+    let second_input = ConversationQAInput {
+        question: caller_follow_up.to_string(),
+    };
 
-    let (second_predicted, second_chat) = predict
-        .forward_continue(chat)
+    let second_predicted = predict
+        .forward(second_input, Some(chat))
         .await
-        .expect("second turn should succeed");
+        .expect("second turn forward should succeed");
+    let second_chat = second_predicted.chat().clone();
 
     assert_eq!(second_predicted.into_inner().answer, "Second turn answer");
     assert!(second_chat.len() >= 5);

--- a/crates/dspy-rs/tests/test_predict_conversation.rs
+++ b/crates/dspy-rs/tests/test_predict_conversation.rs
@@ -1,0 +1,159 @@
+use dspy_rs::{
+    ChatAdapter, LM, LMClient, Message, Predict, Role, Signature, TestCompletionModel, configure,
+};
+use rig::completion::{AssistantContent, CompletionRequest};
+use rig::message::{Message as RigMessage, Text, UserContent};
+use std::sync::LazyLock;
+use tokio::sync::Mutex;
+
+static SETTINGS_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+fn response_with_fields(fields: &[(&str, &str)]) -> String {
+    let mut response = String::new();
+    for (name, value) in fields {
+        response.push_str(&format!("[[ ## {name} ## ]]\n{value}\n\n"));
+    }
+    response.push_str("[[ ## completed ## ]]\n");
+    response
+}
+
+fn text_response(text: impl Into<String>) -> AssistantContent {
+    AssistantContent::Text(Text { text: text.into() })
+}
+
+async fn configure_test_lm(responses: Vec<String>) -> TestCompletionModel {
+    let client = TestCompletionModel::new(responses.into_iter().map(text_response));
+    let lm = temp_env::async_with_vars(
+        [("OPENAI_API_KEY", Some("test"))],
+        LM::builder()
+            .model("openai:gpt-4o-mini".to_string())
+            .build(),
+    )
+    .await
+    .unwrap()
+    .with_client(LMClient::Test(client.clone()))
+    .await
+    .unwrap();
+
+    configure(lm, ChatAdapter {});
+
+    client
+}
+
+fn request_contains_text(request: &CompletionRequest, needle: &str) -> bool {
+    if request
+        .preamble
+        .as_ref()
+        .is_some_and(|preamble| preamble.contains(needle))
+    {
+        return true;
+    }
+
+    for message in request.chat_history.iter() {
+        match message {
+            RigMessage::User { content } => {
+                for item in content.iter() {
+                    if let UserContent::Text(text) = item
+                        && text.text.contains(needle)
+                    {
+                        return true;
+                    }
+                }
+            }
+            RigMessage::Assistant { content, .. } => {
+                for item in content.iter() {
+                    match item {
+                        AssistantContent::Text(text) if text.text.contains(needle) => return true,
+                        AssistantContent::Reasoning(reasoning)
+                            if reasoning.display_text().contains(needle) =>
+                        {
+                            return true;
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+    }
+
+    false
+}
+
+#[derive(Signature, Clone, Debug, PartialEq)]
+/// Conversational QA test signature.
+struct ConversationQA {
+    #[input]
+    question: String,
+
+    #[output]
+    answer: String,
+}
+
+#[cfg_attr(miri, ignore = "MIRI has issues with tokio's I/O driver")]
+#[tokio::test]
+async fn forward_returns_chat_and_prediction() {
+    let _lock = SETTINGS_LOCK.lock().await;
+    let response = response_with_fields(&[("answer", "Paris")]);
+    let _client = configure_test_lm(vec![response]).await;
+
+    let predict = Predict::<ConversationQA>::new();
+    let input = ConversationQAInput {
+        question: "What is the capital of France?".to_string(),
+    };
+
+    let chat = predict
+        .build_chat(&input)
+        .expect("build_chat should succeed");
+    let (predicted, chat) = predict
+        .call_and_parse(chat)
+        .await
+        .expect("first turn should succeed");
+
+    assert_eq!(predicted.into_inner().answer, "Paris");
+    assert_eq!(chat.len(), 3);
+    assert_eq!(chat.messages[0].role, Role::System);
+    assert_eq!(chat.messages[1].role, Role::User);
+    assert_eq!(chat.messages[2].role, Role::Assistant);
+}
+
+#[cfg_attr(miri, ignore = "MIRI has issues with tokio's I/O driver")]
+#[tokio::test]
+async fn forward_continue_supports_two_turn_roundtrip() {
+    let _lock = SETTINGS_LOCK.lock().await;
+    let first_response = response_with_fields(&[("answer", "First turn answer")]);
+    let second_response = response_with_fields(&[("answer", "Second turn answer")]);
+    let client = configure_test_lm(vec![first_response, second_response]).await;
+
+    let predict = Predict::<ConversationQA>::new();
+    let first_input = ConversationQAInput {
+        question: "Turn 1 question".to_string(),
+    };
+
+    // First turn: build fresh chat
+    let chat = predict
+        .build_chat(&first_input)
+        .expect("build_chat should succeed");
+    let (first_predicted, mut chat) = predict
+        .call_and_parse(chat)
+        .await
+        .expect("first turn should succeed");
+    assert_eq!(first_predicted.into_inner().answer, "First turn answer");
+
+    // Second turn: append follow-up, continue conversation
+    let caller_follow_up = "Caller follow-up message";
+    chat.push_message(Message::user(caller_follow_up));
+
+    let (second_predicted, second_chat) = predict
+        .forward_continue(chat)
+        .await
+        .expect("second turn should succeed");
+
+    assert_eq!(second_predicted.into_inner().answer, "Second turn answer");
+    assert!(second_chat.len() >= 5);
+
+    // Verify the follow-up text was sent to the LM
+    let last_request = client
+        .last_request()
+        .expect("test model should capture last request");
+    assert!(request_contains_text(&last_request, caller_follow_up));
+}

--- a/crates/dspy-rs/tests/test_predict_conversation.rs
+++ b/crates/dspy-rs/tests/test_predict_conversation.rs
@@ -35,7 +35,7 @@ async fn configure_test_lm(responses: Vec<String>) -> TestCompletionModel {
     .await
     .unwrap();
 
-    configure(lm, ChatAdapter {});
+    configure(lm, ChatAdapter::new());
 
     client
 }

--- a/crates/dspy-rs/tests/test_predict_conversation_live.rs
+++ b/crates/dspy-rs/tests/test_predict_conversation_live.rs
@@ -1,0 +1,65 @@
+use dspy_rs::{ChatAdapter, LM, Message, Predict, Signature, configure};
+use std::sync::LazyLock;
+use tokio::sync::Mutex;
+
+static SETTINGS_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+#[derive(Signature, Clone, Debug, PartialEq)]
+/// Live multi-turn conversation signature.
+struct LiveConversation {
+    #[input]
+    prompt: String,
+
+    #[output]
+    answer: String,
+}
+
+#[tokio::test]
+#[ignore] // Requires real network access and provider API key(s)
+async fn live_forward_continue_two_turn_roundtrip() {
+    let _lock = SETTINGS_LOCK.lock().await;
+
+    let lm = LM::builder()
+        .model("openai:gpt-4o-mini".to_string())
+        .temperature(0.0)
+        .max_tokens(256)
+        .build()
+        .await
+        .expect("failed to build LM for live smoke test");
+    configure(lm, ChatAdapter {});
+
+    let predict = Predict::<LiveConversation>::new();
+
+    // First turn: build and call
+    let first_input = LiveConversationInput {
+        prompt: "Reply with the word ONE.".to_string(),
+    };
+    let chat = predict
+        .build_chat(&first_input)
+        .expect("build_chat should succeed");
+    let (first, mut chat) = predict
+        .call_and_parse(chat)
+        .await
+        .expect("first turn failed");
+    assert!(
+        !first.answer.trim().is_empty(),
+        "first turn answer should not be empty"
+    );
+
+    // Second turn: append follow-up, continue
+    chat.push_message(Message::user(
+        "Now reply with the word TWO. Use the same answer field format.",
+    ));
+
+    let (second, chat2) = predict
+        .forward_continue(chat)
+        .await
+        .expect("second turn failed");
+
+    assert!(
+        second.answer.to_ascii_lowercase().contains("two"),
+        "second turn answer should include 'two', got: {}",
+        second.answer
+    );
+    assert!(chat2.len() >= 5, "chat should grow across turns");
+}

--- a/crates/dspy-rs/tests/test_predict_conversation_live.rs
+++ b/crates/dspy-rs/tests/test_predict_conversation_live.rs
@@ -26,7 +26,7 @@ async fn live_forward_with_history_two_turn_roundtrip() {
         .build()
         .await
         .expect("failed to build LM for live smoke test");
-    configure(lm, ChatAdapter {});
+    configure(lm, ChatAdapter::new());
 
     let predict = Predict::<LiveConversation>::new();
 

--- a/crates/dspy-rs/tests/test_react_builder.rs
+++ b/crates/dspy-rs/tests/test_react_builder.rs
@@ -112,7 +112,7 @@ async fn react_builder_executes_multi_tool_calculator_loop_and_extracts_output()
         .await
         .expect("react call should succeed");
 
-    let (result, metadata) = predicted.into_parts();
+    let (result, metadata, _chat) = predicted.into_parts();
     assert_eq!(
         add_calls.load(Ordering::SeqCst),
         1,
@@ -208,7 +208,7 @@ async fn react_unknown_tool_name_does_not_execute_first_tool() {
         })
         .await
         .expect("react call should succeed");
-    let (_, metadata) = predicted.into_parts();
+    let (_, metadata, _chat) = predicted.into_parts();
 
     assert_eq!(
         add_calls.load(Ordering::SeqCst),

--- a/crates/dspy-rs/tests/test_react_builder.rs
+++ b/crates/dspy-rs/tests/test_react_builder.rs
@@ -31,19 +31,18 @@ fn parse_calculator_args(args: &str) -> (i64, i64) {
 }
 
 async fn configure_test_lm(responses: Vec<String>) {
-    unsafe {
-        std::env::set_var("OPENAI_API_KEY", "test");
-    }
-
     let client = TestCompletionModel::new(responses.into_iter().map(text_response));
-    let lm = LM::builder()
-        .model("openai:gpt-4o-mini".to_string())
-        .build()
-        .await
-        .unwrap()
-        .with_client(LMClient::Test(client))
-        .await
-        .unwrap();
+    let lm = temp_env::async_with_vars(
+        [("OPENAI_API_KEY", Some("test"))],
+        LM::builder()
+            .model("openai:gpt-4o-mini".to_string())
+            .build(),
+    )
+    .await
+    .unwrap()
+    .with_client(LMClient::Test(client))
+    .await
+    .unwrap();
 
     configure(lm, ChatAdapter {});
 }

--- a/crates/dspy-rs/tests/test_react_builder.rs
+++ b/crates/dspy-rs/tests/test_react_builder.rs
@@ -44,7 +44,7 @@ async fn configure_test_lm(responses: Vec<String>) {
     .await
     .unwrap();
 
-    configure(lm, ChatAdapter {});
+    configure(lm, ChatAdapter::new());
 }
 
 #[derive(Signature, Clone, Debug)]

--- a/crates/dspy-rs/tests/test_rlm_fallback_integration.rs
+++ b/crates/dspy-rs/tests/test_rlm_fallback_integration.rs
@@ -1,0 +1,138 @@
+#![cfg(feature = "rlm")]
+
+use dspy_rs::modules::rlm::PyO3Runtime;
+use dspy_rs::{
+    ChatAdapter, LM, LMClient, PredictError, Rlm, Signature, TestCompletionModel, configure,
+};
+use rig::completion::AssistantContent;
+use rig::message::Text;
+use std::sync::{Arc, LazyLock};
+use tokio::sync::Mutex;
+
+static SETTINGS_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+fn text_response(text: impl Into<String>) -> AssistantContent {
+    AssistantContent::Text(Text { text: text.into() })
+}
+
+fn response_with_fields(fields: &[(&str, &str)]) -> String {
+    let mut response = String::new();
+    for (name, value) in fields {
+        response.push_str(&format!("[[ ## {name} ## ]]\n{value}\n\n"));
+    }
+    response.push_str("[[ ## completed ## ]]\n");
+    response
+}
+
+async fn build_test_lm_with_client(responses: Vec<String>) -> (LM, TestCompletionModel) {
+    let client = TestCompletionModel::new(responses.into_iter().map(text_response));
+    let lm = temp_env::async_with_vars(
+        [("OPENAI_API_KEY", Some("test"))],
+        LM::builder()
+            .model("openai:gpt-4o-mini".to_string())
+            .temperature(0.0)
+            .build(),
+    )
+    .await
+    .expect("build lm")
+    .with_client(LMClient::Test(client.clone()))
+    .await
+    .expect("install test client");
+    (lm, client)
+}
+
+async fn configure_test_lm(responses: Vec<String>) -> LM {
+    let (lm, _) = build_test_lm_with_client(responses).await;
+    configure(lm.clone(), ChatAdapter::new());
+    lm
+}
+
+async fn configure_test_lm_with_client(responses: Vec<String>) -> (LM, TestCompletionModel) {
+    let (lm, client) = build_test_lm_with_client(responses).await;
+    configure(lm.clone(), ChatAdapter::new());
+    (lm, client)
+}
+
+#[derive(Signature, Clone, Debug, PartialEq)]
+struct RlmFallbackSig {
+    #[input]
+    prompt: String,
+    #[output]
+    answer: String,
+}
+
+#[cfg_attr(miri, ignore = "MIRI has issues with tokio's I/O driver")]
+#[tokio::test]
+async fn rlm_fallback_extractor_runs_after_finalization_failure_and_uses_repl_history() {
+    let _lock = SETTINGS_LOCK.lock().await;
+    let (lm, client) = configure_test_lm_with_client(vec![
+        "x = 40 + 2\nprint(f'x={x}')".to_string(),
+        "print('still working')".to_string(),
+        "print('final turn still no submit')".to_string(),
+        response_with_fields(&[("answer", "from-fallback")]),
+    ])
+    .await;
+
+    let rlm = Rlm::<RlmFallbackSig>::builder()
+        .runtime(Arc::new(PyO3Runtime))
+        .sub_lm(Arc::new(lm))
+        .max_iterations(3)
+        .enable_extraction_fallback(true)
+        .build();
+
+    let predicted = rlm
+        .call(RlmFallbackSigInput {
+            prompt: "never submit; let fallback extract".to_string(),
+        })
+        .await
+        .expect("fallback extraction should produce typed output");
+
+    assert_eq!(predicted.answer, "from-fallback");
+    let raw = &predicted.metadata().raw_response;
+    assert!(raw.contains("x = 40 + 2"));
+    assert!(raw.contains("print('final turn still no submit')"));
+    assert!(raw.contains("[[ ## answer ## ]]"));
+
+    let last_request = client.last_request().expect("expected extraction request");
+    let request_debug = format!("{last_request:?}");
+    assert!(request_debug.contains("[[ ## repl_history ## ]]"));
+    assert!(request_debug.contains("=== Turn 1 ==="));
+    assert!(request_debug.contains("Code:"));
+    assert!(request_debug.contains("Output:"));
+    assert!(request_debug.contains("x = 40 + 2"));
+    assert!(request_debug.contains("[[ ## variables_info ## ]]"));
+}
+
+#[cfg_attr(miri, ignore = "MIRI has issues with tokio's I/O driver")]
+#[tokio::test]
+async fn rlm_without_extraction_fallback_returns_max_iterations_error() {
+    let _lock = SETTINGS_LOCK.lock().await;
+    let lm = configure_test_lm(vec![
+        "print('turn1')".to_string(),
+        "print('turn2')".to_string(),
+    ])
+    .await;
+
+    let rlm = Rlm::<RlmFallbackSig>::builder()
+        .runtime(Arc::new(PyO3Runtime))
+        .sub_lm(Arc::new(lm))
+        .max_iterations(2)
+        .enable_extraction_fallback(false)
+        .build();
+
+    let err = rlm
+        .call(RlmFallbackSigInput {
+            prompt: "never submit".to_string(),
+        })
+        .await
+        .expect_err("expected max-iteration failure when fallback is disabled");
+    match err {
+        PredictError::Module { source, .. } => {
+            assert!(
+                source.to_string().contains("max iterations reached (2)"),
+                "unexpected error: {source}"
+            );
+        }
+        other => panic!("expected module error, got: {other}"),
+    }
+}

--- a/crates/dspy-rs/tests/test_rlm_integration_demo.rs
+++ b/crates/dspy-rs/tests/test_rlm_integration_demo.rs
@@ -221,12 +221,21 @@ async fn integration_preview_matches_spec_and_prompt_is_clean() {
         "{request_debug}"
     );
     assert!(request_debug.contains("title: string"), "{request_debug}");
-    assert!(request_debug.contains("[env] 1 turn |"), "{request_debug}");
-    assert!(request_debug.contains("[query]"), "{request_debug}");
     assert!(
-        request_debug.contains("--- namespace ---"),
+        request_debug.contains("=== Execution Receipt (Turn 1) ==="),
         "{request_debug}"
     );
+    assert!(
+        request_debug.contains("Budget: 1 turn remaining |"),
+        "{request_debug}"
+    );
+    assert!(request_debug.contains("[query]"), "{request_debug}");
+    assert!(
+        request_debug.contains("=== Namespace ==="),
+        "{request_debug}"
+    );
+    assert!(request_debug.contains("[Injected]"), "{request_debug}");
+    assert!(request_debug.contains("[Recent]"), "{request_debug}");
     assert!(request_debug.contains(">>>"), "{request_debug}");
     assert!(
         !request_debug.contains("__baml__"),

--- a/crates/dspy-rs/tests/test_rlm_integration_demo.rs
+++ b/crates/dspy-rs/tests/test_rlm_integration_demo.rs
@@ -196,9 +196,12 @@ async fn integration_preview_matches_spec_and_prompt_is_clean() {
     let request_debug = format!("{request:?}");
 
     assert!(
-        request_debug
-            .contains("You work in a Python REPL. Find the most relevant papers for the query."),
-        "system prompt must start with developer instruction"
+        request_debug.contains("## Task"),
+        "system prompt should include Task section"
+    );
+    assert!(
+        request_debug.contains("Find the most relevant papers for the query."),
+        "system prompt should include developer instruction"
     );
     assert!(
         !request_debug.contains("Your input fields are:"),
@@ -209,9 +212,22 @@ async fn integration_preview_matches_spec_and_prompt_is_clean() {
         "adapter wrapping should be absent"
     );
 
-    assert!(request_debug.contains("## Variables"), "{request_debug}");
-    assert!(request_debug.contains("papers:"), "{request_debug}");
+    assert!(
+        request_debug.contains("## Input Variables"),
+        "{request_debug}"
+    );
+    assert!(
+        request_debug.contains("Variable: `papers` (access it in your code)"),
+        "{request_debug}"
+    );
     assert!(request_debug.contains("title: string"), "{request_debug}");
+    assert!(request_debug.contains("[env] 1 turn |"), "{request_debug}");
+    assert!(request_debug.contains("[query]"), "{request_debug}");
+    assert!(
+        request_debug.contains("--- namespace ---"),
+        "{request_debug}"
+    );
+    assert!(request_debug.contains(">>>"), "{request_debug}");
     assert!(
         !request_debug.contains("__baml__"),
         "preview should hide __baml__"
@@ -243,10 +259,23 @@ async fn integration_preview_shows_paper_fields_and_methods() {
         .last_request()
         .expect("expected preview request capture");
     let request_debug = format!("{request:?}");
-    assert!(request_debug.contains("paper:"), "{request_debug}");
+    assert!(
+        request_debug.contains("Variable: `paper` (access it in your code)"),
+        "{request_debug}"
+    );
     assert!(request_debug.contains("title: string"), "{request_debug}");
-    assert!(request_debug.contains("Methods:"), "{request_debug}");
-    assert!(request_debug.contains(".__len__("), "{request_debug}");
+    assert!(
+        request_debug.contains("## Input Variables"),
+        "{request_debug}"
+    );
+    assert!(
+        !request_debug.contains("Methods:"),
+        "legacy methods block should not appear in new schema format"
+    );
+    assert!(
+        !request_debug.contains(".__len__("),
+        "dunder methods should not appear in schema-facing method surface"
+    );
     assert!(
         !request_debug.contains("__baml__"),
         "preview should hide __baml__"

--- a/crates/dspy-rs/tests/test_rlm_integration_demo.rs
+++ b/crates/dspy-rs/tests/test_rlm_integration_demo.rs
@@ -1,0 +1,298 @@
+#![cfg(feature = "rlm")]
+#![allow(legacy_derive_helpers)]
+
+use dspy_rs::modules::rlm::PyO3Runtime;
+use dspy_rs::{
+    ChatAdapter, LM, LMClient, Rlm, Signature, TestCompletionModel, configure, rlm_type,
+};
+use rig::completion::AssistantContent;
+use rig::message::Text;
+use std::sync::{Arc, LazyLock};
+use tokio::sync::Mutex;
+
+use dspy_rs::__macro_support::pyo3;
+use pyo3::types::{PyAnyMethods, PyDict};
+use pyo3::{IntoPyObjectExt, Python};
+
+static SETTINGS_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+fn text_response(text: impl Into<String>) -> AssistantContent {
+    AssistantContent::Text(Text { text: text.into() })
+}
+
+async fn build_test_lm_with_client(responses: Vec<String>) -> (LM, TestCompletionModel) {
+    let client = TestCompletionModel::new(responses.into_iter().map(text_response));
+    let lm = temp_env::async_with_vars(
+        [("OPENAI_API_KEY", Some("test"))],
+        LM::builder()
+            .model("openai:gpt-4o-mini".to_string())
+            .temperature(0.0)
+            .build(),
+    )
+    .await
+    .expect("build lm")
+    .with_client(LMClient::Test(client.clone()))
+    .await
+    .expect("install test client");
+    (lm, client)
+}
+
+async fn configure_test_lm_with_client(responses: Vec<String>) -> (LM, TestCompletionModel) {
+    let (lm, client) = build_test_lm_with_client(responses).await;
+    configure(lm.clone(), ChatAdapter::new());
+    (lm, client)
+}
+
+#[rlm_type]
+#[rlm(iter = "keywords", index = "keywords")]
+#[derive(Clone, Debug)]
+struct Paper {
+    /// Paper title.
+    title: String,
+    /// Abstract body.
+    abstract_text: String,
+    /// Publication year.
+    year: i32,
+    /// Search keywords.
+    keywords: Vec<String>,
+    #[rlm(skip_python)]
+    internal_rank: i32,
+}
+
+#[derive(Signature, Clone, Debug)]
+/// Find the most relevant papers for the query.
+struct PaperSearch {
+    #[input]
+    papers: Vec<Paper>,
+    #[input]
+    query: String,
+    #[output]
+    relevant_titles: Vec<String>,
+    #[output]
+    reasoning: String,
+}
+
+#[derive(Signature, Clone, Debug)]
+/// Render-only signature for previewing a single paper object.
+struct PaperPreviewSig {
+    #[input]
+    paper: Paper,
+    #[output]
+    ok: bool,
+}
+
+fn demo_papers() -> Vec<Paper> {
+    vec![
+        Paper {
+            title: "Intro to Rust for LLMs".to_string(),
+            abstract_text: "Typed pipelines for model programs.".to_string(),
+            year: 2024,
+            keywords: vec!["rust".to_string(), "llm".to_string()],
+            internal_rank: 1,
+        },
+        Paper {
+            title: "Graph Reasoning at Scale".to_string(),
+            abstract_text: "Large context retrieval and synthesis.".to_string(),
+            year: 2023,
+            keywords: vec!["graph".to_string(), "retrieval".to_string()],
+            internal_rank: 2,
+        },
+    ]
+}
+
+#[test]
+fn demo_signature_generates_correct_pyclass_methods() {
+    Python::attach(|py| {
+        let paper = demo_papers().remove(0);
+        let py_obj = paper
+            .clone()
+            .into_py_any(py)
+            .expect("Paper should convert to native PyO3 object");
+        let bound = py_obj.bind(py);
+
+        assert!(
+            !bound.is_instance_of::<PyDict>(),
+            "Paper must inject as native object, not dict"
+        );
+        assert_eq!(
+            bound
+                .getattr("title")
+                .expect("title getter")
+                .extract::<String>()
+                .expect("title extract"),
+            paper.title
+        );
+        assert!(
+            !bound
+                .hasattr("internal_rank")
+                .expect("hasattr internal_rank"),
+            "skip_python fields must not be exposed as Python attributes"
+        );
+
+        let repr = bound
+            .repr()
+            .expect("repr")
+            .extract::<String>()
+            .expect("repr string");
+        assert!(repr.contains("Paper"));
+
+        let baml = bound.call_method0("__baml__").expect("__baml__ call");
+        assert!(baml.is_instance_of::<PyDict>());
+        let baml_dict = baml.cast::<PyDict>().expect("__baml__ returns dict");
+        assert_eq!(
+            baml_dict
+                .get_item("title")
+                .expect("title get_item")
+                .extract::<String>()
+                .expect("title value"),
+            "Intro to Rust for LLMs"
+        );
+        assert_eq!(
+            bound
+                .call_method0("__len__")
+                .expect("len call")
+                .extract::<usize>()
+                .expect("len value"),
+            2
+        );
+    });
+}
+
+#[cfg_attr(miri, ignore = "MIRI has issues with tokio's I/O driver")]
+#[tokio::test]
+async fn integration_preview_matches_spec_and_prompt_is_clean() {
+    let _lock = SETTINGS_LOCK.lock().await;
+    let (lm, client) = configure_test_lm_with_client(vec![
+        "dict_style_ok = True\ntry:\n    _ = papers[0]['title']\nexcept Exception:\n    dict_style_ok = False\nreason = f\"{type(papers[0]).__name__}:{papers[0].title}:dict={dict_style_ok}\"\nSUBMIT(relevant_titles=[papers[0].title], reasoning=reason)".to_string(),
+    ])
+    .await;
+
+    let rlm = Rlm::<PaperSearch>::builder()
+        .runtime(Arc::new(PyO3Runtime))
+        .sub_lm(Arc::new(lm))
+        .max_iterations(1)
+        .enable_extraction_fallback(false)
+        .build();
+
+    let predicted = rlm
+        .call(PaperSearchInput {
+            papers: demo_papers(),
+            query: "rust typed model pipelines".to_string(),
+        })
+        .await
+        .expect("RLM demo call should complete");
+
+    assert_eq!(predicted.relevant_titles, vec!["Intro to Rust for LLMs"]);
+    assert!(
+        predicted
+            .reasoning
+            .contains("Paper:Intro to Rust for LLMs:dict=False"),
+        "reasoning should confirm native object access and dict-style failure"
+    );
+
+    let request = client
+        .last_request()
+        .expect("expected action turn request capture");
+    let request_debug = format!("{request:?}");
+
+    assert!(
+        request_debug
+            .contains("You work in a Python REPL. Find the most relevant papers for the query."),
+        "system prompt must start with developer instruction"
+    );
+    assert!(
+        !request_debug.contains("Your input fields are:"),
+        "adapter wrapping should be absent"
+    );
+    assert!(
+        !request_debug.contains("Your objective is:"),
+        "adapter wrapping should be absent"
+    );
+
+    assert!(request_debug.contains("## Variables"), "{request_debug}");
+    assert!(request_debug.contains("papers:"), "{request_debug}");
+    assert!(request_debug.contains("title: string"), "{request_debug}");
+    assert!(
+        !request_debug.contains("__baml__"),
+        "preview should hide __baml__"
+    );
+}
+
+#[cfg_attr(miri, ignore = "MIRI has issues with tokio's I/O driver")]
+#[tokio::test]
+async fn integration_preview_shows_paper_fields_and_methods() {
+    let _lock = SETTINGS_LOCK.lock().await;
+    let (lm, client) = configure_test_lm_with_client(vec!["SUBMIT(ok=True)".to_string()]).await;
+
+    let rlm = Rlm::<PaperPreviewSig>::builder()
+        .runtime(Arc::new(PyO3Runtime))
+        .sub_lm(Arc::new(lm))
+        .max_iterations(1)
+        .enable_extraction_fallback(false)
+        .build();
+
+    let predicted = rlm
+        .call(PaperPreviewSigInput {
+            paper: demo_papers().remove(0),
+        })
+        .await
+        .expect("preview demo should submit");
+    assert!(predicted.ok);
+
+    let request = client
+        .last_request()
+        .expect("expected preview request capture");
+    let request_debug = format!("{request:?}");
+    assert!(request_debug.contains("paper:"), "{request_debug}");
+    assert!(request_debug.contains("title: string"), "{request_debug}");
+    assert!(request_debug.contains("Methods:"), "{request_debug}");
+    assert!(request_debug.contains(".__len__("), "{request_debug}");
+    assert!(
+        !request_debug.contains("__baml__"),
+        "preview should hide __baml__"
+    );
+}
+
+#[cfg_attr(miri, ignore = "MIRI has issues with tokio's I/O driver")]
+#[tokio::test]
+async fn submit_validation_errors_are_pythonic_not_baml_internal() {
+    let _lock = SETTINGS_LOCK.lock().await;
+    let (lm, client) = configure_test_lm_with_client(vec![
+        "SUBMIT(relevant_titles=123, reasoning=5)".to_string(),
+        "SUBMIT(relevant_titles=['Intro to Rust for LLMs'], reasoning='fixed')".to_string(),
+    ])
+    .await;
+
+    let rlm = Rlm::<PaperSearch>::builder()
+        .runtime(Arc::new(PyO3Runtime))
+        .sub_lm(Arc::new(lm))
+        .max_iterations(2)
+        .enable_extraction_fallback(false)
+        .build();
+
+    let predicted = rlm
+        .call(PaperSearchInput {
+            papers: demo_papers(),
+            query: "rust".to_string(),
+        })
+        .await
+        .expect("second submit should succeed after validation feedback");
+
+    assert_eq!(predicted.relevant_titles, vec!["Intro to Rust for LLMs"]);
+    assert_eq!(predicted.reasoning, "fixed");
+
+    let request = client
+        .last_request()
+        .expect("expected second-turn request capture");
+    let request_debug = format!("{request:?}");
+
+    assert!(
+        request_debug.contains("SubmitError: Validation failed"),
+        "{request_debug}"
+    );
+    assert!(request_debug.contains("got python"), "{request_debug}");
+    assert!(
+        !request_debug.contains("BamlValue::"),
+        "feedback should not leak Baml internal type names"
+    );
+}

--- a/crates/dspy-rs/tests/test_rlm_live_openai_gpt52.rs
+++ b/crates/dspy-rs/tests/test_rlm_live_openai_gpt52.rs
@@ -1,0 +1,59 @@
+#![cfg(feature = "rlm")]
+
+use dspy_rs::modules::rlm::PyO3Runtime;
+use dspy_rs::{ChatAdapter, LM, Rlm, Signature, configure};
+use std::sync::{Arc, LazyLock};
+use tokio::sync::Mutex;
+
+static SETTINGS_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+#[derive(Signature, Clone, Debug, PartialEq)]
+/// Return executable Python only and call SUBMIT with the final typed answer.
+struct LiveMathProblem {
+    #[input]
+    problem: String,
+
+    #[output]
+    answer: i64,
+}
+
+#[tokio::test]
+#[ignore] // Requires network access + OPENAI_API_KEY
+async fn live_rlm_v1_openai_responses_gpt52_end_to_end() {
+    let _lock = SETTINGS_LOCK.lock().await;
+    let _ = std::env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY must be set for live test");
+
+    let lm = LM::builder()
+        .model("openai-responses:gpt-5.2".to_string())
+        .temperature(0.0)
+        .max_tokens(512)
+        .build()
+        .await
+        .expect("failed to build live LM");
+
+    configure(lm.clone(), ChatAdapter::new());
+
+    let rlm = Rlm::<LiveMathProblem>::builder()
+        .runtime(Arc::new(PyO3Runtime))
+        .sub_lm(Arc::new(lm))
+        .max_iterations(12)
+        .max_llm_calls(8)
+        .enable_extraction_fallback(false)
+        .build();
+
+    let predicted = rlm
+        .call(LiveMathProblemInput {
+            problem:
+                "Compute 12 * 13. Respond with executable Python only (no markdown, no prose). \
+Immediately call SUBMIT(answer=<integer>). Example shape:\nresult = 12 * 13\nSUBMIT(answer=result)"
+                    .to_string(),
+        })
+        .await
+        .expect("live RLM call failed");
+
+    assert_eq!(predicted.answer, 156);
+    assert!(
+        predicted.metadata().raw_response.contains("SUBMIT("),
+        "expected SUBMIT path evidence in raw response"
+    );
+}

--- a/crates/dspy-rs/tests/test_rlm_loop_integration.rs
+++ b/crates/dspy-rs/tests/test_rlm_loop_integration.rs
@@ -158,9 +158,7 @@ async fn rlm_v3_demo_recovers_empty_then_python_error_then_finalization_submit()
         "finalization turn should include prior python error feedback"
     );
     assert!(
-        request_debug.contains(
-            "This is your final turn. Call SUBMIT(answer=...) now with your best answer."
-        ),
+        request_debug.contains("⚠ LAST TURN — you MUST call SUBMIT() now with your best answer."),
         "finalization directive should be present on last repair turn"
     );
 }
@@ -244,7 +242,7 @@ async fn rlm_sub_lm_tools_persist_state_and_decrement_budget_across_turns() {
         .expect("expected second-turn request with feedback");
     let request_debug = format!("{last_request:?}");
     assert!(
-        request_debug.contains("0/3 sub-model calls remaining"),
+        request_debug.contains("[env] 1 turn | 0 sub-LLM calls"),
         "second turn should see depleted sub-LM budget"
     );
 }

--- a/crates/dspy-rs/tests/test_rlm_loop_integration.rs
+++ b/crates/dspy-rs/tests/test_rlm_loop_integration.rs
@@ -13,25 +13,7 @@ fn text_response(text: impl Into<String>) -> AssistantContent {
     AssistantContent::Text(Text { text: text.into() })
 }
 
-async fn configure_test_lm(responses: Vec<String>) -> LM {
-    let client = TestCompletionModel::new(responses.into_iter().map(text_response));
-    let lm = temp_env::async_with_vars(
-        [("OPENAI_API_KEY", Some("test"))],
-        LM::builder()
-            .model("openai:gpt-4o-mini".to_string())
-            .temperature(0.0)
-            .build(),
-    )
-    .await
-    .expect("build lm")
-    .with_client(LMClient::Test(client))
-    .await
-    .expect("install test client");
-    configure(lm.clone(), ChatAdapter::new());
-    lm
-}
-
-async fn configure_test_lm_with_client(responses: Vec<String>) -> (LM, TestCompletionModel) {
+async fn build_test_lm_with_client(responses: Vec<String>) -> (LM, TestCompletionModel) {
     let client = TestCompletionModel::new(responses.into_iter().map(text_response));
     let lm = temp_env::async_with_vars(
         [("OPENAI_API_KEY", Some("test"))],
@@ -45,6 +27,17 @@ async fn configure_test_lm_with_client(responses: Vec<String>) -> (LM, TestCompl
     .with_client(LMClient::Test(client.clone()))
     .await
     .expect("install test client");
+    (lm, client)
+}
+
+async fn configure_test_lm(responses: Vec<String>) -> LM {
+    let (lm, _) = build_test_lm_with_client(responses).await;
+    configure(lm.clone(), ChatAdapter::new());
+    lm
+}
+
+async fn configure_test_lm_with_client(responses: Vec<String>) -> (LM, TestCompletionModel) {
+    let (lm, client) = build_test_lm_with_client(responses).await;
     configure(lm.clone(), ChatAdapter::new());
     (lm, client)
 }
@@ -205,4 +198,53 @@ async fn rlm_feedback_carries_truncation_marker_with_configured_budget() {
     assert!(request_debug.contains(
         "[output truncated at 10 chars - full content in variable. pass to llm_query() to analyze]"
     ));
+}
+
+#[cfg_attr(miri, ignore = "MIRI has issues with tokio's I/O driver")]
+#[tokio::test(flavor = "multi_thread")]
+async fn rlm_sub_lm_tools_persist_state_and_decrement_budget_across_turns() {
+    let _lock = SETTINGS_LOCK.lock().await;
+    let (_action_lm, action_client) = configure_test_lm_with_client(vec![
+        "single = llm_query('single')\nbatch = llm_query_batched(['left', 'right'])\ncounter = 40 + len(batch)".to_string(),
+        "try:\n    llm_query('should_fail')\n    budget_state = 'not_exhausted'\nexcept Exception as err:\n    budget_state = 'exhausted' if 'budget exhausted' in str(err) else f'unexpected:{err}'\nSUBMIT(answer=f'{counter}:{budget_state}:{single}')".to_string(),
+    ])
+    .await;
+    let (sub_lm, _) = build_test_lm_with_client(vec![
+        "single-ok".to_string(),
+        "batch-a".to_string(),
+        "batch-b".to_string(),
+    ])
+    .await;
+
+    let rlm = Rlm::<RlmLoopSig>::builder()
+        .runtime(Arc::new(PyO3Runtime))
+        .sub_lm(Arc::new(sub_lm))
+        .max_iterations(2)
+        .max_llm_calls(3)
+        .enable_extraction_fallback(false)
+        .build();
+
+    let predicted = rlm
+        .call(RlmLoopSigInput {
+            prompt: "Use both sub-LM helpers, then submit on turn two.".to_string(),
+        })
+        .await
+        .expect("rlm should complete with persisted state and enforced budget");
+
+    assert_eq!(predicted.answer, "42:exhausted:single-ok");
+    assert!(
+        predicted
+            .metadata()
+            .raw_response
+            .contains("llm_query_batched")
+    );
+
+    let last_request = action_client
+        .last_request()
+        .expect("expected second-turn request with feedback");
+    let request_debug = format!("{last_request:?}");
+    assert!(
+        request_debug.contains("0/3 sub-model calls remaining"),
+        "second turn should see depleted sub-LM budget"
+    );
 }

--- a/crates/dspy-rs/tests/test_rlm_loop_integration.rs
+++ b/crates/dspy-rs/tests/test_rlm_loop_integration.rs
@@ -1,0 +1,112 @@
+#![cfg(feature = "rlm")]
+
+use dspy_rs::modules::rlm::PyO3Runtime;
+use dspy_rs::{ChatAdapter, LM, LMClient, Rlm, Signature, TestCompletionModel, configure};
+use rig::completion::AssistantContent;
+use rig::message::Text;
+use std::sync::{Arc, LazyLock};
+use tokio::sync::Mutex;
+
+static SETTINGS_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+fn text_response(text: impl Into<String>) -> AssistantContent {
+    AssistantContent::Text(Text { text: text.into() })
+}
+
+async fn configure_test_lm(responses: Vec<String>) -> LM {
+    let client = TestCompletionModel::new(responses.into_iter().map(text_response));
+    let lm = temp_env::async_with_vars(
+        [("OPENAI_API_KEY", Some("test"))],
+        LM::builder()
+            .model("openai:gpt-4o-mini".to_string())
+            .temperature(0.0)
+            .build(),
+    )
+    .await
+    .expect("build lm")
+    .with_client(LMClient::Test(client))
+    .await
+    .expect("install test client");
+    configure(lm.clone(), ChatAdapter::new());
+    lm
+}
+
+#[derive(Signature, Clone, Debug, PartialEq)]
+struct RlmLoopSig {
+    #[input]
+    prompt: String,
+    #[output]
+    answer: String,
+}
+
+#[cfg_attr(miri, ignore = "MIRI has issues with tokio's I/O driver")]
+#[tokio::test]
+async fn rlm_recovers_from_empty_action_then_submits() {
+    let _lock = SETTINGS_LOCK.lock().await;
+    let lm = configure_test_lm(vec![
+        String::new(),
+        "SUBMIT(answer='recovered')".to_string(),
+    ])
+    .await;
+
+    let rlm = Rlm::<RlmLoopSig>::builder()
+        .runtime(Arc::new(PyO3Runtime))
+        .sub_lm(Arc::new(lm))
+        .max_iterations(3)
+        .enable_extraction_fallback(false)
+        .build();
+
+    let predicted = rlm
+        .call(RlmLoopSigInput {
+            prompt: "return recovered".to_string(),
+        })
+        .await
+        .expect("rlm call should recover and submit");
+
+    assert_eq!(predicted.answer, "recovered");
+    assert!(
+        predicted
+            .metadata()
+            .raw_response
+            .contains("SUBMIT(answer='recovered')")
+    );
+}
+
+#[cfg_attr(miri, ignore = "MIRI has issues with tokio's I/O driver")]
+#[tokio::test]
+async fn rlm_invalid_submit_retries_then_accepts_valid_submit() {
+    let _lock = SETTINGS_LOCK.lock().await;
+    let lm = configure_test_lm(vec![
+        "SUBMIT(answer=123)".to_string(),
+        "SUBMIT(answer='fixed')".to_string(),
+    ])
+    .await;
+
+    let rlm = Rlm::<RlmLoopSig>::builder()
+        .runtime(Arc::new(PyO3Runtime))
+        .sub_lm(Arc::new(lm))
+        .max_iterations(3)
+        .enable_extraction_fallback(false)
+        .build();
+
+    let predicted = rlm
+        .call(RlmLoopSigInput {
+            prompt: "return fixed".to_string(),
+        })
+        .await
+        .expect("rlm call should retry after invalid submit");
+
+    assert_eq!(predicted.answer, "fixed");
+    assert!(
+        predicted
+            .metadata()
+            .raw_response
+            .contains("SUBMIT(answer=123)")
+    );
+    assert!(
+        predicted
+            .metadata()
+            .raw_response
+            .contains("SUBMIT(answer='fixed')")
+    );
+}

--- a/crates/dspy-rs/tests/test_rlm_loop_integration.rs
+++ b/crates/dspy-rs/tests/test_rlm_loop_integration.rs
@@ -193,7 +193,7 @@ async fn rlm_feedback_carries_truncation_marker_with_configured_budget() {
         .last_request()
         .expect("expected request carrying truncated feedback");
     let request_debug = format!("{last_request:?}");
-    assert!(request_debug.contains("... [STDOUT TRUNCATED: Exceeded 10 char threshold]"));
+    assert!(request_debug.contains("[STDOUT TRUNCATED at 10 chars ("));
 }
 
 #[cfg_attr(miri, ignore = "MIRI has issues with tokio's I/O driver")]

--- a/crates/dspy-rs/tests/test_rlm_loop_integration.rs
+++ b/crates/dspy-rs/tests/test_rlm_loop_integration.rs
@@ -193,9 +193,7 @@ async fn rlm_feedback_carries_truncation_marker_with_configured_budget() {
         .last_request()
         .expect("expected request carrying truncated feedback");
     let request_debug = format!("{last_request:?}");
-    assert!(request_debug.contains(
-        "[output truncated at 10 chars - full content in variable. pass to llm_query() to analyze]"
-    ));
+    assert!(request_debug.contains("... [STDOUT TRUNCATED: Exceeded 10 char threshold]"));
 }
 
 #[cfg_attr(miri, ignore = "MIRI has issues with tokio's I/O driver")]
@@ -242,7 +240,7 @@ async fn rlm_sub_lm_tools_persist_state_and_decrement_budget_across_turns() {
         .expect("expected second-turn request with feedback");
     let request_debug = format!("{last_request:?}");
     assert!(
-        request_debug.contains("[env] 1 turn | 0 sub-LLM calls"),
+        request_debug.contains("Budget: 1 turn remaining | 0 sub-LLM calls remaining"),
         "second turn should see depleted sub-LM budget"
     );
 }

--- a/crates/dspy-rs/tests/test_rlm_loop_integration.rs
+++ b/crates/dspy-rs/tests/test_rlm_loop_integration.rs
@@ -31,6 +31,24 @@ async fn configure_test_lm(responses: Vec<String>) -> LM {
     lm
 }
 
+async fn configure_test_lm_with_client(responses: Vec<String>) -> (LM, TestCompletionModel) {
+    let client = TestCompletionModel::new(responses.into_iter().map(text_response));
+    let lm = temp_env::async_with_vars(
+        [("OPENAI_API_KEY", Some("test"))],
+        LM::builder()
+            .model("openai:gpt-4o-mini".to_string())
+            .temperature(0.0)
+            .build(),
+    )
+    .await
+    .expect("build lm")
+    .with_client(LMClient::Test(client.clone()))
+    .await
+    .expect("install test client");
+    configure(lm.clone(), ChatAdapter::new());
+    (lm, client)
+}
+
 #[derive(Signature, Clone, Debug, PartialEq)]
 struct RlmLoopSig {
     #[input]
@@ -109,4 +127,82 @@ async fn rlm_invalid_submit_retries_then_accepts_valid_submit() {
             .raw_response
             .contains("SUBMIT(answer='fixed')")
     );
+}
+
+#[cfg_attr(miri, ignore = "MIRI has issues with tokio's I/O driver")]
+#[tokio::test]
+async fn rlm_v3_demo_recovers_empty_then_python_error_then_finalization_submit() {
+    let _lock = SETTINGS_LOCK.lock().await;
+    let (lm, client) = configure_test_lm_with_client(vec![
+        String::new(),
+        "if True print('x')".to_string(),
+        "SUBMIT(answer='finalized')".to_string(),
+    ])
+    .await;
+
+    let rlm = Rlm::<RlmLoopSig>::builder()
+        .runtime(Arc::new(PyO3Runtime))
+        .sub_lm(Arc::new(lm))
+        .max_iterations(3)
+        .max_output_chars(500)
+        .enable_extraction_fallback(false)
+        .build();
+
+    let predicted = rlm
+        .call(RlmLoopSigInput {
+            prompt: "finalize with best answer".to_string(),
+        })
+        .await
+        .expect("rlm should recover and submit on finalization turn");
+    assert_eq!(predicted.answer, "finalized");
+
+    let last_request = client
+        .last_request()
+        .expect("expected final request to be captured");
+    let request_debug = format!("{last_request:?}");
+    assert!(
+        request_debug.contains("SyntaxError"),
+        "finalization turn should include prior python error feedback"
+    );
+    assert!(
+        request_debug.contains(
+            "This is your final turn. Call SUBMIT(answer=...) now with your best answer."
+        ),
+        "finalization directive should be present on last repair turn"
+    );
+}
+
+#[cfg_attr(miri, ignore = "MIRI has issues with tokio's I/O driver")]
+#[tokio::test]
+async fn rlm_feedback_carries_truncation_marker_with_configured_budget() {
+    let _lock = SETTINGS_LOCK.lock().await;
+    let (lm, client) = configure_test_lm_with_client(vec![
+        "print('abcdefghijklmnopqrstuvwxyz0123456789')".to_string(),
+        "SUBMIT(answer='done')".to_string(),
+    ])
+    .await;
+
+    let rlm = Rlm::<RlmLoopSig>::builder()
+        .runtime(Arc::new(PyO3Runtime))
+        .sub_lm(Arc::new(lm))
+        .max_iterations(2)
+        .max_output_chars(10)
+        .enable_extraction_fallback(false)
+        .build();
+
+    let predicted = rlm
+        .call(RlmLoopSigInput {
+            prompt: "test truncation".to_string(),
+        })
+        .await
+        .expect("rlm should truncate feedback and still submit");
+    assert_eq!(predicted.answer, "done");
+
+    let last_request = client
+        .last_request()
+        .expect("expected request carrying truncated feedback");
+    let request_debug = format!("{last_request:?}");
+    assert!(request_debug.contains(
+        "[output truncated at 10 chars - full content in variable. pass to llm_query() to analyze]"
+    ));
 }

--- a/crates/dspy-rs/tests/test_settings.rs
+++ b/crates/dspy-rs/tests/test_settings.rs
@@ -3,31 +3,27 @@ use dspy_rs::{ChatAdapter, LM, configure, get_lm};
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
 async fn test_settings() {
-    unsafe {
-        std::env::set_var("OPENAI_API_KEY", "test");
-    }
-    configure(
+    let lm1 = temp_env::async_with_vars(
+        [("OPENAI_API_KEY", Some("test"))],
         LM::builder()
             .model("openai:gpt-4o-mini".to_string())
-            .build()
-            .await
-            .unwrap(),
-        ChatAdapter {},
-    );
+            .build(),
+    )
+    .await
+    .unwrap();
+    configure(lm1, ChatAdapter {});
 
     let lm = get_lm();
     assert_eq!(lm.model, "openai:gpt-4o-mini");
 
-    configure(
-        LM::builder()
-            .model("openai:gpt-4o".to_string())
-            .build()
-            .await
-            .unwrap(),
-        ChatAdapter {},
-    );
+    let lm2 = temp_env::async_with_vars(
+        [("OPENAI_API_KEY", Some("test"))],
+        LM::builder().model("openai:gpt-4o".to_string()).build(),
+    )
+    .await
+    .unwrap();
+    configure(lm2, ChatAdapter {});
 
     let lm = get_lm();
-
     assert_eq!(lm.model, "openai:gpt-4o");
 }

--- a/crates/dspy-rs/tests/test_settings.rs
+++ b/crates/dspy-rs/tests/test_settings.rs
@@ -11,7 +11,7 @@ async fn test_settings() {
     )
     .await
     .unwrap();
-    configure(lm1, ChatAdapter {});
+    configure(lm1, ChatAdapter::new());
 
     let lm = get_lm();
     assert_eq!(lm.model, "openai:gpt-4o-mini");
@@ -22,7 +22,7 @@ async fn test_settings() {
     )
     .await
     .unwrap();
-    configure(lm2, ChatAdapter {});
+    configure(lm2, ChatAdapter::new());
 
     let lm = get_lm();
     assert_eq!(lm.model, "openai:gpt-4o");

--- a/crates/dspy-rs/tests/test_tool_call.rs
+++ b/crates/dspy-rs/tests/test_tool_call.rs
@@ -108,13 +108,10 @@ async fn test_tool_call_with_no_tools() {
     }
 
     let response = response.unwrap();
-    match response.output {
-        Message::Assistant { content } => {
-            // The response should contain some mention of 4
-            println!("Assistant response: {}", content);
-        }
-        _ => panic!("Expected assistant message"),
-    }
+    assert_eq!(response.output.role, dspy_rs::Role::Assistant);
+    let content = response.output.content();
+    // The response should contain some mention of 4
+    println!("Assistant response: {}", content);
 }
 
 #[tokio::test]
@@ -140,12 +137,9 @@ async fn test_tool_call_with_calculator() {
     // Call with the calculator tool
     let response = lm.call(chat, tools).await.unwrap();
 
-    match response.output {
-        Message::Assistant { content } => {
-            println!("Assistant response after tool use: {}", content);
-            // The response should mention the result (100) or that the tool was called
-            assert!(content.contains("100") || content.contains("Tool call"));
-        }
-        _ => panic!("Expected assistant message"),
-    }
+    assert_eq!(response.output.role, dspy_rs::Role::Assistant);
+    let content = response.output.content();
+    println!("Assistant response after tool use: {}", content);
+    // The response should mention the result (100) or that the tool was called
+    assert!(content.contains("100") || content.contains("Tool call"));
 }

--- a/crates/dspy-rs/tests/test_tool_call.rs
+++ b/crates/dspy-rs/tests/test_tool_call.rs
@@ -1,4 +1,4 @@
-use dspy_rs::{Chat, LM, Message};
+use dspy_rs::{Chat, LM, Message, ToolLoopMode};
 use rig::completion::ToolDefinition;
 use rig::tool::ToolDyn;
 use std::error::Error;
@@ -99,7 +99,7 @@ async fn test_tool_call_with_no_tools() {
     chat.push_message(Message::user("What is 2 + 2?"));
 
     // Call without tools
-    let response = lm.call(chat, vec![]).await;
+    let response = lm.call(chat, vec![], ToolLoopMode::Auto).await;
 
     // Should get a text response (or network error if no real API key)
     if let Err(e) = &response {
@@ -135,7 +135,7 @@ async fn test_tool_call_with_calculator() {
     let tools: Vec<Arc<dyn ToolDyn>> = vec![Arc::new(calculator)];
 
     // Call with the calculator tool
-    let response = lm.call(chat, tools).await.unwrap();
+    let response = lm.call(chat, tools, ToolLoopMode::Auto).await.unwrap();
 
     assert_eq!(response.output.role, dspy_rs::Role::Assistant);
     let content = response.output.content();

--- a/crates/dspy-rs/tests/test_typed_alias.rs
+++ b/crates/dspy-rs/tests/test_typed_alias.rs
@@ -14,7 +14,7 @@ struct AliasSignature {
 
 #[test]
 fn typed_alias_is_used_in_prompt_and_user_message() {
-    let adapter = ChatAdapter;
+    let adapter = ChatAdapter::new();
     let system = adapter
         .format_system_message_typed::<AliasSignature>()
         .expect("system message");
@@ -37,7 +37,7 @@ fn typed_alias_is_used_in_prompt_and_user_message() {
 
 #[test]
 fn typed_alias_parses_output_and_maps_to_rust_name() {
-    let adapter = ChatAdapter;
+    let adapter = ChatAdapter::new();
     let response = Message::assistant("[[ ## final_answer ## ]]\nHi\n\n[[ ## completed ## ]]");
     let (output, metas) = adapter
         .parse_response_typed::<AliasSignature>(&response)

--- a/crates/dspy-rs/tests/test_typed_prompt_format.rs
+++ b/crates/dspy-rs/tests/test_typed_prompt_format.rs
@@ -49,7 +49,7 @@ struct ComprehensiveSignature {
 }
 
 fn system_message() -> String {
-    let adapter = ChatAdapter;
+    let adapter = ChatAdapter::new();
     adapter
         .format_system_message_typed::<ComprehensiveSignature>()
         .expect("system message")

--- a/crates/dspy-rs/tests/typed_integration.rs
+++ b/crates/dspy-rs/tests/typed_integration.rs
@@ -23,19 +23,18 @@ fn text_response(text: impl Into<String>) -> AssistantContent {
 }
 
 async fn configure_test_lm(responses: Vec<String>) -> TestCompletionModel {
-    unsafe {
-        std::env::set_var("OPENAI_API_KEY", "test");
-    }
-
     let client = TestCompletionModel::new(responses.into_iter().map(text_response));
-    let lm = LM::builder()
-        .model("openai:gpt-4o-mini".to_string())
-        .build()
-        .await
-        .unwrap()
-        .with_client(LMClient::Test(client.clone()))
-        .await
-        .unwrap();
+    let lm = temp_env::async_with_vars(
+        [("OPENAI_API_KEY", Some("test"))],
+        LM::builder()
+            .model("openai:gpt-4o-mini".to_string())
+            .build(),
+    )
+    .await
+    .unwrap()
+    .with_client(LMClient::Test(client.clone()))
+    .await
+    .unwrap();
 
     configure(lm, ChatAdapter {});
 

--- a/crates/dspy-rs/tests/typed_integration.rs
+++ b/crates/dspy-rs/tests/typed_integration.rs
@@ -36,7 +36,7 @@ async fn configure_test_lm(responses: Vec<String>) -> TestCompletionModel {
     .await
     .unwrap();
 
-    configure(lm, ChatAdapter {});
+    configure(lm, ChatAdapter::new());
 
     client
 }

--- a/crates/dsrs-macros/Cargo.toml
+++ b/crates/dsrs-macros/Cargo.toml
@@ -13,6 +13,10 @@ license = "Apache-2.0"
 [lib]
 proc-macro = true
 
+[features]
+default = []
+rlm = []
+
 [dependencies]
 syn   = { version = "2", features = ["full"] }
 quote = "1"

--- a/crates/dsrs-macros/src/lib.rs
+++ b/crates/dsrs-macros/src/lib.rs
@@ -743,10 +743,34 @@ fn generate_rlm_input_impl(
         .map(|field| &field.ident)
         .collect();
     let field_types: Vec<_> = parsed.input_fields.iter().map(|field| &field.ty).collect();
-    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+    let (impl_generics, ty_generics, _where_clause) = generics.split_for_impl();
+    let py_bounds = field_types
+        .iter()
+        .map(|field_ty| {
+            quote! {
+                #field_ty: for<'py> #runtime::__macro_support::pyo3::conversion::IntoPyObject<'py>
+            }
+        })
+        .collect::<Vec<_>>();
+    let combined_where = match (&generics.where_clause, py_bounds.is_empty()) {
+        (Some(where_clause), false) => {
+            let existing = where_clause.predicates.iter();
+            quote! {
+                where
+                    #(#existing,)*
+                    #(#py_bounds),*
+            }
+        }
+        (Some(where_clause), true) => quote! { #where_clause },
+        (None, false) => quote! {
+            where
+                #(#py_bounds),*
+        },
+        (None, true) => quote! {},
+    };
 
     quote! {
-        impl #impl_generics #runtime::RlmInputFields for #input_name #ty_generics #where_clause {
+        impl #impl_generics #runtime::RlmInputFields for #input_name #ty_generics #combined_where {
             fn rlm_field_names(&self) -> &'static [&'static str] {
                 &[#(#field_names),*]
             }

--- a/crates/dsrs-macros/src/lib.rs
+++ b/crates/dsrs-macros/src/lib.rs
@@ -706,12 +706,14 @@ fn generate_signature_code(
     let name = &input.ident;
     let vis = &input.vis;
     let generics = &input.generics;
+    let input_name = format_ident!("{}Input", name);
 
     let helper_structs = generate_helper_structs(name, generics, parsed, vis, runtime)?;
     let input_metadata = generate_field_metadata(name, &parsed.input_fields, "INPUT", runtime)?;
     let output_metadata = generate_field_metadata(name, &parsed.output_fields, "OUTPUT", runtime)?;
     let baml_delegation = generate_baml_delegation(name, generics, parsed, runtime);
     let signature_impl = generate_signature_impl(name, generics, parsed, runtime);
+    let rlm_input_impl = generate_rlm_input_impl(&input_name, generics, parsed, runtime);
 
     Ok(quote! {
         #helper_structs
@@ -719,7 +721,65 @@ fn generate_signature_code(
         #output_metadata
         #baml_delegation
         #signature_impl
+        #rlm_input_impl
     })
+}
+
+#[cfg(feature = "rlm")]
+fn generate_rlm_input_impl(
+    input_name: &Ident,
+    generics: &syn::Generics,
+    parsed: &ParsedSignature,
+    runtime: &syn::Path,
+) -> proc_macro2::TokenStream {
+    let field_names: Vec<_> = parsed
+        .input_fields
+        .iter()
+        .map(|field| LitStr::new(&field.ident.to_string(), proc_macro2::Span::call_site()))
+        .collect();
+    let field_idents: Vec<_> = parsed.input_fields.iter().map(|field| &field.ident).collect();
+    let field_types: Vec<_> = parsed.input_fields.iter().map(|field| &field.ty).collect();
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    quote! {
+        impl #impl_generics #runtime::RlmInputFields for #input_name #ty_generics #where_clause {
+            fn rlm_field_names(&self) -> &'static [&'static str] {
+                &[#(#field_names),*]
+            }
+
+            fn rlm_py_fields(
+                &self,
+                py: #runtime::__macro_support::pyo3::Python<'_>,
+            ) -> #runtime::__macro_support::pyo3::PyResult<Vec<(String, #runtime::__macro_support::pyo3::Py<#runtime::__macro_support::pyo3::PyAny>)>> {
+                Ok(vec![
+                    #(
+                        (
+                            #field_names.to_string(),
+                            #runtime::__macro_support::pyo3::IntoPyObjectExt::into_py_any(self.#field_idents.clone(), py).map_err(|err| {
+                                #runtime::__macro_support::pyo3::exceptions::PyTypeError::new_err(format!(
+                                    "RLM input field `{}` on `{}` (Rust type `{}`) could not convert to a Python object: {}. If this is a custom struct, ensure it is annotated with #[rlm_type].",
+                                    #field_names,
+                                    stringify!(#input_name),
+                                    ::std::any::type_name::<#field_types>(),
+                                    err
+                                ))
+                            })?,
+                        )
+                    ),*
+                ])
+            }
+        }
+    }
+}
+
+#[cfg(not(feature = "rlm"))]
+fn generate_rlm_input_impl(
+    _input_name: &Ident,
+    _generics: &syn::Generics,
+    _parsed: &ParsedSignature,
+    _runtime: &syn::Path,
+) -> proc_macro2::TokenStream {
+    proc_macro2::TokenStream::new()
 }
 
 fn generate_helper_structs(

--- a/crates/dsrs-macros/src/lib.rs
+++ b/crates/dsrs-macros/src/lib.rs
@@ -737,7 +737,11 @@ fn generate_rlm_input_impl(
         .iter()
         .map(|field| LitStr::new(&field.ident.to_string(), proc_macro2::Span::call_site()))
         .collect();
-    let field_idents: Vec<_> = parsed.input_fields.iter().map(|field| &field.ident).collect();
+    let field_idents: Vec<_> = parsed
+        .input_fields
+        .iter()
+        .map(|field| &field.ident)
+        .collect();
     let field_types: Vec<_> = parsed.input_fields.iter().map(|field| &field.ty).collect();
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 

--- a/crates/rlm-derive/Cargo.toml
+++ b/crates/rlm-derive/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "rlm-derive"
+version = "0.1.0"
+edition = "2024"
+license = "Apache-2.0"
+publish = false
+description = "Proc macros for RLM native typed objects"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "2", features = ["full", "parsing", "extra-traits"] }
+proc-macro-crate = "3.2"
+
+[dev-dependencies]
+dspy-rs = { path = "../dspy-rs" }
+facet = { git = "https://github.com/darinkishore/facet", rev = "cc8613c97cd1ec03e63659db34a947989b45c8a5", default-features = false, features = ["std"] }
+trybuild = "1.0.110"

--- a/crates/rlm-derive/src/lib.rs
+++ b/crates/rlm-derive/src/lib.rs
@@ -1,0 +1,20 @@
+use proc_macro::TokenStream;
+use syn::parse_macro_input;
+
+mod rlm_attr;
+mod rlm_type;
+mod runtime_path;
+
+#[proc_macro_attribute]
+pub fn rlm_type(attr: TokenStream, item: TokenStream) -> TokenStream {
+    rlm_attr::expand(attr, item)
+}
+
+#[proc_macro_derive(RlmType, attributes(rlm))]
+pub fn derive_rlm_type(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as syn::DeriveInput);
+    match rlm_type::derive(input) {
+        Ok(tokens) => tokens.into(),
+        Err(err) => err.to_compile_error().into(),
+    }
+}

--- a/crates/rlm-derive/src/rlm_attr.rs
+++ b/crates/rlm-derive/src/rlm_attr.rs
@@ -6,14 +6,24 @@ use syn::{Data, DeriveInput, Fields, Meta, parse_macro_input};
 use crate::runtime_path::{ensure_facet_resolvable, resolve_dspy_rs_path};
 
 pub(crate) fn expand(attr: TokenStream, item: TokenStream) -> TokenStream {
-    let attr_args = parse_macro_input!(attr with syn::punctuated::Punctuated::<Meta, syn::Token![,]>::parse_terminated);
-    if !attr_args.is_empty() {
-        return syn::Error::new_spanned(
-            quote!(#attr_args),
-            "rlm_type does not accept arguments in V1",
-        )
-        .to_compile_error()
-        .into();
+    let attr_args = parse_macro_input!(
+        attr with syn::punctuated::Punctuated::<Meta, syn::Token![,]>::parse_terminated
+    );
+    let mut skip_repr = false;
+    for meta in attr_args {
+        match meta {
+            Meta::Path(path) if path.is_ident("skip_repr") => {
+                skip_repr = true;
+            }
+            other => {
+                return syn::Error::new_spanned(
+                    quote!(#other),
+                    "unsupported #[rlm_type(...)] key; supported keys in V1: skip_repr",
+                )
+                .to_compile_error()
+                .into();
+            }
+        }
     }
 
     let mut input = parse_macro_input!(item as DeriveInput);
@@ -44,6 +54,9 @@ pub(crate) fn expand(attr: TokenStream, item: TokenStream) -> TokenStream {
         .push(syn::parse_quote!(#[#runtime::__macro_support::pyo3::pyclass(crate = #pyo3_crate)]));
     input.attrs.push(syn::parse_quote!(#[#runtime::BamlType]));
     merge_derive(&mut input.attrs, &[syn::parse_quote!(#runtime::RlmType)]);
+    if skip_repr {
+        input.attrs.push(syn::parse_quote!(#[rlm(skip_repr)]));
+    }
 
     TokenStream::from(quote! { #input })
 }

--- a/crates/rlm-derive/src/rlm_attr.rs
+++ b/crates/rlm-derive/src/rlm_attr.rs
@@ -1,0 +1,136 @@
+use proc_macro::TokenStream;
+use proc_macro2::Span;
+use quote::quote;
+use syn::{Data, DeriveInput, Fields, Meta, parse_macro_input};
+
+use crate::runtime_path::{ensure_facet_resolvable, resolve_dspy_rs_path};
+
+pub(crate) fn expand(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let attr_args = parse_macro_input!(attr with syn::punctuated::Punctuated::<Meta, syn::Token![,]>::parse_terminated);
+    if !attr_args.is_empty() {
+        return syn::Error::new_spanned(
+            quote!(#attr_args),
+            "rlm_type does not accept arguments in V1",
+        )
+        .to_compile_error()
+        .into();
+    }
+
+    let mut input = parse_macro_input!(item as DeriveInput);
+    if let Err(err) = validate_input(&input) {
+        return err.to_compile_error().into();
+    }
+    if let Err(err) = ensure_facet_resolvable() {
+        return err.to_compile_error().into();
+    }
+
+    let runtime = match resolve_dspy_rs_path() {
+        Ok(path) => path,
+        Err(err) => return err.to_compile_error().into(),
+    };
+    let pyo3_crate = pyo3_crate_lit(&runtime);
+
+    if has_baml_type_attr(&input.attrs) {
+        return syn::Error::new_spanned(
+            &input.ident,
+            "#[rlm_type] subsumes #[BamlType]; remove #[BamlType] and keep only #[rlm_type]",
+        )
+        .to_compile_error()
+        .into();
+    }
+
+    input
+        .attrs
+        .push(syn::parse_quote!(#[#runtime::__macro_support::pyo3::pyclass(crate = #pyo3_crate)]));
+    input.attrs.push(syn::parse_quote!(#[#runtime::BamlType]));
+    merge_derive(&mut input.attrs, &[syn::parse_quote!(#runtime::RlmType)]);
+
+    TokenStream::from(quote! { #input })
+}
+
+fn validate_input(input: &DeriveInput) -> syn::Result<()> {
+    if !input.generics.params.is_empty() {
+        return Err(syn::Error::new_spanned(
+            &input.ident,
+            "rlm_type currently supports named structs only (no generics or lifetimes)",
+        ));
+    }
+
+    match &input.data {
+        Data::Struct(data) => match &data.fields {
+            Fields::Named(_) => Ok(()),
+            _ => Err(syn::Error::new_spanned(
+                &input.ident,
+                "rlm_type currently supports named structs only",
+            )),
+        },
+        _ => Err(syn::Error::new_spanned(
+            &input.ident,
+            "rlm_type currently supports named structs only",
+        )),
+    }
+}
+
+fn has_baml_type_attr(attrs: &[syn::Attribute]) -> bool {
+    attrs.iter().any(|attr| {
+        let path = attr.path();
+        path.is_ident("BamlType")
+            || path
+                .segments
+                .last()
+                .map(|s| s.ident == "BamlType")
+                .unwrap_or(false)
+    })
+}
+
+fn merge_derive(attrs: &mut Vec<syn::Attribute>, required: &[syn::Path]) {
+    for attr in attrs.iter_mut() {
+        if !attr.path().is_ident("derive") {
+            continue;
+        }
+
+        let mut derives: syn::punctuated::Punctuated<syn::Path, syn::Token![,]> = attr
+            .parse_args_with(syn::punctuated::Punctuated::parse_terminated)
+            .unwrap_or_default();
+
+        for required_path in required {
+            if !derives
+                .iter()
+                .any(|existing| paths_eq(existing, required_path))
+            {
+                derives.push(required_path.clone());
+            }
+        }
+
+        *attr = syn::parse_quote!(#[derive(#derives)]);
+        return;
+    }
+
+    attrs.push(syn::parse_quote!(#[derive(#(#required),*)]));
+}
+
+fn paths_eq(left: &syn::Path, right: &syn::Path) -> bool {
+    if left
+        .segments
+        .iter()
+        .map(|s| &s.ident)
+        .eq(right.segments.iter().map(|s| &s.ident))
+    {
+        return true;
+    }
+
+    left.segments.last().map(|s| &s.ident) == right.segments.last().map(|s| &s.ident)
+}
+
+fn pyo3_crate_lit(runtime: &syn::Path) -> syn::LitStr {
+    let runtime_str = runtime
+        .segments
+        .iter()
+        .map(|segment| segment.ident.to_string())
+        .collect::<Vec<_>>()
+        .join("::");
+    syn::LitStr::new(
+        &format!("{runtime_str}::__macro_support::pyo3"),
+        Span::call_site(),
+    )
+}

--- a/crates/rlm-derive/src/rlm_type.rs
+++ b/crates/rlm-derive/src/rlm_type.rs
@@ -1,0 +1,539 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{Data, DeriveInput, Expr, ExprLit, Fields, Lit, Meta, Type};
+
+use crate::runtime_path::resolve_dspy_rs_path;
+
+pub(crate) fn derive(input: DeriveInput) -> syn::Result<TokenStream> {
+    validate_struct_surface(&input)?;
+    ensure_pyclass(&input)?;
+
+    let runtime = resolve_dspy_rs_path()?;
+    let pyo3_crate = pyo3_crate_lit(&runtime);
+    let options = parse_container_options(&input.attrs)?;
+    let fields = parse_fields(&input)?;
+    validate_iter_index_fields(&input.ident, &fields, &options)?;
+
+    let struct_name = &input.ident;
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+
+    let helper_impl = generate_helper_impl(
+        struct_name,
+        &impl_generics,
+        &ty_generics,
+        where_clause,
+        &runtime,
+    );
+    let getter_methods = fields
+        .iter()
+        .filter(|f| !f.skip_python)
+        .map(generate_getter_method)
+        .collect::<Vec<_>>();
+    let repr_method = generate_repr_method(&runtime);
+    let baml_method = generate_baml_method(&runtime);
+    let mut extra_methods = Vec::new();
+    if let Some(iter_field) = options.iter_field {
+        extra_methods.push(generate_len_method(&runtime, &iter_field));
+        extra_methods.push(generate_iter_method(&runtime, &iter_field));
+    }
+    if let Some(index_field) = options.index_field {
+        extra_methods.push(generate_getitem_method(&runtime, &index_field));
+    }
+
+    Ok(quote! {
+        #helper_impl
+
+        #[#runtime::__macro_support::pyo3::pymethods(crate = #pyo3_crate)]
+        impl #impl_generics #struct_name #ty_generics #where_clause {
+            #(#getter_methods)*
+            #repr_method
+            #(#extra_methods)*
+            #baml_method
+        }
+    })
+}
+
+#[derive(Clone)]
+struct FieldSpec {
+    ident: syn::Ident,
+    ty: Type,
+    doc: String,
+    skip_python: bool,
+}
+
+#[derive(Default)]
+struct ContainerOptions {
+    iter_field: Option<String>,
+    index_field: Option<String>,
+}
+
+fn validate_struct_surface(input: &DeriveInput) -> syn::Result<()> {
+    if !input.generics.params.is_empty() {
+        return Err(syn::Error::new_spanned(
+            &input.ident,
+            "RlmType currently supports named structs only (no generics or lifetimes)",
+        ));
+    }
+
+    match &input.data {
+        Data::Struct(data) => match &data.fields {
+            Fields::Named(_) => Ok(()),
+            _ => Err(syn::Error::new_spanned(
+                &input.ident,
+                "RlmType currently supports named structs only",
+            )),
+        },
+        _ => Err(syn::Error::new_spanned(
+            &input.ident,
+            "RlmType currently supports named structs only",
+        )),
+    }
+}
+
+fn ensure_pyclass(input: &DeriveInput) -> syn::Result<()> {
+    if has_pyclass_attr(&input.attrs) {
+        Ok(())
+    } else {
+        Err(syn::Error::new_spanned(
+            &input.ident,
+            "RlmType requires a #[pyclass] attribute; use #[rlm_type] instead of deriving RlmType directly",
+        ))
+    }
+}
+
+fn has_pyclass_attr(attrs: &[syn::Attribute]) -> bool {
+    attrs.iter().any(|attr| {
+        let path = attr.path();
+        path.is_ident("pyclass")
+            || path
+                .segments
+                .last()
+                .map(|segment| segment.ident == "pyclass")
+                .unwrap_or(false)
+    })
+}
+
+fn parse_container_options(attrs: &[syn::Attribute]) -> syn::Result<ContainerOptions> {
+    let mut out = ContainerOptions::default();
+
+    for attr in attrs {
+        if !attr.path().is_ident("rlm") {
+            continue;
+        }
+
+        attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("iter") {
+                let lit: syn::LitStr = meta.value()?.parse()?;
+                out.iter_field = Some(lit.value());
+                return Ok(());
+            }
+            if meta.path.is_ident("index") {
+                let lit: syn::LitStr = meta.value()?.parse()?;
+                out.index_field = Some(lit.value());
+                return Ok(());
+            }
+
+            Err(meta.error("unsupported #[rlm(...)] key for structs; supported keys in V1 are `iter` and `index`"))
+        })?;
+    }
+
+    Ok(out)
+}
+
+fn parse_fields(input: &DeriveInput) -> syn::Result<Vec<FieldSpec>> {
+    let Data::Struct(data) = &input.data else {
+        return Err(syn::Error::new_spanned(
+            &input.ident,
+            "RlmType currently supports named structs only",
+        ));
+    };
+    let Fields::Named(named) = &data.fields else {
+        return Err(syn::Error::new_spanned(
+            &input.ident,
+            "RlmType currently supports named structs only",
+        ));
+    };
+
+    let mut out = Vec::with_capacity(named.named.len());
+    for field in &named.named {
+        let ident = field
+            .ident
+            .clone()
+            .ok_or_else(|| syn::Error::new_spanned(field, "RlmType fields must be named"))?;
+        let mut doc = doc_from_attrs(&field.attrs);
+        let mut skip_python = false;
+
+        for attr in &field.attrs {
+            if !attr.path().is_ident("rlm") {
+                continue;
+            }
+            attr.parse_nested_meta(|meta| {
+                if meta.path.is_ident("skip_python") {
+                    skip_python = true;
+                    return Ok(());
+                }
+                if meta.path.is_ident("desc") {
+                    let lit: syn::LitStr = meta.value()?.parse()?;
+                    doc = lit.value();
+                    return Ok(());
+                }
+                Err(meta.error(
+                    "unsupported #[rlm(...)] key for fields; supported keys in V1 are `skip_python` and `desc`",
+                ))
+            })?;
+        }
+
+        out.push(FieldSpec {
+            ident,
+            ty: field.ty.clone(),
+            doc,
+            skip_python,
+        });
+    }
+
+    Ok(out)
+}
+
+fn validate_iter_index_fields(
+    struct_name: &syn::Ident,
+    fields: &[FieldSpec],
+    options: &ContainerOptions,
+) -> syn::Result<()> {
+    let has_field = |name: &str| fields.iter().any(|f| f.ident == name);
+
+    if let Some(iter) = &options.iter_field
+        && !has_field(iter)
+    {
+        return Err(syn::Error::new_spanned(
+            struct_name,
+            format!("iter field `{iter}` not found on `{struct_name}`"),
+        ));
+    }
+    if let Some(index) = &options.index_field
+        && !has_field(index)
+    {
+        return Err(syn::Error::new_spanned(
+            struct_name,
+            format!("index field `{index}` not found on `{struct_name}`"),
+        ));
+    }
+    Ok(())
+}
+
+fn doc_from_attrs(attrs: &[syn::Attribute]) -> String {
+    let mut docs = Vec::new();
+    for attr in attrs {
+        if !attr.path().is_ident("doc") {
+            continue;
+        }
+        if let Meta::NameValue(meta) = &attr.meta
+            && let Expr::Lit(ExprLit {
+                lit: Lit::Str(lit), ..
+            }) = &meta.value
+        {
+            docs.push(lit.value().trim().to_string());
+        }
+    }
+    docs.join("\n")
+}
+
+fn generate_getter_method(field: &FieldSpec) -> TokenStream {
+    let name = &field.ident;
+    let ty = &field.ty;
+    let doc = if field.doc.trim().is_empty() {
+        format!("Get `{name}`.")
+    } else {
+        field.doc.trim().to_string()
+    };
+
+    let (ret_ty, body) = getter_strategy(ty, name);
+    quote! {
+        #[doc = #doc]
+        #[getter]
+        fn #name(&self) -> #ret_ty {
+            #body
+        }
+    }
+}
+
+fn getter_strategy(ty: &Type, field_name: &syn::Ident) -> (TokenStream, TokenStream) {
+    if is_string_type(ty) {
+        (quote! { &str }, quote! { self.#field_name.as_str() })
+    } else if is_copy_primitive(ty) {
+        (quote! { #ty }, quote! { self.#field_name })
+    } else {
+        (quote! { #ty }, quote! { self.#field_name.clone() })
+    }
+}
+
+fn is_string_type(ty: &Type) -> bool {
+    if let Type::Path(type_path) = ty
+        && let Some(segment) = type_path.path.segments.last()
+    {
+        return segment.ident == "String";
+    }
+    false
+}
+
+fn is_copy_primitive(ty: &Type) -> bool {
+    if let Type::Path(type_path) = ty
+        && let Some(segment) = type_path.path.segments.last()
+    {
+        return matches!(
+            segment.ident.to_string().as_str(),
+            "bool"
+                | "i8"
+                | "i16"
+                | "i32"
+                | "i64"
+                | "i128"
+                | "isize"
+                | "u8"
+                | "u16"
+                | "u32"
+                | "u64"
+                | "u128"
+                | "usize"
+                | "f32"
+                | "f64"
+                | "char"
+        );
+    }
+    false
+}
+
+fn generate_helper_impl(
+    struct_name: &syn::Ident,
+    impl_generics: &syn::ImplGenerics<'_>,
+    ty_generics: &syn::TypeGenerics<'_>,
+    where_clause: Option<&syn::WhereClause>,
+    runtime: &syn::Path,
+) -> TokenStream {
+    quote! {
+        impl #impl_generics #struct_name #ty_generics #where_clause {
+            fn __rlm_truncate_chars(input: &str, max_chars: usize) -> String {
+                let mut out = String::new();
+                let mut iter = input.chars();
+                for _ in 0..max_chars {
+                    if let Some(ch) = iter.next() {
+                        out.push(ch);
+                    } else {
+                        return out;
+                    }
+                }
+                if iter.next().is_some() {
+                    out.push_str("...");
+                }
+                out
+            }
+
+            fn __rlm_render_repr_value(value: &#runtime::BamlValue, depth: usize) -> String {
+                const MAX_ITEMS: usize = 3;
+                const MAX_STRING_CHARS: usize = 200;
+                match value {
+                    #runtime::BamlValue::String(s) => {
+                        format!("\"{}\"", Self::__rlm_truncate_chars(s, MAX_STRING_CHARS))
+                    }
+                    #runtime::BamlValue::Int(v) => v.to_string(),
+                    #runtime::BamlValue::Float(v) => v.to_string(),
+                    #runtime::BamlValue::Bool(v) => v.to_string(),
+                    #runtime::BamlValue::Null => "None".to_string(),
+                    #runtime::BamlValue::Enum(name, variant) => format!("{name}.{variant}"),
+                    #runtime::BamlValue::Media(_) => "<media>".to_string(),
+                    #runtime::BamlValue::List(items) => {
+                        let mut rendered = items
+                            .iter()
+                            .take(MAX_ITEMS)
+                            .map(|item| Self::__rlm_render_repr_value(item, depth + 1))
+                            .collect::<Vec<_>>();
+                        if items.len() > MAX_ITEMS {
+                            rendered.push(format!("... ({} total)", items.len()));
+                        }
+                        format!("[{}]", rendered.join(", "))
+                    }
+                    #runtime::BamlValue::Map(fields) => {
+                        let mut rendered = fields
+                            .iter()
+                            .take(MAX_ITEMS)
+                            .map(|(k, v)| format!("{k}={}", Self::__rlm_render_repr_value(v, depth + 1)))
+                            .collect::<Vec<_>>();
+                        if fields.len() > MAX_ITEMS {
+                            rendered.push(format!("... ({} total)", fields.len()));
+                        }
+                        if depth > 0 {
+                            format!("Map({})", rendered.join(", "))
+                        } else {
+                            format!("{{{}}}", rendered.join(", "))
+                        }
+                    }
+                    #runtime::BamlValue::Class(name, fields) => {
+                        let mut rendered = fields
+                            .iter()
+                            .take(MAX_ITEMS)
+                            .map(|(k, v)| format!("{k}={}", Self::__rlm_render_repr_value(v, depth + 1)))
+                            .collect::<Vec<_>>();
+                        if fields.len() > MAX_ITEMS {
+                            rendered.push(format!("... ({} total)", fields.len()));
+                        }
+                        if depth > 0 {
+                            format!("{name}({})", rendered.join(", "))
+                        } else {
+                            format!("{}({})", stringify!(#struct_name), rendered.join(", "))
+                        }
+                    }
+                }
+            }
+
+            fn __rlm_baml_to_py(
+                py: #runtime::__macro_support::pyo3::Python<'_>,
+                value: &#runtime::BamlValue,
+            ) -> #runtime::__macro_support::pyo3::PyResult<#runtime::__macro_support::pyo3::Py<#runtime::__macro_support::pyo3::PyAny>> {
+                use #runtime::__macro_support::pyo3::IntoPyObjectExt;
+                use #runtime::__macro_support::pyo3::types::{PyAnyMethods, PyDictMethods, PyListMethods};
+
+                match value {
+                    #runtime::BamlValue::String(v) => v.clone().into_py_any(py),
+                    #runtime::BamlValue::Int(v) => v.into_py_any(py),
+                    #runtime::BamlValue::Float(v) => v.into_py_any(py),
+                    #runtime::BamlValue::Bool(v) => v.into_py_any(py),
+                    #runtime::BamlValue::Null => Ok(py.None()),
+                    #runtime::BamlValue::Enum(_, variant) => variant.clone().into_py_any(py),
+                    #runtime::BamlValue::List(items) => {
+                        let list = #runtime::__macro_support::pyo3::types::PyList::empty(py);
+                        for item in items {
+                            list.append(Self::__rlm_baml_to_py(py, item)?)?;
+                        }
+                        Ok(list.into_any().unbind())
+                    }
+                    #runtime::BamlValue::Map(map) | #runtime::BamlValue::Class(_, map) => {
+                        let dict = #runtime::__macro_support::pyo3::types::PyDict::new(py);
+                        for (key, item) in map.iter() {
+                            dict.set_item(key, Self::__rlm_baml_to_py(py, item)?)?;
+                        }
+                        Ok(dict.into_any().unbind())
+                    }
+                    #runtime::BamlValue::Media(_) => Err(#runtime::__macro_support::pyo3::exceptions::PyTypeError::new_err(
+                        "Media values are not supported in rlm_type::__baml__",
+                    )),
+                }
+            }
+
+            fn __rlm_list_field<'a>(
+                value: &'a #runtime::BamlValue,
+                field_name: &str,
+            ) -> #runtime::__macro_support::pyo3::PyResult<&'a Vec<#runtime::BamlValue>> {
+                let fields = match value {
+                    #runtime::BamlValue::Class(_, fields) | #runtime::BamlValue::Map(fields) => fields,
+                    _ => {
+                        return Err(#runtime::__macro_support::pyo3::exceptions::PyTypeError::new_err(
+                            "expected object-like value for list access",
+                        ))
+                    }
+                };
+                let Some(field_value) = fields.get(field_name) else {
+                    return Err(#runtime::__macro_support::pyo3::exceptions::PyKeyError::new_err(format!(
+                        "missing field `{field_name}`"
+                    )));
+                };
+                match field_value {
+                    #runtime::BamlValue::List(items) => Ok(items),
+                    _ => Err(#runtime::__macro_support::pyo3::exceptions::PyTypeError::new_err(format!(
+                        "field `{field_name}` is not a list"
+                    ))),
+                }
+            }
+        }
+    }
+}
+
+fn generate_repr_method(runtime: &syn::Path) -> TokenStream {
+    quote! {
+        #[doc = "Compact model-safe representation of this object."]
+        fn __repr__(&self) -> String {
+            const MAX_TOTAL_CHARS: usize = 500;
+            let value = <Self as #runtime::BamlType>::to_baml_value(self);
+            let raw = Self::__rlm_render_repr_value(&value, 0);
+            Self::__rlm_truncate_chars(&raw, MAX_TOTAL_CHARS)
+        }
+    }
+}
+
+fn generate_baml_method(runtime: &syn::Path) -> TokenStream {
+    quote! {
+        #[doc = "Convert this object to a dict/list/scalar representation for serialization or delegation."]
+        #[pyo3(text_signature = "() -> dict")]
+        fn __baml__(
+            &self,
+            py: #runtime::__macro_support::pyo3::Python<'_>,
+        ) -> #runtime::__macro_support::pyo3::PyResult<#runtime::__macro_support::pyo3::Py<#runtime::__macro_support::pyo3::PyAny>> {
+            let value = <Self as #runtime::BamlType>::to_baml_value(self);
+            Self::__rlm_baml_to_py(py, &value)
+        }
+    }
+}
+
+fn generate_len_method(runtime: &syn::Path, field_name: &str) -> TokenStream {
+    quote! {
+        #[doc = "Return the number of elements in the configured collection field."]
+        fn __len__(&self) -> #runtime::__macro_support::pyo3::PyResult<usize> {
+            let value = <Self as #runtime::BamlType>::to_baml_value(self);
+            Ok(Self::__rlm_list_field(&value, #field_name)?.len())
+        }
+    }
+}
+
+fn generate_iter_method(runtime: &syn::Path, field_name: &str) -> TokenStream {
+    quote! {
+        #[doc = "Iterate over elements in the configured collection field."]
+        fn __iter__(
+            &self,
+            py: #runtime::__macro_support::pyo3::Python<'_>,
+        ) -> #runtime::__macro_support::pyo3::PyResult<#runtime::__macro_support::pyo3::Py<#runtime::__macro_support::pyo3::PyAny>> {
+            use #runtime::__macro_support::pyo3::types::{PyAnyMethods, PyListMethods};
+
+            let value = <Self as #runtime::BamlType>::to_baml_value(self);
+            let items = Self::__rlm_list_field(&value, #field_name)?;
+            let list = #runtime::__macro_support::pyo3::types::PyList::empty(py);
+            for item in items {
+                list.append(Self::__rlm_baml_to_py(py, item)?)?;
+            }
+            let iter = list.into_any().call_method0("__iter__")?;
+            Ok(iter.unbind())
+        }
+    }
+}
+
+fn generate_getitem_method(runtime: &syn::Path, field_name: &str) -> TokenStream {
+    quote! {
+        #[doc = "Index into the configured collection field. Supports negative indexing."]
+        fn __getitem__(
+            &self,
+            py: #runtime::__macro_support::pyo3::Python<'_>,
+            index: isize,
+        ) -> #runtime::__macro_support::pyo3::PyResult<#runtime::__macro_support::pyo3::Py<#runtime::__macro_support::pyo3::PyAny>> {
+            let value = <Self as #runtime::BamlType>::to_baml_value(self);
+            let items = Self::__rlm_list_field(&value, #field_name)?;
+
+            let len = items.len() as isize;
+            let normalized = if index < 0 { len + index } else { index };
+            if normalized < 0 || normalized >= len {
+                return Err(#runtime::__macro_support::pyo3::exceptions::PyIndexError::new_err("index out of range"));
+            }
+
+            Self::__rlm_baml_to_py(py, &items[normalized as usize])
+        }
+    }
+}
+
+fn pyo3_crate_lit(runtime: &syn::Path) -> syn::LitStr {
+    let runtime_str = runtime
+        .segments
+        .iter()
+        .map(|segment| segment.ident.to_string())
+        .collect::<Vec<_>>()
+        .join("::");
+    syn::LitStr::new(
+        &format!("{runtime_str}::__macro_support::pyo3"),
+        proc_macro2::Span::call_site(),
+    )
+}

--- a/crates/rlm-derive/src/rlm_type.rs
+++ b/crates/rlm-derive/src/rlm_type.rs
@@ -29,7 +29,7 @@ pub(crate) fn derive(input: DeriveInput) -> syn::Result<TokenStream> {
         .filter(|f| !f.skip_python)
         .map(generate_getter_method)
         .collect::<Vec<_>>();
-    let repr_method = generate_repr_method(&runtime);
+    let repr_method = (!options.skip_repr).then(|| generate_repr_method(&runtime));
     let baml_method = generate_baml_method(&runtime);
     let mut extra_methods = Vec::new();
     if let Some(iter_field) = options.iter_field {
@@ -65,6 +65,7 @@ struct FieldSpec {
 struct ContainerOptions {
     iter_field: Option<String>,
     index_field: Option<String>,
+    skip_repr: bool,
 }
 
 fn validate_struct_surface(input: &DeriveInput) -> syn::Result<()> {
@@ -132,8 +133,13 @@ fn parse_container_options(attrs: &[syn::Attribute]) -> syn::Result<ContainerOpt
                 out.index_field = Some(lit.value());
                 return Ok(());
             }
-
-            Err(meta.error("unsupported #[rlm(...)] key for structs; supported keys in V1 are `iter` and `index`"))
+            if meta.path.is_ident("skip_repr") {
+                out.skip_repr = true;
+                return Ok(());
+            }
+            Err(meta.error(
+                "unsupported #[rlm(...)] key for structs; supported keys in V1 are `iter`, `index`, and `skip_repr`",
+            ))
         })?;
     }
 

--- a/crates/rlm-derive/src/runtime_path.rs
+++ b/crates/rlm-derive/src/runtime_path.rs
@@ -1,0 +1,27 @@
+use proc_macro_crate::{FoundCrate, crate_name};
+use proc_macro2::Span;
+use syn::Path;
+
+pub(crate) fn resolve_dspy_rs_path() -> syn::Result<Path> {
+    match crate_name("dspy-rs") {
+        Ok(FoundCrate::Itself) => Ok(syn::parse_quote!(::dspy_rs)),
+        Ok(FoundCrate::Name(name)) => {
+            let ident = syn::Ident::new(&name.replace('-', "_"), Span::call_site());
+            Ok(syn::parse_quote!(::#ident))
+        }
+        Err(_) => Err(syn::Error::new(
+            Span::call_site(),
+            "could not resolve `dspy-rs`; add it as a dependency (renamed dependencies are supported)",
+        )),
+    }
+}
+
+pub(crate) fn ensure_facet_resolvable() -> syn::Result<()> {
+    match crate_name("facet") {
+        Ok(_) => Ok(()),
+        Err(_) => Err(syn::Error::new(
+            Span::call_site(),
+            "rlm_type requires `facet` to be resolvable; add `facet` as a dependency or use a dspy-rs workspace crate that already depends on facet",
+        )),
+    }
+}

--- a/crates/rlm-derive/tests/ui.rs
+++ b/crates/rlm-derive/tests/ui.rs
@@ -1,0 +1,5 @@
+#[test]
+fn ui() {
+    let tests = trybuild::TestCases::new();
+    tests.compile_fail("tests/ui/*.rs");
+}

--- a/crates/rlm-derive/tests/ui/enum_not_supported.rs
+++ b/crates/rlm-derive/tests/ui/enum_not_supported.rs
@@ -1,0 +1,8 @@
+use rlm_derive::rlm_type;
+
+#[rlm_type]
+enum BadEnum {
+    A,
+}
+
+fn main() {}

--- a/crates/rlm-derive/tests/ui/enum_not_supported.stderr
+++ b/crates/rlm-derive/tests/ui/enum_not_supported.stderr
@@ -1,0 +1,5 @@
+error: rlm_type currently supports named structs only
+ --> tests/ui/enum_not_supported.rs:4:6
+  |
+4 | enum BadEnum {
+  |      ^^^^^^^

--- a/crates/rlm-derive/tests/ui/generics_not_supported.rs
+++ b/crates/rlm-derive/tests/ui/generics_not_supported.rs
@@ -1,0 +1,8 @@
+use rlm_derive::rlm_type;
+
+#[rlm_type]
+struct Generic<T> {
+    value: T,
+}
+
+fn main() {}

--- a/crates/rlm-derive/tests/ui/generics_not_supported.stderr
+++ b/crates/rlm-derive/tests/ui/generics_not_supported.stderr
@@ -1,0 +1,5 @@
+error: rlm_type currently supports named structs only (no generics or lifetimes)
+ --> tests/ui/generics_not_supported.rs:4:8
+  |
+4 | struct Generic<T> {
+  |        ^^^^^^^

--- a/crates/rlm-derive/tests/ui/missing_pyclass.rs
+++ b/crates/rlm-derive/tests/ui/missing_pyclass.rs
@@ -1,0 +1,8 @@
+use rlm_derive::RlmType;
+
+#[derive(RlmType)]
+struct MissingPyclass {
+    value: i32,
+}
+
+fn main() {}

--- a/crates/rlm-derive/tests/ui/missing_pyclass.stderr
+++ b/crates/rlm-derive/tests/ui/missing_pyclass.stderr
@@ -1,0 +1,5 @@
+error: RlmType requires a #[pyclass] attribute; use #[rlm_type] instead of deriving RlmType directly
+ --> tests/ui/missing_pyclass.rs:4:8
+  |
+4 | struct MissingPyclass {
+  |        ^^^^^^^^^^^^^^


### PR DESCRIPTION
Draft PR for the RLM v1 stack. **Not ready to land yet** — there's an unresolved base-API decision documented below.

## Summary

- 44 commits implementing the RLM (Reasoning Language Module) architecture: PyO3 runtime, perception loop, REPL/passthrough adapters, Phase 1–5 work, and downstream tightening (schema dedup, sub-LM batching, prompt redesign, etc.).
- Branch tip: `nqzvplvs 94685374` "RLM schema rendering overhaul: type dedup, nested methods, clean unions".

## ⚠️ Base-API ambiguity (blocker)

The branch is built on top of an **orphaned multi-turn-predict refactor** that never made it to main, and main has since taken a different shape. Specifically:

| Surface | This branch's base (`ynqyxtnl`) | Main (`3c850e60` + `5bb65ca5`) |
|---|---|---|
| Forward signature | `forward(input, history: Option<Chat>) -> Predicted` | `forward(input) -> Predicted` |
| Continue conversation | Same `forward` with `Some(history)` | Separate `forward_continue(chat) -> (Predicted, Chat)` |
| Internal split | `compose_chat` + `execute_chat` (private) | `build_chat` + `call_and_parse` (public) |
| LM call signature | `lm.call(chat, tools, ToolLoopMode::Auto)` | `lm.call(chat, tools)` (no `ToolLoopMode`) |
| Per-instance LM override | not present | `Predict.lm: Option<Arc<LM>>` + `.lm()` builder |

### How it ended up like this

1. **2026-02-19** — initial multi-turn-predict commits (`zqytoppy`, `kqyktwmv`) with the **split API** (`forward(input)` + `forward_continue(chat)`) + `ToolLoopMode::CallerManaged`.
2. **2026-02-21 23:08** — local refactor `1e9d503a` "collapse call API" (= `ynqyxtnl` on this branch): collapses split API back to unified `forward(input, history)`, switches to `ToolLoopMode::Auto`, uses `Role` enum.
3. **2026-02-22 00:21:20** — PR squash-merged to main as `3c850e60` containing only the first two commits. The "collapse call API" refactor was **not** included.
4. **2026-02-22 00:21:27** — 7 seconds after the squash-merge, the local `multi-turn-predict` branch got the orphaned refactor as `659c3938 ynqyxtnl`. RLM v1 was then built on top.
5. **2026-04-08** — main got `5bb65ca5 feat(predict): add per-instance LM override` on top of the older split API.

So the local stack uses the **newer/collapsed** API; main uses the **older/split** API plus an LM-override addition.

## Two paths forward

**(A) Keep main's split API.** Port the RLM stack to use `forward(input)` + `forward_continue(chat)` + drop `ToolLoopMode::Auto` for the equivalent main-side construct. The `ynqyxtnl` "collapse call API" refactor is effectively discarded.

**(B) Restore the unified API.** Land `ynqyxtnl` (the orphaned refactor) into main first as its own PR, re-apply `5bb65ca5` (per-instance LM override) on top, then rebase RLM. Preserves the local API design.

Both involve a non-trivial API migration in the rebase; the "update with main" delta itself is only one small commit (`5bb65ca5`, 143 lines).

## Test plan

- [ ] Decide A vs B
- [ ] Resolve the API mismatch (port RLM call sites or re-land the orphaned refactor)
- [ ] Rebase onto current `main`
- [ ] Full `cargo test` across `dspy-rs` + RLM-derive + integration suites
- [ ] Re-verify RLM live demos (OpenAI Responses, Anthropic prompt caching) still pass